### PR TITLE
Add TelemetryEncoder with delta-modulation for ternary spike generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Rust
+/target/
+**/*.rs.bk
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Debug
+*.log

--- a/README.md
+++ b/README.md
@@ -8,10 +8,17 @@ Standalone SNN-logic quantization crate focused on the spiking projector and OLM
 
 `corinth-canal` keeps the real projector and OLMoE simulation logic, while the old telemetry/SNN front-end is replaced by a deterministic in-repo spike generator. That keeps the crate self-contained and runnable from a fresh clone.
 
+## Origin
+
+This repository originated from the `spikenaut-hybrid` codebase and was reorganized into `corinth-canal` with a consolidated `src/hybrid`, `src/tensor`, and `src/transformer` structure.
+
 ## Architecture
 
 ```text
 TelemetrySnapshot
+       |
+       v  TelemetryEncoder (delta modulation)
+[i8; 4] ternary spikes (+1/0/-1)
        |
        v  deterministic dummy spike generator
 spike_train + membrane_potentials
@@ -26,15 +33,69 @@ expert_weights + selected_experts + hidden
 ## Quick start
 
 ```rust
-use corinth_canal::{HybridConfig, HybridModel, TelemetrySnapshot};
+use corinth_canal::{HybridConfig, HybridModel, TelemetryEncoder, TelemetrySnapshot};
 
+// Configure delta modulation thresholds
+let thresholds = [1.0, 5.0, 1.0, 5.0];
+let mut encoder = TelemetryEncoder::new(thresholds);
+
+// Create a telemetry snapshot
+let snap = TelemetrySnapshot {
+    gpu_temp_c: 60.0,
+    gpu_power_w: 260.0,
+    cpu_tctl_c: 77.0,
+    cpu_package_power_w: 153.0,
+    timestamp_ms: 0,
+};
+
+// Encode into ternary spikes
+let spikes = encoder.encode(&snap);
+
+// Or use the full hybrid pipeline
 let cfg = HybridConfig::default();
 let mut model = HybridModel::new(cfg)?;
-
-let snap = TelemetrySnapshot::default();
 let output = model.forward(&snap)?;
 
 println!("Selected experts: {:?}", output.selected_experts);
+```
+
+## TelemetryEncoder
+
+The `TelemetryEncoder` converts continuous telemetry values into ternary spike vectors using delta modulation. This bridges raw telemetry data into the spiking projection path.
+
+### Delta modulation
+
+For each telemetry channel (GPU temp, GPU power, CPU temp, CPU power), the encoder:
+
+- Stores a baseline value (seeded from the first sample)
+- Compares each new value to its baseline
+- Emits `+1` if the change exceeds the positive threshold
+- Emits `-1` if the change exceeds the negative threshold
+- Emits `0` otherwise
+- Updates the baseline only when a spike fires
+
+### Usage
+
+```rust
+use corinth_canal::{TelemetryEncoder, TelemetrySnapshot};
+
+// Configure thresholds: [temp, power, temp, power]
+let thresholds = [1.0, 5.0, 1.0, 5.0];
+let mut encoder = TelemetryEncoder::new(thresholds);
+
+let snap = TelemetrySnapshot {
+    gpu_temp_c: 60.0,
+    gpu_power_w: 260.0,
+    cpu_tctl_c: 77.0,
+    cpu_package_power_w: 153.0,
+    timestamp_ms: 0,
+};
+
+// First call seeds the baseline, returns [0, 0, 0, 0]
+let spikes = encoder.encode(&snap);
+
+// Subsequent calls emit spikes based on delta
+let spikes = encoder.encode(&snap);
 ```
 
 ## Features
@@ -86,8 +147,10 @@ cargo run --example csv_replay /path/to/canonical.csv
 | `src/lib.rs` | public API and crate docs |
 | `src/types.rs` | `TelemetrySnapshot`, config, enums, output types |
 | `src/error.rs` | `HybridError`, `Result` |
+| `src/telemetry.rs` | `TelemetryEncoder` delta-modulation state machine |
 | `src/tensor/mod.rs` | candle-free tensor utilities |
 | `src/transformer/mod.rs` | transformer helpers |
+| `src/hybrid/mod.rs` | hybrid module switchboard |
 | `src/hybrid/projector.rs` | 2-bit spiking projector logic |
 | `src/hybrid/olmoe.rs` | GGUF-aware OLMoE simulation |
 | `src/hybrid/hybrid.rs` | deterministic front-end + projector + OLMoE orchestration |

--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -27,6 +27,11 @@ fn main() -> corinth_canal::Result<()> {
     };
 
     let mut model = HybridModel::new(cfg)?;
+    println!(
+        "olmoe_loaded={} olmoe_mode={:?}",
+        model.olmoe_loaded(),
+        model.config().olmoe_execution_mode
+    );
     let mut total_loss = 0.0_f32;
 
     for step in 0..25usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,14 @@
 
 pub mod error;
 pub mod hybrid;
+pub mod telemetry;
 pub mod tensor;
 pub mod transformer;
 pub mod types;
 
 pub use error::{HybridError, Result};
 pub use hybrid::{HybridModel, OLMoE, Projector};
+pub use telemetry::TelemetryEncoder;
 pub use types::{
     EMBEDDING_DIM, HybridConfig, HybridOutput, OlmoeExecutionMode, ProjectionMode,
     TelemetrySnapshot,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,121 @@
+use crate::types::TelemetrySnapshot;
+
+#[derive(Debug, Clone)]
+pub struct TelemetryEncoder {
+    baseline: [f32; 4],
+    thresholds: [f32; 4],
+    initialized: bool,
+}
+
+impl TelemetryEncoder {
+    pub fn new(thresholds: [f32; 4]) -> Self {
+        Self {
+            baseline: [0.0; 4],
+            thresholds,
+            initialized: false,
+        }
+    }
+
+    pub fn encode(&mut self, snap: &TelemetrySnapshot) -> [i8; 4] {
+        let values = [
+            snap.gpu_temp_c,
+            snap.gpu_power_w,
+            snap.cpu_tctl_c,
+            snap.cpu_package_power_w,
+        ];
+
+        if !self.initialized {
+            self.baseline = values;
+            self.initialized = true;
+            return [0; 4];
+        }
+
+        let mut spikes = [0; 4];
+        for i in 0..values.len() {
+            let delta = values[i] - self.baseline[i];
+            if delta >= self.thresholds[i] {
+                spikes[i] = 1;
+                self.baseline[i] = values[i];
+            } else if delta <= -self.thresholds[i] {
+                spikes[i] = -1;
+                self.baseline[i] = values[i];
+            }
+        }
+
+        spikes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(
+        gpu_temp_c: f32,
+        gpu_power_w: f32,
+        cpu_tctl_c: f32,
+        cpu_package_power_w: f32,
+    ) -> TelemetrySnapshot {
+        TelemetrySnapshot {
+            gpu_temp_c,
+            gpu_power_w,
+            cpu_tctl_c,
+            cpu_package_power_w,
+            timestamp_ms: 0,
+        }
+    }
+
+    #[test]
+    fn first_encode_seeds_baseline_and_emits_zeroes() {
+        let mut encoder = TelemetryEncoder::new([1.0, 5.0, 1.0, 5.0]);
+        let snap = snapshot(60.0, 260.0, 77.0, 153.0);
+
+        assert_eq!(encoder.encode(&snap), [0, 0, 0, 0]);
+        assert!(encoder.initialized);
+        assert_eq!(encoder.baseline, [60.0, 260.0, 77.0, 153.0]);
+    }
+
+    #[test]
+    fn positive_threshold_crossing_emits_positive_spike_and_updates_baseline() {
+        let mut encoder = TelemetryEncoder::new([1.0, 5.0, 1.0, 5.0]);
+        encoder.encode(&snapshot(60.0, 260.0, 77.0, 153.0));
+
+        let output = encoder.encode(&snapshot(61.0, 260.0, 77.0, 153.0));
+
+        assert_eq!(output, [1, 0, 0, 0]);
+        assert_eq!(encoder.baseline, [61.0, 260.0, 77.0, 153.0]);
+    }
+
+    #[test]
+    fn negative_threshold_crossing_emits_negative_spike_and_updates_baseline() {
+        let mut encoder = TelemetryEncoder::new([1.0, 5.0, 1.0, 5.0]);
+        encoder.encode(&snapshot(60.0, 260.0, 77.0, 153.0));
+
+        let output = encoder.encode(&snapshot(60.0, 254.5, 77.0, 153.0));
+
+        assert_eq!(output, [0, -1, 0, 0]);
+        assert_eq!(encoder.baseline, [60.0, 254.5, 77.0, 153.0]);
+    }
+
+    #[test]
+    fn subthreshold_change_emits_zero_and_preserves_baseline() {
+        let mut encoder = TelemetryEncoder::new([1.0, 5.0, 1.0, 5.0]);
+        encoder.encode(&snapshot(60.0, 260.0, 77.0, 153.0));
+
+        let output = encoder.encode(&snapshot(60.5, 264.9, 77.9, 157.9));
+
+        assert_eq!(output, [0, 0, 0, 0]);
+        assert_eq!(encoder.baseline, [60.0, 260.0, 77.0, 153.0]);
+    }
+
+    #[test]
+    fn channels_use_independent_thresholds_and_baselines() {
+        let mut encoder = TelemetryEncoder::new([1.0, 10.0, 0.5, 7.0]);
+        encoder.encode(&snapshot(60.0, 260.0, 77.0, 153.0));
+
+        let output = encoder.encode(&snapshot(61.0, 269.0, 76.0, 160.0));
+
+        assert_eq!(output, [1, 0, -1, 1]);
+        assert_eq!(encoder.baseline, [61.0, 260.0, 76.0, 160.0]);
+    }
+}


### PR DESCRIPTION
This PR adds a pure-Rust TelemetryEncoder that converts TelemetrySnapshot values into ternary spike vectors using delta modulation. This bridges raw telemetry data into the spiking projection path.

Changes:
- Added src/telemetry.rs with TelemetryEncoder state machine
- Updated src/lib.rs to re-export TelemetryEncoder
- Added unit tests for delta modulation behavior
- Updated README.md with encoder documentation and architecture diagram
- Added .gitignore for Rust projects

The encoder emits +1/0/-1 spikes based on configurable thresholds per channel (GPU temp, GPU power, CPU temp, CPU power), making it suitable for the SpikingTernary projection mode.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `TelemetryEncoder`, a pure-Rust delta-modulation state machine that converts `TelemetrySnapshot` fields into `[i8; 4]` ternary spike vectors (`+1`/`0`/`-1`), bridging raw telemetry into the existing `SpikingTernary` projection path. The implementation is clean and well-tested with five focused unit tests covering seeding, positive/negative threshold crossings, sub-threshold preservation, and per-channel independence.

**Key changes:**
- `src/telemetry.rs`: New `TelemetryEncoder` struct with delta-modulation `encode()` and five unit tests
- `src/lib.rs`: `pub mod telemetry` + re-export of `TelemetryEncoder`
- `README.md`: Architecture diagram updated, full usage section added
- `examples/telemetry_bridge.rs`: Minor diagnostic `println!` added (encoder not yet wired in)
- `.gitignore`: Standard Rust additions

**One issue to address before merging:**
- `TelemetryEncoder::new()` does not validate that thresholds are strictly positive. A zero threshold causes `delta >= 0.0` to be `true` even when the telemetry value is unchanged, so the encoder fires a spike and mutates the baseline on every call — silently breaking the delta-modulation contract.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding threshold validation in TelemetryEncoder::new(); all other changes are clean.

The core delta-modulation logic is correct and well-tested. One concrete P1 remains: zero thresholds silently break the spike contract. This is a targeted, one-line fix. The P2s (example and doc-comment updates) are non-blocking polish.

src/telemetry.rs — specifically the new() constructor which needs threshold validation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/telemetry.rs | New TelemetryEncoder with well-structured delta-modulation logic and good test coverage; missing threshold validation in new() allows zero/negative thresholds that silently break spike semantics. |
| src/lib.rs | Cleanly re-exports TelemetryEncoder; crate-level doc quick-start snippet not updated to include the new import. |
| examples/telemetry_bridge.rs | Only adds a diagnostic println!; does not demonstrate the new TelemetryEncoder despite the file name implying it should bridge telemetry to the spike path. |
| README.md | Good documentation of delta-modulation semantics, usage examples, and updated architecture diagram; consistent with the implementation. |
| .gitignore | Standard Rust .gitignore; correctly excludes Cargo.lock (appropriate for a library crate). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Encoder as TelemetryEncoder
    participant Model as HybridModel

    Caller->>Encoder: new(thresholds)
    Caller->>Encoder: encode(snap) first call
    Encoder-->>Caller: returns zeros, seeds baseline
    Caller->>Encoder: encode(snap) subsequent calls
    loop per channel
        alt delta ge threshold
            Encoder->>Encoder: spike plus one, update baseline
        else delta le neg threshold
            Encoder->>Encoder: spike neg one, update baseline
        else subthreshold
            Encoder->>Encoder: spike zero, baseline unchanged
        end
    end
    Encoder-->>Caller: spikes i8 array
    Caller->>Model: forward(snap)
    Model-->>Caller: HybridOutput
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `examples/telemetry_bridge.rs`, line 1-6 ([link](https://github.com/spikenaut/corinth-canal/blob/940880e7a92d7b392d6d48d18be40addcb51314f/examples/telemetry_bridge.rs#L1-L6)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Example doesn't demonstrate the new `TelemetryEncoder`**

   The file is named `telemetry_bridge.rs` and the PR's primary addition is `TelemetryEncoder`, but the example only adds a diagnostic `println!` for OLMoE status — it never imports or uses `TelemetryEncoder`. Consider threading the encoder into the loop so the example actually shows how the delta-modulation output feeds into the model:

   ```rust
   use corinth_canal::{
       EMBEDDING_DIM, HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode,
       TelemetryEncoder, TelemetrySnapshot,
   };
   // ...
   let mut encoder = TelemetryEncoder::new([1.0, 5.0, 1.0, 5.0]);
   // inside the loop:
   let spikes = encoder.encode(&snap);
   println!("ternary_spikes={:?}", spikes);
   ```

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikenaut%2Fcorinth-canal%22%20on%20the%20existing%20branch%20%22add-telemetry-encoder%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-telemetry-encoder%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Ftelemetry_bridge.rs%0ALine%3A%201-6%0A%0AComment%3A%0A**Example%20doesn't%20demonstrate%20the%20new%20%60TelemetryEncoder%60**%0A%0AThe%20file%20is%20named%20%60telemetry_bridge.rs%60%20and%20the%20PR's%20primary%20addition%20is%20%60TelemetryEncoder%60%2C%20but%20the%20example%20only%20adds%20a%20diagnostic%20%60println!%60%20for%20OLMoE%20status%20%E2%80%94%20it%20never%20imports%20or%20uses%20%60TelemetryEncoder%60.%20Consider%20threading%20the%20encoder%20into%20the%20loop%20so%20the%20example%20actually%20shows%20how%20the%20delta-modulation%20output%20feeds%20into%20the%20model%3A%0A%0A%60%60%60rust%0Ause%20corinth_canal%3A%3A%7B%0A%20%20%20%20EMBEDDING_DIM%2C%20HybridConfig%2C%20HybridModel%2C%20OlmoeExecutionMode%2C%20ProjectionMode%2C%0A%20%20%20%20TelemetryEncoder%2C%20TelemetrySnapshot%2C%0A%7D%3B%0A%2F%2F%20...%0Alet%20mut%20encoder%20%3D%20TelemetryEncoder%3A%3Anew%28%5B1.0%2C%205.0%2C%201.0%2C%205.0%5D%29%3B%0A%2F%2F%20inside%20the%20loop%3A%0Alet%20spikes%20%3D%20encoder.encode%28%26snap%29%3B%0Aprintln!%28%22ternary_spikes%3D%7B%3A%3F%7D%22%2C%20spikes%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


2. `src/lib.rs`, line 24-31 ([link](https://github.com/spikenaut/corinth-canal/blob/940880e7a92d7b392d6d48d18be40addcb51314f/src/lib.rs#L24-L31)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Crate-level doc comment doesn't import `TelemetryEncoder`**

   The quick-start snippet in the module-level doc block still uses the old import list without `TelemetryEncoder`. The README was updated, but `src/lib.rs` was not. Users reading `cargo doc` output will see an incomplete example. Consider syncing the two:

   no_run
   //! use corinth_canal::{HybridConfig, HybridModel, TelemetryEncoder, TelemetrySnapshot};
   //!
   //! let mut model = HybridModel::new(HybridConfig::default()).unwrap();
   //! let output = model.forward(&TelemetrySnapshot::default()).unwrap();
   //!
   //! println!("Selected experts: {:?}", output.selected_experts);
   //! ```
   ```

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikenaut%2Fcorinth-canal%22%20on%20the%20existing%20branch%20%22add-telemetry-encoder%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-telemetry-encoder%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib.rs%0ALine%3A%2024-31%0A%0AComment%3A%0A**Crate-level%20doc%20comment%20doesn't%20import%20%60TelemetryEncoder%60**%0A%0AThe%20quick-start%20snippet%20in%20the%20module-level%20doc%20block%20still%20uses%20the%20old%20import%20list%20without%20%60TelemetryEncoder%60.%20The%20README%20was%20updated%2C%20but%20%60src%2Flib.rs%60%20was%20not.%20Users%20reading%20%60cargo%20doc%60%20output%20will%20see%20an%20incomplete%20example.%20Consider%20syncing%20the%20two%3A%0A%0A%60%60%60suggestion%0A%2F%2F!%20%60%60%60no_run%0A%2F%2F!%20use%20corinth_canal%3A%3A%7BHybridConfig%2C%20HybridModel%2C%20TelemetryEncoder%2C%20TelemetrySnapshot%7D%3B%0A%2F%2F!%0A%2F%2F!%20let%20mut%20model%20%3D%20HybridModel%3A%3Anew%28HybridConfig%3A%3Adefault%28%29%29.unwrap%28%29%3B%0A%2F%2F!%20let%20output%20%3D%20model.forward%28%26TelemetrySnapshot%3A%3Adefault%28%29%29.unwrap%28%29%3B%0A%2F%2F!%0A%2F%2F!%20println!%28%22Selected%20experts%3A%20%7B%3A%3F%7D%22%2C%20output.selected_experts%29%3B%0A%2F%2F!%20%60%60%60%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikenaut%2Fcorinth-canal%22%20on%20the%20existing%20branch%20%22add-telemetry-encoder%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-telemetry-encoder%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Ftelemetry.rs%3A11-17%0A**Zero%2Fnegative%20threshold%20causes%20always-firing%20spikes**%0A%0A%60TelemetryEncoder%3A%3Anew%28%29%60%20accepts%20any%20%60%5Bf32%3B%204%5D%60%20without%20validation.%20If%20any%20threshold%20is%20%600.0%60%2C%20the%20condition%20%60delta%20%3E%3D%20self.thresholds%5Bi%5D%60%20is%20true%20even%20when%20the%20value%20hasn't%20changed%20%28%600.0%20%3E%3D%200.0%60%29%2C%20so%20the%20encoder%20fires%20a%20%60%2B1%60%20spike%20and%20updates%20the%20baseline%20on%20every%20call%20%E2%80%94%20even%20when%20the%20telemetry%20is%20completely%20flat.%20A%20negative%20threshold%20makes%20the%20behavior%20even%20harder%20to%20reason%20about%20%28nearly%20every%20delta%20satisfies%20both%20half-conditions%29.%0A%0AA%20simple%20guard%20in%20%60new%28%29%60%20would%20prevent%20silent%20misbehavior%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20new%28thresholds%3A%20%5Bf32%3B%204%5D%29%20-%3E%20Self%20%7B%0A%20%20%20%20%20%20%20%20for%20%28i%2C%20%26t%29%20in%20thresholds.iter%28%29.enumerate%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28t%20%3E%200.0%2C%20%22TelemetryEncoder%20threshold%5B%7Bi%7D%5D%20must%20be%20strictly%20positive%2C%20got%20%7Bt%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20Self%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20baseline%3A%20%5B0.0%3B%204%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20thresholds%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20initialized%3A%20false%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aexamples%2Ftelemetry_bridge.rs%3A1-6%0A**Example%20doesn't%20demonstrate%20the%20new%20%60TelemetryEncoder%60**%0A%0AThe%20file%20is%20named%20%60telemetry_bridge.rs%60%20and%20the%20PR's%20primary%20addition%20is%20%60TelemetryEncoder%60%2C%20but%20the%20example%20only%20adds%20a%20diagnostic%20%60println!%60%20for%20OLMoE%20status%20%E2%80%94%20it%20never%20imports%20or%20uses%20%60TelemetryEncoder%60.%20Consider%20threading%20the%20encoder%20into%20the%20loop%20so%20the%20example%20actually%20shows%20how%20the%20delta-modulation%20output%20feeds%20into%20the%20model%3A%0A%0A%60%60%60rust%0Ause%20corinth_canal%3A%3A%7B%0A%20%20%20%20EMBEDDING_DIM%2C%20HybridConfig%2C%20HybridModel%2C%20OlmoeExecutionMode%2C%20ProjectionMode%2C%0A%20%20%20%20TelemetryEncoder%2C%20TelemetrySnapshot%2C%0A%7D%3B%0A%2F%2F%20...%0Alet%20mut%20encoder%20%3D%20TelemetryEncoder%3A%3Anew%28%5B1.0%2C%205.0%2C%201.0%2C%205.0%5D%29%3B%0A%2F%2F%20inside%20the%20loop%3A%0Alet%20spikes%20%3D%20encoder.encode%28%26snap%29%3B%0Aprintln!%28%22ternary_spikes%3D%7B%3A%3F%7D%22%2C%20spikes%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Flib.rs%3A24-31%0A**Crate-level%20doc%20comment%20doesn't%20import%20%60TelemetryEncoder%60**%0A%0AThe%20quick-start%20snippet%20in%20the%20module-level%20doc%20block%20still%20uses%20the%20old%20import%20list%20without%20%60TelemetryEncoder%60.%20The%20README%20was%20updated%2C%20but%20%60src%2Flib.rs%60%20was%20not.%20Users%20reading%20%60cargo%20doc%60%20output%20will%20see%20an%20incomplete%20example.%20Consider%20syncing%20the%20two%3A%0A%0A%60%60%60suggestion%0A%2F%2F!%20%60%60%60no_run%0A%2F%2F!%20use%20corinth_canal%3A%3A%7BHybridConfig%2C%20HybridModel%2C%20TelemetryEncoder%2C%20TelemetrySnapshot%7D%3B%0A%2F%2F!%0A%2F%2F!%20let%20mut%20model%20%3D%20HybridModel%3A%3Anew%28HybridConfig%3A%3Adefault%28%29%29.unwrap%28%29%3B%0A%2F%2F!%20let%20output%20%3D%20model.forward%28%26TelemetrySnapshot%3A%3Adefault%28%29%29.unwrap%28%29%3B%0A%2F%2F!%0A%2F%2F!%20println!%28%22Selected%20experts%3A%20%7B%3A%3F%7D%22%2C%20output.selected_experts%29%3B%0A%2F%2F!%20%60%60%60%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Genesis: Corinth-Canal consolidated SNN-..."](https://github.com/spikenaut/corinth-canal/commit/940880e7a92d7b392d6d48d18be40addcb51314f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28188109)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->