### PR TITLE
[codex] finish standalone cleanup

### DIFF
--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -32,16 +32,11 @@ fn main() -> corinth_canal::Result<()> {
     for step in 0..25usize {
         let phase = step as f32 / 25.0;
         let snap = TelemetrySnapshot {
-            timestamp_ms: (step as u64) * 1000,
             gpu_temp_c: 55.0 + phase * 30.0,
             gpu_power_w: 180.0 + phase * 120.0,
-            gpu_clock_mhz: 1800.0 + phase * 300.0,
-            mem_util_pct: 50.0 + phase * 30.0,
             cpu_tctl_c: 48.0 + phase * 20.0,
             cpu_package_power_w: 70.0 + phase * 40.0,
-            workload_throughput: (0.005 + phase as f64 * 0.01),
-            workload_efficiency: (0.6 + phase as f64 * 0.2),
-            auxiliary_signal: (phase as f64).sin().abs(),
+            timestamp_ms: (step as u64) * 1000,
         };
 
         let output = model.forward(&snap)?;

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -88,23 +88,17 @@ impl HybridModel {
         &self,
         snap: &TelemetrySnapshot,
     ) -> (Vec<Vec<usize>>, Vec<f32>, Vec<f32>) {
-        let phase_seed = (snap.timestamp_ms as usize / 1_000
-            + snap.gpu_temp_c.max(0.0).round() as usize
-            + snap.cpu_tctl_c.max(0.0).round() as usize)
-            % N_NEURONS;
+        let temp_offset = snap.gpu_temp_c.max(0.0).round() as usize % N_NEURONS;
 
         let spike_train = (0..self.config.snn_steps)
             .map(|step| {
-                let lead = (phase_seed + step) % N_NEURONS;
-                let trail = (lead + N_NEURONS / 2) % N_NEURONS;
+                let lead = (step + temp_offset) % N_NEURONS;
+                let trail = (lead + 5) % N_NEURONS;
                 vec![lead, trail]
             })
             .collect();
 
-        let thermal_bias = 0.2 + 0.4 * snap.thermal_stress();
-        let potentials = (0..N_NEURONS)
-            .map(|idx| thermal_bias + (idx as f32 / N_NEURONS as f32) * 0.3)
-            .collect();
+        let potentials = vec![0.25 + 0.5 * snap.thermal_stress(); N_NEURONS];
         let iz_potentials = vec![0.0; IZ_NEURONS];
 
         (spike_train, potentials, iz_potentials)
@@ -240,8 +234,8 @@ mod tests {
             gpu_temp_c: 72.0,
             gpu_power_w: 280.0,
             cpu_tctl_c: 65.0,
-            workload_throughput: 10.0,
-            workload_efficiency: 0.7,
+            cpu_package_power_w: 120.0,
+            timestamp_ms: 1_000,
             ..Default::default()
         };
         let loss = model

--- a/src/hybrid/olmoe.rs
+++ b/src/hybrid/olmoe.rs
@@ -235,7 +235,7 @@ impl OLMoE {
 
         if magic[0] == b'{' || (magic[0] == 0 && magic[1] == 0) {
             return Err(HybridError::UnsupportedFormat(
-                "safetensors files are not supported in standalone mode".into(),
+                "non-GGUF checkpoint headers are not supported in standalone mode".into(),
             ));
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,16 +8,11 @@ pub const EMBEDDING_DIM: usize = 2048;
 /// Minimal local telemetry payload used to seed deterministic spike patterns.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TelemetrySnapshot {
-    pub timestamp_ms: u64,
     pub gpu_temp_c: f32,
     pub gpu_power_w: f32,
-    pub gpu_clock_mhz: f32,
-    pub mem_util_pct: f32,
     pub cpu_tctl_c: f32,
     pub cpu_package_power_w: f32,
-    pub workload_throughput: f64,
-    pub workload_efficiency: f64,
-    pub auxiliary_signal: f64,
+    pub timestamp_ms: u64,
 }
 
 impl TelemetrySnapshot {


### PR DESCRIPTION
## Summary
Finalize the standalone cleanup by removing the last legacy telemetry/mining surface and keeping the crate self-contained around the minimal local `TelemetrySnapshot`.

## What changed
- Reduced `TelemetrySnapshot` to the minimal five-field shape
- Simplified the dummy spike generator in `HybridModel` to two spikes per step based only on step index and temperature
- Updated the example to use the minimal local telemetry payload
- Removed the last stale standalone-mode wording in OLMoE error handling

## Validation
- `cargo check`
- `cargo test`
- `cargo run --example telemetry_bridge`
