### PR TITLE
Tighten canonical CSV replay contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ OLMOE_PATH=/models/OLMoE-1B-7B-Q5_K_M.gguf \
   cargo run --example telemetry_bridge --features gguf --release
 ```
 
+## CSV Replay Contract
+
+`corinth-canal` consumes canonical CSV exported by `gaming-telemetry`:
+
+`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`
+
+Producer/consumer flow:
+
+`collector -> gpu_telemetry_v1_batch_N.parquet -> export_csv -> csv_replay`
+
+Replay command:
+
+```bash
+cargo run --example csv_replay /path/to/canonical.csv
+```
+
+`csv_replay` validates the header strictly, counts malformed rows, and prints:
+- `rows_processed`
+- `rows_skipped`
+- `global_step`
+- `olmoe_loaded`
+
 ## Project layout
 
 | Path | Responsibility |
@@ -70,6 +92,7 @@ OLMOE_PATH=/models/OLMoE-1B-7B-Q5_K_M.gguf \
 | `src/hybrid/olmoe.rs` | GGUF-aware OLMoE simulation |
 | `src/hybrid/hybrid.rs` | deterministic front-end + projector + OLMoE orchestration |
 | `examples/telemetry_bridge.rs` | end-to-end standalone example |
+| `examples/csv_replay.rs` | canonical CSV replay adapter |
 
 ## Acknowledgments
 

--- a/examples/csv_replay.rs
+++ b/examples/csv_replay.rs
@@ -3,15 +3,31 @@
 //! Canonical CSV format: timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w
 
 use corinth_canal::{
-    EMBEDDING_DIM, HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode,
+    EMBEDDING_DIM, HybridConfig, HybridError, HybridModel, OlmoeExecutionMode, ProjectionMode,
     TelemetrySnapshot,
 };
+
+const EXPECTED_HEADER: &str =
+    "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
+
+fn parse_u64(v: &str) -> Option<u64> {
+    v.parse::<u64>().ok()
+}
+
+fn parse_f32(v: &str) -> Option<f32> {
+    let n = v.parse::<f32>().ok()?;
+    if n.is_finite() {
+        Some(n)
+    } else {
+        None
+    }
+}
 
 fn main() -> corinth_canal::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: cargo run --example csv_replay <telemetry.csv>");
-        eprintln!("  CSV format: timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w");
+        eprintln!("  CSV format: {}", EXPECTED_HEADER);
         std::process::exit(1);
     }
 
@@ -34,30 +50,59 @@ fn main() -> corinth_canal::Result<()> {
         model.config().olmoe_execution_mode
     );
 
-    // Parse CSV
     let csv_content = std::fs::read_to_string(csv_path)?;
     let mut lines = csv_content.lines();
 
-    // Skip header
-    let header = lines.next().ok_or("Empty CSV file")?;
-    if !header.contains("timestamp_ms") {
-        eprintln!("Warning: CSV header may be missing expected columns");
+    let header = lines
+        .next()
+        .ok_or_else(|| HybridError::InvalidConfig("empty CSV file".to_owned()))?
+        .trim();
+
+    if header != EXPECTED_HEADER {
+        return Err(HybridError::InvalidConfig(format!(
+            "invalid CSV header: expected '{EXPECTED_HEADER}', got '{header}'"
+        )));
     }
 
     let mut total_loss = 0.0_f32;
-    let mut row_count = 0_usize;
+    let mut rows_processed = 0_usize;
+    let mut rows_skipped = 0_usize;
 
-    for line in lines {
-        let fields: Vec<&str> = line.split(',').collect();
-        if fields.len() < 5 {
-            continue; // Skip malformed lines
+    for (idx, raw_line) in lines.enumerate() {
+        let line_number = idx + 2;
+        let line = raw_line.trim();
+
+        if line.is_empty() {
+            rows_skipped += 1;
+            continue;
         }
 
-        let timestamp_ms: u64 = fields[0].parse().unwrap_or(0);
-        let gpu_temp_c: f32 = fields[1].parse().unwrap_or(0.0);
-        let gpu_power_w: f32 = fields[2].parse().unwrap_or(0.0);
-        let cpu_tctl_c: f32 = fields[3].parse().unwrap_or(0.0);
-        let cpu_package_power_w: f32 = fields[4].parse().unwrap_or(0.0);
+        let fields: Vec<&str> = line.split(',').collect();
+        if fields.len() != 5 {
+            rows_skipped += 1;
+            eprintln!(
+                "Skipping malformed row {}: expected 5 columns, got {}",
+                line_number,
+                fields.len()
+            );
+            continue;
+        }
+
+        let parsed = (
+            parse_u64(fields[0]),
+            parse_f32(fields[1]),
+            parse_f32(fields[2]),
+            parse_f32(fields[3]),
+            parse_f32(fields[4]),
+        );
+
+        let (Some(timestamp_ms), Some(gpu_temp_c), Some(gpu_power_w), Some(cpu_tctl_c), Some(cpu_package_power_w)) =
+            parsed
+        else {
+            rows_skipped += 1;
+            eprintln!("Skipping malformed row {}: parse/finite check failed", line_number);
+            continue;
+        };
 
         let snap = TelemetrySnapshot {
             timestamp_ms,
@@ -69,7 +114,6 @@ fn main() -> corinth_canal::Result<()> {
 
         let output = model.forward(&snap)?;
 
-        // Calculate simple loss against mean embedding
         let mean_embed = output.embedding.iter().sum::<f32>() / EMBEDDING_DIM as f32;
         let target = vec![mean_embed * 0.9; EMBEDDING_DIM];
         let loss = output
@@ -79,26 +123,30 @@ fn main() -> corinth_canal::Result<()> {
             .map(|(hidden, expected)| (hidden - expected).powi(2))
             .sum::<f32>()
             / EMBEDDING_DIM as f32;
-        total_loss += loss;
-        row_count += 1;
 
-        // Per-step diagnostics
-        if row_count % 100 == 0 || row_count <= 5 {
+        total_loss += loss;
+        rows_processed += 1;
+
+        if rows_processed % 100 == 0 || rows_processed <= 5 {
             println!(
                 "step={:>4} gpu_temp={:5.1}C gpu_power={:6.1}W cpu_temp={:5.1}C loss={:.6}",
-                row_count, gpu_temp_c, gpu_power_w, cpu_tctl_c, loss
+                rows_processed, gpu_temp_c, gpu_power_w, cpu_tctl_c, loss
             );
         }
     }
 
-    // Final summary
-    let avg_loss = if row_count > 0 { total_loss / row_count as f32 } else { 0.0 };
+    let avg_loss = if rows_processed > 0 {
+        total_loss / rows_processed as f32
+    } else {
+        0.0
+    };
 
     println!("\n=== Replay Summary ===");
-    println!("Rows processed: {}", row_count);
-    println!("Avg loss: {:.6}", avg_loss);
-    println!("Global step: {}", model.global_step());
-    println!("OLMoE loaded: {}", model.olmoe_loaded());
+    println!("rows_processed={}", rows_processed);
+    println!("rows_skipped={}", rows_skipped);
+    println!("avg_loss={:.6}", avg_loss);
+    println!("global_step={}", model.global_step());
+    println!("olmoe_loaded={}", model.olmoe_loaded());
 
     Ok(())
 }


### PR DESCRIPTION
Enforce the spec-locked telemetry replay boundary.\n\nChanges:\n- Strict canonical CSV header validation in examples/csv_replay.rs\n- Malformed row counting/reporting instead of silent skips\n- Replay summary now reports rows_processed, rows_skipped, global_step, and olmoe_loaded\n- README docs for the collector -> parquet -> export_csv -> csv_replay flow\n\nNo changes to the standalone model math or dependencies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the canonical CSV replay contract by adding strict header validation, malformed-row counting/reporting, and a structured replay summary to `examples/csv_replay.rs`, along with README documentation for the `collector -> parquet -> export_csv -> csv_replay` pipeline flow.

Key changes:
- `EXPECTED_HEADER` constant enforces an exact header match at startup; a mismatch now returns a hard error instead of silently mis-parsing rows
- Malformed rows (wrong column count or unparseable/non-finite values) are counted in `rows_skipped` and reported to `stderr` with their line number
- The replay summary now emits `rows_processed`, `rows_skipped`, `avg_loss`, `global_step`, and `olmoe_loaded`
- README gains a \"CSV Replay Contract\" section documenting the format, pipeline flow, and replay command — however, the documented output list omits `avg_loss`, which the code does print

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the README omission of avg_loss; no logic or security regressions.

The core implementation is correct — header validation, row-skip counting, and summary output all work as intended. The only concrete gap introduced in this PR is that the new README documentation section lists four summary fields while the code prints five (avg_loss is omitted). Since README docs are a stated deliverable of this PR, that is a targeted fix rather than a purely cosmetic nit. The two P2s are non-blocking for a replay example tool.

README.md — the CSV Replay Contract bullet list needs avg_loss added to match the actual code output.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/csv_replay.rs | Adds strict canonical CSV header validation, per-row malformed field counting with diagnostics, and a structured replay summary — logic is correct; minor style concerns around blank-line counting and f32 accumulator precision. |
| README.md | Adds CSV Replay Contract section documenting the producer/consumer flow and replay command, but the documented summary output list is incomplete — `avg_loss` is printed by the code but absent from the README bullet list. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open CSV file] --> B{File empty?}
    B -- yes --> ERR1[Error: empty CSV file]
    B -- no --> C[Read header line]
    C --> D{Header == EXPECTED_HEADER?}
    D -- no --> ERR2[Error: invalid CSV header]
    D -- yes --> E[Iterate data rows]
    E --> F{Line empty?}
    F -- yes --> G[rows_skipped++\ncontinue]
    F -- no --> H{fields.len == 5?}
    H -- no --> I[rows_skipped++\neprintln malformed\ncontinue]
    H -- yes --> J{All fields parse OK\nand finite?}
    J -- no --> K[rows_skipped++\neprintln parse failed\ncontinue]
    J -- yes --> L[Build TelemetrySnapshot]
    L --> M[model.forward]
    M --> N[Compute MSE loss]
    N --> O[total_loss += loss\nrows_processed++]
    O --> P{rows_processed % 100 == 0\nor <= 5?}
    P -- yes --> Q[Print step log]
    P -- no --> E
    Q --> E
    E -- exhausted --> R[Compute avg_loss]
    R --> S[Print Replay Summary\nrows_processed / rows_skipped\navg_loss / global_step / olmoe_loaded]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A75-80%0A**%60avg_loss%60%20missing%20from%20documented%20summary%20output**%0A%0AThe%20README%20lists%20four%20fields%20printed%20by%20the%20replay%20summary%2C%20but%20the%20actual%20code%20prints%20five.%20%60avg_loss%60%20is%20omitted%20from%20the%20docs%20even%20though%20it%20appears%20in%20the%20%60%3D%3D%3D%20Replay%20Summary%20%3D%3D%3D%60%20block%20at%20line%20147%20of%20%60csv_replay.rs%60%3A%0A%0A%60%60%60%0Aprintln!%28%22avg_loss%3D%7B%3A.6%7D%22%2C%20avg_loss%29%3B%0A%60%60%60%0A%0AThe%20README%20should%20be%20updated%20to%20match%3A%0A%0A%60%60%60suggestion%0A%60csv_replay%60%20validates%20the%20header%20strictly%2C%20counts%20malformed%20rows%2C%20and%20prints%3A%0A-%20%60rows_processed%60%0A-%20%60rows_skipped%60%0A-%20%60avg_loss%60%0A-%20%60global_step%60%0A-%20%60olmoe_loaded%60%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aexamples%2Fcsv_replay.rs%3A75-78%0A**Empty%20lines%20counted%20as%20skipped%20rows**%0A%0ABlank%20trailing%20lines%20%28common%20in%20CSV%20files%20exported%20from%20many%20tools%29%20are%20silently%20counted%20as%20skipped%20rows%20without%20any%20diagnostic%20message.%20This%20will%20inflate%20%60rows_skipped%60%20in%20normal%20use%20and%20could%20be%20confusing%20when%20operators%20inspect%20the%20summary.%20Consider%20distinguishing%20truly%20blank%20lines%20from%20malformed%20data%20lines%20%E2%80%94%20either%20by%20not%20counting%20blank%20lines%20in%20%60rows_skipped%60%20at%20all%2C%20or%20by%20tracking%20them%20in%20a%20separate%20%60rows_blank%60%20counter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20line.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aexamples%2Fcsv_replay.rs%3A67%0A**%60total_loss%60%20accumulation%20using%20%60f32%60%20may%20lose%20precision%20for%20large%20replays**%0A%0ASumming%20many%20%60f32%60%20loss%20values%20into%20a%20single%20%60f32%60%20accumulator%20%28%60total_loss%60%29%20can%20silently%20lose%20precision%20or%20even%20saturate%20to%20%60inf%60%20for%20long%20replay%20sessions%20%28e.g.%2C%20millions%20of%20telemetry%20rows%29.%20Consider%20accumulating%20in%20%60f64%60%20and%20only%20downcast%20when%20printing%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20total_loss%20%3D%200.0_f64%3B%0A%60%60%60%0A%0A%E2%80%A6and%20update%20the%20per-row%20accumulation%20to%3A%0A%60%60%60rust%0Atotal_loss%20%2B%3D%20loss%20as%20f64%3B%0A%60%60%60%0A%0A%E2%80%A6and%20the%20average%3A%0A%60%60%60rust%0Alet%20avg_loss%20%3D%20if%20rows_processed%20%3E%200%20%7B%0A%20%20%20%20total_loss%20%2F%20rows_processed%20as%20f64%0A%7D%20else%20%7B%0A%20%20%20%200.0%0A%7D%3B%0A%60%60%60%0A%0A&repo=spikenaut%2Fcorinth-canal"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Tighten canonical CSV replay contract"](https://github.com/spikenaut/corinth-canal/commit/8422136828e5e27e48911a527289e47b936edecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27946402)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->