### PR TITLE
[codex] finish standalone crate cleanup

### DIFF
--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -20,7 +20,6 @@ fn main() -> corinth_canal::Result<()> {
     let cfg = HybridConfig {
         olmoe_model_path: model_path,
         snn_steps: 20,
-        context_length: 512,
         num_experts: 8,
         top_k_experts: 1,
         olmoe_execution_mode,

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,10 +33,6 @@ pub enum HybridError {
     #[error("input length mismatch: expected {expected}, got {got}")]
     InputLengthMismatch { expected: usize, got: usize },
 
-    /// The synthetic spike front-end produced no spikes.
-    #[error("SNN produced no spikes after {steps} steps — network may be silent")]
-    SilentNetwork { steps: usize },
-
     /// OLMoE forward pass returned an error.
     #[error("OLMoE forward pass failed: {0}")]
     OlmoeForward(String),

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -24,6 +24,9 @@ impl HybridModel {
         if config.snn_steps == 0 {
             return Err(HybridError::InvalidConfig("snn_steps must be ≥ 1".into()));
         }
+        if config.num_experts == 0 {
+            return Err(HybridError::InvalidConfig("num_experts must be ≥ 1".into()));
+        }
         if config.top_k_experts == 0 {
             return Err(HybridError::InvalidConfig("top_k_experts must be ≥ 1".into()));
         }
@@ -53,15 +56,7 @@ impl HybridModel {
     pub fn forward(&mut self, snap: &TelemetrySnapshot) -> Result<HybridOutput> {
         self.global_step += 1;
 
-        let mut spike_train = Vec::with_capacity(self.config.snn_steps);
-        for step in 0..self.config.snn_steps {
-            let active_1 = (step + snap.gpu_temp_c.max(0.0) as usize) % N_NEURONS;
-            let active_2 = (active_1 + 5) % N_NEURONS;
-            spike_train.push(vec![active_1, active_2]);
-        }
-
-        let potentials = vec![0.5; N_NEURONS];
-        let iz_potentials = vec![0.0; IZ_NEURONS];
+        let (spike_train, potentials, iz_potentials) = self.synthetic_activity(snap);
         let embedding = self
             .projector
             .project(&spike_train, &potentials, &iz_potentials)?;
@@ -87,6 +82,32 @@ impl HybridModel {
             selected_experts: Some(olmoe_out.selected_experts),
             reasoning: None,
         })
+    }
+
+    fn synthetic_activity(
+        &self,
+        snap: &TelemetrySnapshot,
+    ) -> (Vec<Vec<usize>>, Vec<f32>, Vec<f32>) {
+        let phase_seed = (snap.timestamp_ms as usize / 1_000
+            + snap.gpu_temp_c.max(0.0).round() as usize
+            + snap.cpu_tctl_c.max(0.0).round() as usize)
+            % N_NEURONS;
+
+        let spike_train = (0..self.config.snn_steps)
+            .map(|step| {
+                let lead = (phase_seed + step) % N_NEURONS;
+                let trail = (lead + N_NEURONS / 2) % N_NEURONS;
+                vec![lead, trail]
+            })
+            .collect();
+
+        let thermal_bias = 0.2 + 0.4 * snap.thermal_stress();
+        let potentials = (0..N_NEURONS)
+            .map(|idx| thermal_bias + (idx as f32 / N_NEURONS as f32) * 0.3)
+            .collect();
+        let iz_potentials = vec![0.0; IZ_NEURONS];
+
+        (spike_train, potentials, iz_potentials)
     }
 
     pub fn train_step(&mut self, snap: &TelemetrySnapshot, target: &[f32]) -> Result<f32> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,5 +40,5 @@ pub use error::{HybridError, Result};
 pub use hybrid::{HybridModel, OLMoE, Projector};
 pub use types::{
     EMBEDDING_DIM, HybridConfig, HybridOutput, OlmoeExecutionMode, ProjectionMode,
-    SNN_INPUT_CHANNELS, TelemetrySnapshot,
+    TelemetrySnapshot,
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,9 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Number of synthetic input channels used by the dummy spike front-end.
-pub const SNN_INPUT_CHANNELS: usize = 16;
-
 /// Dimensionality of the dense embedding the projector hands to OLMoE.
 pub const EMBEDDING_DIM: usize = 2048;
 
@@ -33,7 +30,6 @@ impl TelemetrySnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HybridConfig {
     pub olmoe_model_path: String,
-    pub context_length: usize,
     pub num_experts: usize,
     pub top_k_experts: usize,
     pub olmoe_execution_mode: OlmoeExecutionMode,
@@ -45,7 +41,6 @@ impl Default for HybridConfig {
     fn default() -> Self {
         Self {
             olmoe_model_path: String::new(),
-            context_length: 512,
             num_experts: 8,
             top_k_experts: 1,
             olmoe_execution_mode: OlmoeExecutionMode::SpikingSim,


### PR DESCRIPTION
## Summary
Finish the standalone cleanup by removing dead config/error surface that survived the earlier merge and tightening the deterministic dummy spike front-end.

## What changed
- removed unused `context_length` from `HybridConfig` and the example config
- removed the unreachable `SilentNetwork` error variant and its export path
- removed the unused `SNN_INPUT_CHANNELS` public constant export
- simplified the dummy SNN generation into a dedicated deterministic helper in `HybridModel`
- kept the public standalone API centered on `TelemetrySnapshot`, `HybridModel`, the projector, and OLMoE routing

## Validation
- `cargo test --offline`
- `cargo run --offline --example telemetry_bridge`
