### PR TITLE
feat: Telemetry Funnel Architecture with 512 GIF Hidden Neurons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ TelemetrySnapshot
        v  TelemetryEncoder (delta modulation)
 [i8; 4] ternary spikes (+1/0/-1)
        |
-       v  deterministic dummy spike generator
-spike_train + membrane_potentials
+       v  SignedSplitBankBridge
+16 input neurons (4 ch × 2 signs × 2 bank width)
        |
-       v  Projector
+       v  SparseGifHiddenLayer (sparse 16 → 512)
+512 GIF hidden neurons with adaptive thresholds
+       |
+       v  Projector (generalized for 512-neuron input)
 dense embedding [2048]
        |
        v  OLMoE (stub/dense/spiking sim)
@@ -33,11 +36,15 @@ expert_weights + selected_experts + hidden
 ## Quick start
 
 ```rust
-use corinth_canal::{HybridConfig, HybridModel, TelemetryEncoder, TelemetrySnapshot};
+use corinth_canal::{
+    HybridConfig, HybridModel, TelemetryFunnel, TelemetrySnapshot,
+    FUNNEL_HIDDEN_NEURONS,
+};
 
-// Configure delta modulation thresholds
+// Configure the telemetry funnel
 let thresholds = [1.0, 5.0, 1.0, 5.0];
-let mut encoder = TelemetryEncoder::new(thresholds);
+let snn_steps = 20;
+let mut funnel = TelemetryFunnel::new(thresholds, snn_steps);
 
 // Create a telemetry snapshot
 let snap = TelemetrySnapshot {
@@ -48,13 +55,17 @@ let snap = TelemetrySnapshot {
     timestamp_ms: 0,
 };
 
-// Encode into ternary spikes
-let spikes = encoder.encode(&snap);
+// Run the full funnel: encoder -> bridge -> 512-neuron GIF hidden layer
+let activity = funnel.encode_snapshot(&snap);
 
-// Or use the full hybrid pipeline
+// Or use the complete hybrid pipeline
 let cfg = HybridConfig::default();
-let mut model = HybridModel::new(cfg)?;
-let output = model.forward(&snap)?;
+let mut model = HybridModel::new_with_projector_neurons(cfg, FUNNEL_HIDDEN_NEURONS)?;
+let output = model.forward_activity(
+    &activity.spike_train,
+    &activity.potentials,
+    &activity.iz_potentials,
+)?;
 
 println!("Selected experts: {:?}", output.selected_experts);
 ```
@@ -96,6 +107,63 @@ let spikes = encoder.encode(&snap);
 
 // Subsequent calls emit spikes based on delta
 let spikes = encoder.encode(&snap);
+```
+
+## TelemetryFunnel
+
+The `TelemetryFunnel` orchestrates the full spiking pipeline from raw telemetry to hidden-layer activity ready for projection.
+
+### Architecture
+
+```
+TelemetrySnapshot
+       |
+       v  TelemetryEncoder (delta modulation)
+[i8; 4] ternary spikes
+       |
+       v  SignedSplitBankBridge
+16 input neurons (4 channels × 2 polarities × 2 neurons)
+       |
+       v  SparseGifHiddenLayer
+512 GIF neurons with adaptive thresholds (sparse 16→512 weights)
+       |
+       v  FunnelActivity
+spike_train + potentials + iz_potentials
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SignedSplitBankBridge` | Expands 4-channel ternary spikes into 16 input neurons using signed split banks (positive/negative pairs per channel) |
+| `SparseGifHiddenLayer` | Pure-Rust Generalized Integrate-and-Fire (GIF) layer with adaptive thresholds. Uses sparse 4-edge connectivity per hidden neuron for fast inference |
+| `FunnelActivity` | Output struct containing the 512-neuron spike train, membrane potentials, and Izhikevich potentials |
+
+### GIF neuron parameters
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `leak` | 0.92 | Membrane leak factor |
+| `threshold_base` | 0.65 | Base firing threshold |
+| `adaptation_scale` | 0.22 | Adaptive threshold scaling |
+| `adaptation_decay` | 0.94 | Adaptation variable decay |
+| `reset_ratio` | 0.35 | Post-spike membrane reset |
+
+### Usage
+
+```rust
+use corinth_canal::{TelemetryFunnel, TelemetrySnapshot, FUNNEL_HIDDEN_NEURONS};
+
+let mut funnel = TelemetryFunnel::new(
+    [1.0, 5.0, 1.0, 5.0], // thresholds
+    20,                   // snn_steps
+);
+
+let activity = funnel.encode_snapshot(&TelemetrySnapshot::default());
+
+// activity.spike_train: 512-neuron spike activity over 20 steps
+// activity.potentials: final membrane potentials (512 values)
+// activity.iz_potentials: Izhikevich potentials (5 values)
 ```
 
 ## Features
@@ -153,9 +221,10 @@ cargo run --example csv_replay /path/to/canonical.csv
 | `src/hybrid/mod.rs` | hybrid module switchboard |
 | `src/hybrid/projector.rs` | 2-bit spiking projector logic |
 | `src/hybrid/olmoe.rs` | GGUF-aware OLMoE simulation |
+| `src/funnel.rs` | TelemetryFunnel: encoder + split-bank bridge + sparse GIF hidden layer |
 | `src/hybrid/hybrid.rs` | deterministic front-end + projector + OLMoE orchestration |
 | `examples/telemetry_bridge.rs` | end-to-end standalone example |
-| `examples/csv_replay.rs` | canonical CSV replay adapter |
+| `examples/csv_replay.rs` | canonical CSV replay adapter (funnel-driven) |
 
 ## Acknowledgments
 

--- a/examples/csv_replay.rs
+++ b/examples/csv_replay.rs
@@ -3,12 +3,13 @@
 //! Canonical CSV format: timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w
 
 use corinth_canal::{
-    EMBEDDING_DIM, HybridConfig, HybridError, HybridModel, OlmoeExecutionMode, ProjectionMode,
-    TelemetrySnapshot,
+    EMBEDDING_DIM, FUNNEL_HIDDEN_NEURONS, HybridConfig, HybridError, HybridModel,
+    OlmoeExecutionMode, ProjectionMode, TelemetryFunnel, TelemetrySnapshot,
 };
 
 const EXPECTED_HEADER: &str =
     "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
+const TELEMETRY_THRESHOLDS: [f32; 4] = [1.0, 5.0, 1.0, 5.0];
 
 fn parse_u64(v: &str) -> Option<u64> {
     v.parse::<u64>().ok()
@@ -43,11 +44,13 @@ fn main() -> corinth_canal::Result<()> {
         projection_mode: ProjectionMode::SpikingTernary,
     };
 
-    let mut model = HybridModel::new(cfg)?;
+    let mut model = HybridModel::new_with_projector_neurons(cfg.clone(), FUNNEL_HIDDEN_NEURONS)?;
+    let mut funnel = TelemetryFunnel::new(TELEMETRY_THRESHOLDS, cfg.snn_steps);
     println!(
-        "olmoe_loaded={} olmoe_mode={:?}",
+        "olmoe_loaded={} olmoe_mode={:?} funnel_hidden_neurons={}",
         model.olmoe_loaded(),
-        model.config().olmoe_execution_mode
+        model.config().olmoe_execution_mode,
+        FUNNEL_HIDDEN_NEURONS,
     );
 
     let csv_content = std::fs::read_to_string(csv_path)?;
@@ -67,6 +70,8 @@ fn main() -> corinth_canal::Result<()> {
     let mut total_loss = 0.0_f32;
     let mut rows_processed = 0_usize;
     let mut rows_skipped = 0_usize;
+    let mut total_input_spikes = 0_usize;
+    let mut total_hidden_spikes = 0_usize;
 
     for (idx, raw_line) in lines.enumerate() {
         let line_number = idx + 2;
@@ -112,7 +117,18 @@ fn main() -> corinth_canal::Result<()> {
             cpu_package_power_w,
         };
 
-        let output = model.forward(&snap)?;
+        let activity = funnel.encode_snapshot(&snap);
+        let output = model.forward_activity(
+            &activity.spike_train,
+            &activity.potentials,
+            &activity.iz_potentials,
+        )?;
+        let input_spikes = activity
+            .input_spike_train
+            .iter()
+            .map(Vec::len)
+            .sum::<usize>();
+        let hidden_spikes = activity.spike_train.iter().map(Vec::len).sum::<usize>();
 
         let mean_embed = output.embedding.iter().sum::<f32>() / EMBEDDING_DIM as f32;
         let target = vec![mean_embed * 0.9; EMBEDDING_DIM];
@@ -126,11 +142,20 @@ fn main() -> corinth_canal::Result<()> {
 
         total_loss += loss;
         rows_processed += 1;
+        total_input_spikes += input_spikes;
+        total_hidden_spikes += hidden_spikes;
 
         if rows_processed % 100 == 0 || rows_processed <= 5 {
             println!(
-                "step={:>4} gpu_temp={:5.1}C gpu_power={:6.1}W cpu_temp={:5.1}C loss={:.6}",
-                rows_processed, gpu_temp_c, gpu_power_w, cpu_tctl_c, loss
+                "step={:>4} gpu_temp={:5.1}C gpu_power={:6.1}W cpu_temp={:5.1}C ternary={:?} input_spikes={:>3} hidden_spikes={:>4} loss={:.6}",
+                rows_processed,
+                gpu_temp_c,
+                gpu_power_w,
+                cpu_tctl_c,
+                activity.ternary_events,
+                input_spikes,
+                hidden_spikes,
+                loss
             );
         }
     }
@@ -145,6 +170,22 @@ fn main() -> corinth_canal::Result<()> {
     println!("rows_processed={}", rows_processed);
     println!("rows_skipped={}", rows_skipped);
     println!("avg_loss={:.6}", avg_loss);
+    println!(
+        "avg_input_spikes_per_row={:.3}",
+        if rows_processed > 0 {
+            total_input_spikes as f32 / rows_processed as f32
+        } else {
+            0.0
+        }
+    );
+    println!(
+        "avg_hidden_spikes_per_row={:.3}",
+        if rows_processed > 0 {
+            total_hidden_spikes as f32 / rows_processed as f32
+        } else {
+            0.0
+        }
+    );
     println!("global_step={}", model.global_step());
     println!("olmoe_loaded={}", model.olmoe_loaded());
 

--- a/src/funnel.rs
+++ b/src/funnel.rs
@@ -1,0 +1,313 @@
+use crate::telemetry::TelemetryEncoder;
+use crate::types::TelemetrySnapshot;
+
+pub const FUNNEL_INPUT_NEURONS: usize = 16;
+pub const FUNNEL_HIDDEN_NEURONS: usize = 512;
+const TELEMETRY_CHANNELS: usize = 4;
+const BANK_WIDTH: usize = 2;
+const GIF_FAN_IN: usize = 4;
+const GIF_IZ_NEURONS: usize = 5;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunnelActivity {
+    pub ternary_events: [i8; 4],
+    pub input_spike_train: Vec<Vec<usize>>,
+    pub spike_train: Vec<Vec<usize>>,
+    pub potentials: Vec<f32>,
+    pub iz_potentials: Vec<f32>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SignedSplitBankBridge;
+
+impl SignedSplitBankBridge {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn active_bank(&self, channel: usize, spike: i8) -> Option<[usize; BANK_WIDTH]> {
+        if channel >= TELEMETRY_CHANNELS {
+            return None;
+        }
+
+        let channel_base = channel * (BANK_WIDTH * 2);
+        match spike {
+            1 => Some([channel_base, channel_base + 1]),
+            -1 => Some([channel_base + 2, channel_base + 3]),
+            _ => None,
+        }
+    }
+
+    pub fn expand(&self, ternary: [i8; 4], snn_steps: usize) -> Vec<Vec<usize>> {
+        let mut spike_train = vec![Vec::new(); snn_steps];
+        for (channel, spike) in ternary.into_iter().enumerate() {
+            let Some(bank) = self.active_bank(channel, spike) else {
+                continue;
+            };
+            for step in 0..snn_steps {
+                if step % 2 == 0 {
+                    spike_train[step].push(bank[0]);
+                    spike_train[step].push(bank[1]);
+                } else {
+                    spike_train[step].push(bank[1]);
+                    spike_train[step].push(bank[0]);
+                }
+            }
+        }
+        spike_train
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SparseGifHiddenLayer {
+    weight_indices: Vec<[usize; GIF_FAN_IN]>,
+    weight_values: Vec<[f32; GIF_FAN_IN]>,
+    membrane: Vec<f32>,
+    adaptation: Vec<f32>,
+    leak: f32,
+    drive_scale: f32,
+    threshold_base: f32,
+    adaptation_scale: f32,
+    adaptation_decay: f32,
+    reset_ratio: f32,
+}
+
+impl SparseGifHiddenLayer {
+    pub fn new() -> Self {
+        let mut weight_indices = Vec::with_capacity(FUNNEL_HIDDEN_NEURONS);
+        let mut weight_values = Vec::with_capacity(FUNNEL_HIDDEN_NEURONS);
+
+        for hidden in 0..FUNNEL_HIDDEN_NEURONS {
+            let tuned_negative = hidden % 2 == 1;
+            let mut indices = [0usize; GIF_FAN_IN];
+            let mut values = [0.0f32; GIF_FAN_IN];
+            let mut cursor = (hidden * 11 + 3) % FUNNEL_INPUT_NEURONS;
+
+            for edge in 0..GIF_FAN_IN {
+                while indices[..edge].contains(&cursor) {
+                    cursor = (cursor + 5) % FUNNEL_INPUT_NEURONS;
+                }
+
+                indices[edge] = cursor;
+
+                let positive_bank = cursor % 4 < 2;
+                let preference = if tuned_negative {
+                    if positive_bank { -1.0 } else { 1.0 }
+                } else if positive_bank {
+                    1.0
+                } else {
+                    -1.0
+                };
+                let phase = ((hidden * 37 + edge * 19 + cursor * 13) % 97) as f32 / 96.0;
+                values[edge] = preference * (0.35 + phase * 0.4);
+                cursor = (cursor + 7 + hidden % 3) % FUNNEL_INPUT_NEURONS;
+            }
+
+            weight_indices.push(indices);
+            weight_values.push(values);
+        }
+
+        Self {
+            weight_indices,
+            weight_values,
+            membrane: vec![0.0; FUNNEL_HIDDEN_NEURONS],
+            adaptation: vec![0.0; FUNNEL_HIDDEN_NEURONS],
+            leak: 0.92,
+            drive_scale: 0.75,
+            threshold_base: 0.65,
+            adaptation_scale: 0.22,
+            adaptation_decay: 0.94,
+            reset_ratio: 0.35,
+        }
+    }
+
+    pub fn run(&mut self, input_spike_train: &[Vec<usize>]) -> (Vec<Vec<usize>>, Vec<f32>, Vec<f32>) {
+        let mut spike_train = Vec::with_capacity(input_spike_train.len());
+        let mut active = [false; FUNNEL_INPUT_NEURONS];
+
+        for step in input_spike_train {
+            active.fill(false);
+            for &idx in step {
+                if idx < FUNNEL_INPUT_NEURONS {
+                    active[idx] = true;
+                }
+            }
+
+            let mut step_spikes = Vec::new();
+            for hidden in 0..FUNNEL_HIDDEN_NEURONS {
+                self.adaptation[hidden] *= self.adaptation_decay;
+
+                let mut drive = 0.0f32;
+                let indices = &self.weight_indices[hidden];
+                let values = &self.weight_values[hidden];
+                for edge in 0..GIF_FAN_IN {
+                    if active[indices[edge]] {
+                        drive += values[edge];
+                    }
+                }
+
+                self.membrane[hidden] =
+                    self.membrane[hidden] * self.leak + drive * self.drive_scale - self.adaptation[hidden] * 0.05;
+
+                let threshold = self.threshold_base + self.adaptation[hidden] * self.adaptation_scale;
+                if self.membrane[hidden] >= threshold {
+                    step_spikes.push(hidden);
+                    self.membrane[hidden] -= threshold * self.reset_ratio;
+                    self.adaptation[hidden] += 1.0;
+                }
+            }
+
+            spike_train.push(step_spikes);
+        }
+
+        let potentials = self
+            .membrane
+            .iter()
+            .map(|value| (value / (self.threshold_base * 2.0)).clamp(0.0, 1.0))
+            .collect();
+
+        (spike_train, potentials, vec![0.0; GIF_IZ_NEURONS])
+    }
+
+    pub fn reset(&mut self) {
+        self.membrane.fill(0.0);
+        self.adaptation.fill(0.0);
+    }
+
+    pub fn state_activity(&self) -> bool {
+        self.membrane.iter().any(|value| value.abs() > 1e-6)
+            || self.adaptation.iter().any(|value| value.abs() > 1e-6)
+    }
+}
+
+impl Default for SparseGifHiddenLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TelemetryFunnel {
+    encoder: TelemetryEncoder,
+    bridge: SignedSplitBankBridge,
+    hidden: SparseGifHiddenLayer,
+    snn_steps: usize,
+}
+
+impl TelemetryFunnel {
+    pub fn new(thresholds: [f32; 4], snn_steps: usize) -> Self {
+        Self {
+            encoder: TelemetryEncoder::new(thresholds),
+            bridge: SignedSplitBankBridge::new(),
+            hidden: SparseGifHiddenLayer::new(),
+            snn_steps,
+        }
+    }
+
+    pub fn encode_snapshot(&mut self, snap: &TelemetrySnapshot) -> FunnelActivity {
+        let ternary_events = self.encoder.encode(snap);
+        let input_spike_train = self.bridge.expand(ternary_events, self.snn_steps);
+        let (spike_train, potentials, iz_potentials) = self.hidden.run(&input_spike_train);
+
+        FunnelActivity {
+            ternary_events,
+            input_spike_train,
+            spike_train,
+            potentials,
+            iz_potentials,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.hidden.reset();
+    }
+
+    pub fn hidden_state_active(&self) -> bool {
+        self.hidden.state_activity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(
+        gpu_temp_c: f32,
+        gpu_power_w: f32,
+        cpu_tctl_c: f32,
+        cpu_package_power_w: f32,
+    ) -> TelemetrySnapshot {
+        TelemetrySnapshot {
+            gpu_temp_c,
+            gpu_power_w,
+            cpu_tctl_c,
+            cpu_package_power_w,
+            timestamp_ms: 0,
+        }
+    }
+
+    #[test]
+    fn signed_split_bank_mapping_uses_distinct_neurons() {
+        let bridge = SignedSplitBankBridge::new();
+        assert_eq!(bridge.active_bank(0, 1), Some([0, 1]));
+        assert_eq!(bridge.active_bank(0, -1), Some([2, 3]));
+        assert_eq!(bridge.active_bank(3, 1), Some([12, 13]));
+        assert_eq!(bridge.active_bank(3, -1), Some([14, 15]));
+    }
+
+    #[test]
+    fn zero_events_produce_silent_input_spike_train() {
+        let bridge = SignedSplitBankBridge::new();
+        let spike_train = bridge.expand([0, 0, 0, 0], 6);
+        assert_eq!(spike_train.len(), 6);
+        assert!(spike_train.iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn hidden_layer_output_has_expected_shape() {
+        let bridge = SignedSplitBankBridge::new();
+        let mut hidden = SparseGifHiddenLayer::new();
+        let input = bridge.expand([1, -1, 0, 1], 20);
+        let (spike_train, potentials, iz_potentials) = hidden.run(&input);
+
+        assert_eq!(spike_train.len(), 20);
+        assert_eq!(potentials.len(), FUNNEL_HIDDEN_NEURONS);
+        assert_eq!(iz_potentials.len(), GIF_IZ_NEURONS);
+    }
+
+    #[test]
+    fn hidden_layer_is_deterministic_from_fresh_state() {
+        let bridge = SignedSplitBankBridge::new();
+        let input = bridge.expand([1, 0, -1, 1], 12);
+        let mut hidden_a = SparseGifHiddenLayer::new();
+        let mut hidden_b = SparseGifHiddenLayer::new();
+
+        let output_a = hidden_a.run(&input);
+        let output_b = hidden_b.run(&input);
+
+        assert_eq!(output_a, output_b);
+    }
+
+    #[test]
+    fn adaptive_threshold_state_accumulates_under_repeated_drive() {
+        let bridge = SignedSplitBankBridge::new();
+        let input = bridge.expand([1, 1, 1, 1], 20);
+        let mut hidden = SparseGifHiddenLayer::new();
+        let _ = hidden.run(&input);
+
+        assert!(hidden.state_activity());
+        assert!(hidden.adaptation.iter().any(|value| *value > 0.0));
+    }
+
+    #[test]
+    fn telemetry_funnel_emits_hidden_activity_after_threshold_crossing() {
+        let mut funnel = TelemetryFunnel::new([1.0, 5.0, 1.0, 5.0], 20);
+        let _ = funnel.encode_snapshot(&snapshot(60.0, 260.0, 77.0, 153.0));
+        let activity = funnel.encode_snapshot(&snapshot(61.0, 266.0, 78.0, 160.0));
+
+        assert_eq!(activity.ternary_events, [1, 1, 1, 1]);
+        assert_eq!(activity.input_spike_train.len(), 20);
+        assert_eq!(activity.potentials.len(), FUNNEL_HIDDEN_NEURONS);
+        assert_eq!(activity.iz_potentials.len(), GIF_IZ_NEURONS);
+    }
+}

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -21,6 +21,13 @@ pub struct HybridModel {
 
 impl HybridModel {
     pub fn new(config: HybridConfig) -> Result<Self> {
+        Self::new_with_projector_neurons(config, N_NEURONS)
+    }
+
+    pub fn new_with_projector_neurons(
+        config: HybridConfig,
+        projector_neurons: usize,
+    ) -> Result<Self> {
         if config.snn_steps == 0 {
             return Err(HybridError::InvalidConfig("snn_steps must be ≥ 1".into()));
         }
@@ -37,7 +44,7 @@ impl HybridModel {
             )));
         }
 
-        let projector = Projector::new(config.projection_mode);
+        let projector = Projector::with_input_neurons(config.projection_mode, projector_neurons);
         let olmoe = OLMoE::load_with_mode(
             &config.olmoe_model_path,
             config.num_experts,
@@ -54,19 +61,29 @@ impl HybridModel {
     }
 
     pub fn forward(&mut self, snap: &TelemetrySnapshot) -> Result<HybridOutput> {
+        let (spike_train, potentials, iz_potentials) = self.synthetic_activity(snap);
+        self.forward_activity(&spike_train, &potentials, &iz_potentials)
+    }
+
+    pub fn forward_activity(
+        &mut self,
+        spike_train: &[Vec<usize>],
+        potentials: &[f32],
+        iz_potentials: &[f32],
+    ) -> Result<HybridOutput> {
         self.global_step += 1;
 
-        let (spike_train, potentials, iz_potentials) = self.synthetic_activity(snap);
         let embedding = self
             .projector
             .project(&spike_train, &potentials, &iz_potentials)?;
         let olmoe_out = self.olmoe.forward(&embedding)?;
 
-        let steps_f = self.config.snn_steps as f32;
-        let mut counts = vec![0usize; N_NEURONS];
-        for step in &spike_train {
+        let steps_f = spike_train.len().max(1) as f32;
+        let neuron_count = self.projector.input_neurons();
+        let mut counts = vec![0usize; neuron_count];
+        for step in spike_train {
             for &idx in step {
-                if idx < N_NEURONS {
+                if idx < neuron_count {
                     counts[idx] += 1;
                 }
             }
@@ -74,9 +91,9 @@ impl HybridModel {
         let firing_rates: Vec<f32> = counts.iter().map(|&c| c as f32 / steps_f).collect();
 
         Ok(HybridOutput {
-            spike_train,
+            spike_train: spike_train.to_vec(),
             firing_rates,
-            membrane_potentials: potentials,
+            membrane_potentials: potentials.to_vec(),
             embedding,
             expert_weights: Some(olmoe_out.expert_weights),
             selected_experts: Some(olmoe_out.selected_experts),
@@ -150,6 +167,7 @@ impl HybridModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::funnel::FUNNEL_HIDDEN_NEURONS;
     use crate::types::{OlmoeExecutionMode, ProjectionMode};
 
     fn default_model() -> HybridModel {
@@ -260,5 +278,25 @@ mod tests {
             let out = model.forward(&TelemetrySnapshot::default()).unwrap();
             assert_eq!(out.embedding.len(), EMBEDDING_DIM, "mode: {mode:?}");
         }
+    }
+
+    #[test]
+    fn test_forward_activity_supports_custom_projector_width() {
+        let mut model = HybridModel::new_with_projector_neurons(
+            HybridConfig::default(),
+            FUNNEL_HIDDEN_NEURONS,
+        )
+        .unwrap();
+        let spike_train = vec![vec![0, 1, 2, 3]; 20];
+        let potentials = vec![0.4; FUNNEL_HIDDEN_NEURONS];
+        let iz_potentials = vec![0.0; IZ_NEURONS];
+
+        let out = model
+            .forward_activity(&spike_train, &potentials, &iz_potentials)
+            .unwrap();
+
+        assert_eq!(out.firing_rates.len(), FUNNEL_HIDDEN_NEURONS);
+        assert_eq!(out.membrane_potentials.len(), FUNNEL_HIDDEN_NEURONS);
+        assert_eq!(out.embedding.len(), EMBEDDING_DIM);
     }
 }

--- a/src/hybrid/projector.rs
+++ b/src/hybrid/projector.rs
@@ -31,13 +31,14 @@ use crate::types::{ProjectionMode, EMBEDDING_DIM};
 
 /// Number of neurons in the Spikenaut SNN.
 const SNN_NEURONS: usize = 16;
+const TEMPORAL_BINS: usize = 4;
 
 /// Number of Izhikevich neurons in the adaptive bank.
 const IZ_NEURONS: usize = 5;
 
-/// Feature vector length before the linear projection.
-/// = rate features (16) + temporal bins (16 × 4) + membrane (16) + Iz potentials (5)
-const FEATURE_DIM: usize = SNN_NEURONS + (SNN_NEURONS * 4) + SNN_NEURONS + IZ_NEURONS;
+fn feature_dim_for(snn_neurons: usize) -> usize {
+    snn_neurons + (snn_neurons * TEMPORAL_BINS) + snn_neurons + IZ_NEURONS
+}
 
 // ── Projector ─────────────────────────────────────────────────────────────────
 
@@ -64,6 +65,10 @@ pub struct Projector {
     /// Projection strategy.
     mode: ProjectionMode,
 
+    snn_neurons: usize,
+
+    feature_dim: usize,
+
     /// Flat weight matrix `W`, row-major layout: `W[out * FEATURE_DIM + in]`.
     /// Shape: `[EMBEDDING_DIM, FEATURE_DIM]`.
     weights: Vec<f32>,
@@ -73,7 +78,7 @@ pub struct Projector {
 
     /// Running exponential moving average of firing rates (for normalisation).
     /// Updated each call to [`project`](Self::project).
-    rate_ema: [f32; SNN_NEURONS],
+    rate_ema: Vec<f32>,
 
     /// EMA decay constant for firing rate normalisation.
     ema_alpha: f32,
@@ -98,13 +103,19 @@ impl Projector {
     /// # Arguments
     /// * `mode` — how to aggregate spike activity into a feature vector.
     pub fn new(mode: ProjectionMode) -> Self {
-        let fan_in = FEATURE_DIM as f32;
+        Self::with_input_neurons(mode, SNN_NEURONS)
+    }
+
+    pub fn with_input_neurons(mode: ProjectionMode, snn_neurons: usize) -> Self {
+        let snn_neurons = snn_neurons.max(1);
+        let feature_dim = feature_dim_for(snn_neurons);
+        let fan_in = feature_dim as f32;
         let fan_out = EMBEDDING_DIM as f32;
         let limit = (6.0_f32 / (fan_in + fan_out)).sqrt();
 
         // Deterministic Xavier-uniform init (no external rng dep needed).
-        let mut weights = Vec::with_capacity(EMBEDDING_DIM * FEATURE_DIM);
-        for i in 0..(EMBEDDING_DIM * FEATURE_DIM) {
+        let mut weights = Vec::with_capacity(EMBEDDING_DIM * feature_dim);
+        for i in 0..(EMBEDDING_DIM * feature_dim) {
             // Simple deterministic pseudo-random from index hash.
             let t = ((i as f32 * 1.6180339887) % 1.0) * 2.0 - 1.0;
             weights.push(t * limit);
@@ -112,9 +123,11 @@ impl Projector {
 
         Self {
             mode,
+            snn_neurons,
+            feature_dim,
             weights,
             bias: vec![0.0; EMBEDDING_DIM],
-            rate_ema: [0.0; SNN_NEURONS],
+            rate_ema: vec![0.0; snn_neurons],
             ema_alpha: 0.1,
             membrane: vec![0.0; EMBEDDING_DIM],
             threshold: 0.8,   // saliency threshold (SpikeLLM / NSLLM style)
@@ -137,9 +150,9 @@ impl Projector {
         potentials: &[f32],
         iz_potentials: &[f32],
     ) -> Result<Vec<f32>> {
-        if potentials.len() < SNN_NEURONS {
+        if potentials.len() < self.snn_neurons {
             return Err(HybridError::InputLengthMismatch {
-                expected: SNN_NEURONS,
+                expected: self.snn_neurons,
                 got: potentials.len(),
             });
         }
@@ -163,10 +176,10 @@ impl Projector {
         let n_steps = spike_train.len().max(1) as f32;
 
         // 1. Firing rates per neuron [16 dims]
-        let mut rates = [0.0_f32; SNN_NEURONS];
+        let mut rates = vec![0.0_f32; self.snn_neurons];
         for step in spike_train {
             for &idx in step {
-                if idx < SNN_NEURONS {
+                if idx < self.snn_neurons {
                     rates[idx] += 1.0;
                 }
             }
@@ -176,20 +189,20 @@ impl Projector {
         }
 
         // Update EMA for normalisation
-        for i in 0..SNN_NEURONS {
+        for i in 0..self.snn_neurons {
             self.rate_ema[i] =
                 self.ema_alpha * rates[i] + (1.0 - self.ema_alpha) * self.rate_ema[i];
         }
 
         // 2. Temporal histogram bins (4 equal-width bins) [64 dims]
-        let bins = 4usize;
-        let mut hist = vec![0.0_f32; SNN_NEURONS * bins];
+        let bins = TEMPORAL_BINS;
+        let mut hist = vec![0.0_f32; self.snn_neurons * bins];
         if !spike_train.is_empty() {
             let steps = spike_train.len();
             for (t, step) in spike_train.iter().enumerate() {
                 let bin = ((t * bins) / steps).min(bins - 1);
                 for &idx in step {
-                    if idx < SNN_NEURONS {
+                    if idx < self.snn_neurons {
                         hist[idx * bins + bin] += 1.0;
                     }
                 }
@@ -201,7 +214,7 @@ impl Projector {
         }
 
         // 3. Membrane potentials [16 dims] — clamped to [0, 1]
-        let membrane: Vec<f32> = potentials[..SNN_NEURONS]
+        let membrane: Vec<f32> = potentials[..self.snn_neurons]
             .iter()
             .map(|&v| v.clamp(0.0, 1.0))
             .collect();
@@ -216,7 +229,7 @@ impl Projector {
             .collect();
 
         // Mode-specific blending
-        let mut features = Vec::with_capacity(FEATURE_DIM);
+        let mut features = Vec::with_capacity(self.feature_dim);
         match self.mode {
             ProjectionMode::RateSum => {
                 features.extend_from_slice(&rates);
@@ -253,7 +266,7 @@ impl Projector {
         }
 
         // Pad or truncate to exactly FEATURE_DIM
-        features.resize(FEATURE_DIM, 0.0);
+        features.resize(self.feature_dim, 0.0);
         features
     }
 
@@ -264,8 +277,8 @@ impl Projector {
         let mut out = vec![0.0_f32; EMBEDDING_DIM];
         for out_i in 0..EMBEDDING_DIM {
             let mut acc = self.bias[out_i];
-            let row_offset = out_i * FEATURE_DIM;
-            for in_j in 0..features.len().min(FEATURE_DIM) {
+            let row_offset = out_i * self.feature_dim;
+            for in_j in 0..features.len().min(self.feature_dim) {
                 acc += self.weights[row_offset + in_j] * features[in_j];
             }
             // Layer norm approximation: tanh squash keeps embedding bounded
@@ -289,8 +302,8 @@ impl Projector {
         let activity_drive = features.iter().map(|v| v.abs()).fold(0.0_f32, f32::max);
         for out_i in 0..EMBEDDING_DIM {
             let mut acc = self.bias[out_i];
-            let row_offset = out_i * FEATURE_DIM;
-            for in_j in 0..features.len().min(FEATURE_DIM) {
+            let row_offset = out_i * self.feature_dim;
+            for in_j in 0..features.len().min(self.feature_dim) {
                 acc += self.weights[row_offset + in_j] * features[in_j];
             }
             // GIF integration step
@@ -319,7 +332,7 @@ impl Projector {
     /// Returns [`HybridError::InputLengthMismatch`] if the slice length ≠
     /// `EMBEDDING_DIM × FEATURE_DIM`.
     pub fn load_weights(&mut self, weights: &[f32]) -> Result<()> {
-        let expected = EMBEDDING_DIM * FEATURE_DIM;
+        let expected = EMBEDDING_DIM * self.feature_dim;
         if weights.len() != expected {
             return Err(HybridError::InputLengthMismatch {
                 expected,
@@ -358,11 +371,15 @@ impl Projector {
 
     /// Dimensionality constants (useful for allocating buffers).
     pub fn dims(&self) -> (usize, usize) {
-        (FEATURE_DIM, EMBEDDING_DIM)
+        (self.feature_dim, EMBEDDING_DIM)
+    }
+
+    pub fn input_neurons(&self) -> usize {
+        self.snn_neurons
     }
 
     /// Firing rate EMA snapshot (useful for diagnostics / reward shaping).
-    pub fn rate_ema(&self) -> &[f32; SNN_NEURONS] {
+    pub fn rate_ema(&self) -> &[f32] {
         &self.rate_ema
     }
 }
@@ -379,16 +396,16 @@ impl Default for Projector {
 mod tests {
     use super::*;
 
-    fn dummy_spike_train(n_steps: usize) -> Vec<Vec<usize>> {
+    fn dummy_spike_train(n_steps: usize, neurons: usize) -> Vec<Vec<usize>> {
         (0..n_steps)
-            .map(|t| vec![t % SNN_NEURONS, (t + 1) % SNN_NEURONS])
+            .map(|t| vec![t % neurons, (t + 1) % neurons])
             .collect()
     }
 
     #[test]
     fn test_project_output_length() {
         let mut proj = Projector::new(ProjectionMode::RateSum);
-        let spikes = dummy_spike_train(20);
+        let spikes = dummy_spike_train(20, SNN_NEURONS);
         let potentials = vec![0.3; SNN_NEURONS];
         let iz_pots = vec![15.0; IZ_NEURONS];
         let embedding = proj.project(&spikes, &potentials, &iz_pots).unwrap();
@@ -398,7 +415,7 @@ mod tests {
     #[test]
     fn test_project_values_bounded() {
         let mut proj = Projector::new(ProjectionMode::TemporalHistogram);
-        let spikes = dummy_spike_train(10);
+        let spikes = dummy_spike_train(10, SNN_NEURONS);
         let potentials = vec![0.5; SNN_NEURONS];
         let iz_pots = vec![30.0; IZ_NEURONS];
         let embedding = proj.project(&spikes, &potentials, &iz_pots).unwrap();
@@ -413,7 +430,7 @@ mod tests {
     #[test]
     fn test_spiking_ternary_output() {
         let mut proj = Projector::new(ProjectionMode::SpikingTernary);
-        let spikes = dummy_spike_train(20);
+        let spikes = dummy_spike_train(20, SNN_NEURONS);
         let potentials = vec![0.3; SNN_NEURONS];
         let iz_pots = vec![15.0; IZ_NEURONS];
 
@@ -432,7 +449,7 @@ mod tests {
     #[test]
     fn test_spiking_ternary_fires_after_warmup() {
         let mut proj = Projector::new(ProjectionMode::SpikingTernary);
-        let spikes = dummy_spike_train(20);
+        let spikes = dummy_spike_train(20, SNN_NEURONS);
         let potentials = vec![0.9; SNN_NEURONS];   // high activity to charge membranes
         let iz_pots = vec![28.0; IZ_NEURONS];
 
@@ -448,7 +465,7 @@ mod tests {
     #[test]
     fn test_reset_membrane_clears_state() {
         let mut proj = Projector::new(ProjectionMode::SpikingTernary);
-        let spikes = dummy_spike_train(20);
+        let spikes = dummy_spike_train(20, SNN_NEURONS);
         let potentials = vec![0.9; SNN_NEURONS];
         let iz_pots = vec![28.0; IZ_NEURONS];
 
@@ -472,7 +489,7 @@ mod tests {
     #[test]
     fn test_membrane_mode() {
         let mut proj = Projector::new(ProjectionMode::MembraneSnapshot);
-        let spikes = dummy_spike_train(5);
+        let spikes = dummy_spike_train(5, SNN_NEURONS);
         let potentials = vec![0.8; SNN_NEURONS];
         let iz_pots = vec![0.0; IZ_NEURONS];
         let embedding = proj.project(&spikes, &potentials, &iz_pots).unwrap();
@@ -480,10 +497,26 @@ mod tests {
     }
 
     #[test]
+    fn test_custom_input_neuron_count() {
+        let neurons = 512;
+        let mut proj = Projector::with_input_neurons(ProjectionMode::RateSum, neurons);
+        let spikes = dummy_spike_train(8, neurons);
+        let potentials = vec![0.4; neurons];
+        let iz_pots = vec![0.0; IZ_NEURONS];
+        let embedding = proj.project(&spikes, &potentials, &iz_pots).unwrap();
+        let (feature_dim, embedding_dim) = proj.dims();
+
+        assert_eq!(embedding.len(), EMBEDDING_DIM);
+        assert_eq!(embedding_dim, EMBEDDING_DIM);
+        assert_eq!(feature_dim, feature_dim_for(neurons));
+        assert_eq!(proj.input_neurons(), neurons);
+    }
+
+    #[test]
     fn test_dims() {
         let proj = Projector::default();
         let (feat, emb) = proj.dims();
-        assert_eq!(feat, FEATURE_DIM);
+        assert_eq!(feat, feature_dim_for(SNN_NEURONS));
         assert_eq!(emb, EMBEDDING_DIM);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! ```
 
 pub mod error;
+pub mod funnel;
 pub mod hybrid;
 pub mod telemetry;
 pub mod tensor;
@@ -38,6 +39,10 @@ pub mod transformer;
 pub mod types;
 
 pub use error::{HybridError, Result};
+pub use funnel::{
+    FunnelActivity, SignedSplitBankBridge, SparseGifHiddenLayer, TelemetryFunnel,
+    FUNNEL_HIDDEN_NEURONS, FUNNEL_INPUT_NEURONS,
+};
 pub use hybrid::{HybridModel, OLMoE, Projector};
 pub use telemetry::TelemetryEncoder;
 pub use types::{


### PR DESCRIPTION
Implements the complete funnel architecture for processing telemetry data through a neuromorphic pipeline.

## Changes

### New Components
- **SignedSplitBankBridge**: Expands 4-channel ternary spikes into 16 input neurons
- **SparseGifHiddenLayer**: Pure-Rust 512-neuron GIF layer with adaptive thresholds
- **TelemetryFunnel**: Orchestrates encoder → bridge → hidden layer
- **FunnelActivity**: Output struct with 512-neuron spike train

### Generalized Projector
- Added  for configurable widths
- Preserves backward-compatible  default path

### HybridModel Updates
- Added  and  APIs
- Preserves existing  behavior

### CSV Replay
- Full funnel pipeline with per-row spike statistics
- Summary shows avg input/hidden spikes per row

## Architecture
TelemetrySnapshot → TelemetryEncoder → SignedSplitBankBridge (16) → SparseGifHiddenLayer (512) → Projector → OLMoE

Closes: funnel architecture implementation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a full neuromorphic telemetry funnel pipeline (`TelemetrySnapshot → TelemetryEncoder → SignedSplitBankBridge → SparseGifHiddenLayer (512) → Projector → OLMoE`) and wires it end-to-end in the CSV replay example. The `Projector` is generalized to accept configurable neuron counts via `with_input_neurons()`, and `HybridModel` gains a `forward_activity()` entry point that consumes externally-prepared activity rather than relying on the synthetic spike generator.

Key observations:
- **New funnel module** (`src/funnel.rs`) — `SignedSplitBankBridge`, `SparseGifHiddenLayer`, and `TelemetryFunnel` are well-structured with solid deterministic tests; GIF dynamics and adaptive-threshold logic look correct.
- **`HybridModel::forward()` is broken for wide projectors** — `synthetic_activity()` is hardcoded to 16 neurons (`N_NEURONS`). Calling `forward()` on a model built with `new_with_projector_neurons(cfg, 512)` always returns `Err(InputLengthMismatch)`. The new `forward_activity()` path works correctly; `forward()` needs a width guard or updated docs.
- **Xavier init degrades silently for 512-neuron projectors** — the golden-ratio `f32` trick loses its fractional part at index ≈ 5.18 M, making ~18 % of the 512-neuron weight matrix initialize to `−limit` uniformly. Switching the inner loop to an integer PRNG (`u64` LCG) would fix this with no API change.
- **Alternating push order in `SignedSplitBankBridge::expand()`** has no functional effect — `SparseGifHiddenLayer::run()` uses a boolean `active[]` array indexed by neuron ID, so push order is irrelevant.
- CSV replay, public re-exports (`src/lib.rs`), and README updates are all consistent and correct.

<h3>Confidence Score: 3/5</h3>

- Safe to merge once the forward() width-mismatch bug is addressed; the new funnel path itself is correct.
- The primary funnel pipeline (TelemetryFunnel → forward_activity) is sound and the tests covering it pass. However, the public forward() method silently errors at runtime for any HybridModel created with new_with_projector_neurons — a concrete bug that will bite users combining the two APIs. The f32 init degradation is a follow-up concern. Resolving the forward() guard brings this to a 4-5.
- src/hybrid/hybrid.rs (forward() / synthetic_activity() width mismatch), src/hybrid/projector.rs (f32 Xavier init precision for large feature dims)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/funnel.rs | New file introducing SignedSplitBankBridge, SparseGifHiddenLayer, TelemetryFunnel, and FunnelActivity. Core GIF dynamics and weight initialization are sound; alternating push order in expand() is a no-op (minor style issue). |
| src/hybrid/hybrid.rs | Adds forward_activity() and new_with_projector_neurons() APIs. The existing forward() method is broken for any model constructed with wider projector neurons because synthetic_activity() is hardcoded to N_NEURONS=16, causing an Err(InputLengthMismatch) at runtime. |
| src/hybrid/projector.rs | Generalized to support configurable snn_neurons via with_input_neurons(). Feature-dim calculation and weight/bias loading are correct, but the golden-ratio f32 Xavier init degrades (all-negative) for the ~18% of weight entries beyond the f32 precision boundary when using 512 neurons. |
| examples/csv_replay.rs | Correctly uses the funnel pipeline (forward_activity) throughout; good bounds checking, header validation, and per-row stats. Synthetic loss target is clearly illustrative-only. |
| src/lib.rs | Re-exports for all new public funnel types are correct; no issues. |
| README.md | Documentation updated to reflect new architecture accurately; architecture diagram and usage examples are consistent with the implementation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CSV as csv_replay
    participant TF as TelemetryFunnel
    participant ENC as TelemetryEncoder
    participant BRG as SignedSplitBankBridge
    participant GIF as SparseGifHiddenLayer
    participant HM as HybridModel
    participant PRJ as Projector
    participant MOE as OLMoE

    CSV->>TF: encode_snapshot(TelemetrySnapshot)
    TF->>ENC: encode(snap)
    ENC-->>TF: ternary_events [i8 x4]
    TF->>BRG: expand(ternary, snn_steps)
    BRG-->>TF: input_spike_train (16 neurons)
    TF->>GIF: run(input_spike_train)
    GIF-->>TF: spike_train (512), potentials (512), iz_potentials (5)
    TF-->>CSV: FunnelActivity

    CSV->>HM: forward_activity(spike_train, potentials, iz_potentials)
    HM->>PRJ: project(spike_train, potentials, iz_potentials)
    PRJ-->>HM: embedding [2048]
    HM->>MOE: forward(embedding)
    MOE-->>HM: expert_weights, selected_experts
    HM-->>CSV: HybridOutput
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikenaut%2Fcorinth-canal%22%20on%20the%20existing%20branch%20%22funnel-architecture%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22funnel-architecture%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fhybrid%2Fhybrid.rs%3A63-66%0A**%60forward%28%29%60%20always%20errors%20for%20wide-projector%20models**%0A%0A%60synthetic_activity%28%29%60%20is%20hardcoded%20to%20produce%20%60N_NEURONS%20%3D%2016%60%20potentials%2C%20but%20%60forward_activity%28%29%60%20%E2%86%92%20%60projector.project%28%29%60%20guards%20that%20%60potentials.len%28%29%20%3E%3D%20self.snn_neurons%60.%20When%20the%20model%20is%20constructed%20via%20%60new_with_projector_neurons%28cfg%2C%20FUNNEL_HIDDEN_NEURONS%29%60%20%28512%20neurons%29%2C%20calling%20%60forward%28%29%60%20will%20always%20return%20%60Err%28InputLengthMismatch%20%7B%20expected%3A%20512%2C%20got%3A%2016%20%7D%29%60.%0A%0AThe%20new%20CSV-replay%20path%20avoids%20this%20by%20always%20calling%20%60forward_activity%28%29%60%20directly%2C%20but%20%60forward%28%29%60%20is%20a%20public%20API%20with%20no%20documentation%20warning.%20Any%20caller%20that%20creates%20a%20wide%20model%20and%20falls%20back%20to%20%60forward%28%29%60%20%28e.g.%2C%20in%20training%20loops%20or%20benchmarks%29%20gets%20a%20silent%20runtime%20error.%0A%0AOne%20fix%20is%20to%20make%20%60forward%28%29%60%20delegate%20to%20%60synthetic_activity%60%20only%20when%20the%20model%20width%20matches%20%60N_NEURONS%60%2C%20and%20document%20the%20constraint%3A%0A%0A%60%60%60rust%0Apub%20fn%20forward%28%26mut%20self%2C%20snap%3A%20%26TelemetrySnapshot%29%20-%3E%20Result%3CHybridOutput%3E%20%7B%0A%20%20%20%20if%20self.projector.input_neurons%28%29%20!%3D%20N_NEURONS%20%7B%0A%20%20%20%20%20%20%20%20return%20Err%28HybridError%3A%3AInvalidConfig%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22forward%28%29%20requires%20a%2016-neuron%20projector%3B%20use%20forward_activity%28%29%20for%20wider%20models%22.into%28%29%2C%0A%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20let%20%28spike_train%2C%20potentials%2C%20iz_potentials%29%20%3D%20self.synthetic_activity%28snap%29%3B%0A%20%20%20%20self.forward_activity%28%26spike_train%2C%20%26potentials%2C%20%26iz_potentials%29%0A%7D%0A%60%60%60%0A%0AOr%20alternatively%2C%20%60synthetic_activity%60%20could%20be%20parameterized%20on%20the%20configured%20projector%20width%20so%20it%20stays%20consistent%20with%20the%20model.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fhybrid%2Fprojector.rs%3A117-122%0A**F32%20precision%20loss%20degrades%20Xavier%20init%20for%20512-neuron%20projector**%0A%0AThe%20deterministic%20quasi-random%20value%20%60%28i%20as%20f32%20*%201.6180339887%29%20%25%201.0%60%20loses%20its%20fractional%20part%20once%20%60i%20*%20%CF%86%20%3E%202%5E23%20%E2%89%88%208%2C388%2C608%60.%20At%20that%20point%20%60f32%60%20can%20no%20longer%20represent%20non-integer%20values%2C%20so%20%60%25%201.0%60%20consistently%20returns%20%600.0%60%2C%20making%20%60t%20%3D%20-1.0%60%20and%20%60weight%20%3D%20-limit%60%20for%20every%20subsequent%20index.%0A%0AFor%20the%20default%2016-neuron%20projector%2C%20%60EMBEDDING_DIM%20%C3%97%20feature_dim%2816%29%20%3D%202048%20%C3%97%20101%20%3D%20206%2C848%60%20%E2%80%94%20well%20below%20the%20threshold%2C%20so%20no%20problem.%20For%20the%20new%20512-neuron%20path%2C%20%60EMBEDDING_DIM%20%C3%97%20feature_dim%28512%29%20%3D%202048%20%C3%97%203077%20%3D%206%2C301%2C696%60.%20The%20threshold%20is%20crossed%20at%20index%20%E2%89%88%205%2C184%2C180%2C%20meaning%20roughly%20**18%20%25%20of%20the%20weight%20matrix**%20%28%E2%89%88%201.1%20M%20weights%29%20is%20initialized%20to%20exactly%20%60%E2%88%92limit%60%20rather%20than%20uniform%20%60%5B%E2%88%92limit%2C%20%2Blimit%5D%60.%0A%0ASince%20these%20weights%20are%20described%20as%20being%20replaced%20by%20Julia%2FE-prop%20updates%2C%20this%20only%20affects%20cold-start%20behavior%2C%20but%20it%20is%20an%20invisible%20asymmetry.%20Switching%20to%20an%20integer-domain%20PRNG%20%28e.g.%2C%20an%20LCG%20in%20%60u64%60%29%20avoids%20the%20precision%20issue%20entirely%3A%0A%0A%60%60%60rust%0Alet%20mut%20state%20%3D%202_654_435_761_u64%3B%20%2F%2F%20Knuth%20multiplicative%20hash%20seed%0Alet%20mut%20weights%20%3D%20Vec%3A%3Awith_capacity%28EMBEDDING_DIM%20*%20feature_dim%29%3B%0Afor%20_%20in%200..%28EMBEDDING_DIM%20*%20feature_dim%29%20%7B%0A%20%20%20%20state%20%3D%20state.wrapping_mul%286_364_136_223_846_793_005%29.wrapping_add%281_442_695_040_888_963_407%29%3B%0A%20%20%20%20let%20t%20%3D%20%28%28state%20%3E%3E%2033%29%20as%20f32%20%2F%20u32%3A%3AMAX%20as%20f32%29%20*%202.0%20-%201.0%3B%20%2F%2F%20uniform%20%5B%E2%88%921%2C%201%5D%0A%20%20%20%20weights.push%28t%20*%20limit%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Ffunnel.rs%3A46-55%0A**Alternating%20push%20order%20has%20no%20functional%20effect**%0A%0AThe%20even%2Fodd%20step%20alternation%20swaps%20%60bank%5B0%5D%60%20and%20%60bank%5B1%5D%60%20in%20the%20output%20%60Vec%60%2C%20but%20%60SparseGifHiddenLayer%3A%3Arun%60%20immediately%20populates%20a%20boolean%20%60active%5BFUNNEL_INPUT_NEURONS%5D%60%20array%20by%20index%20%E2%80%94%20ordering%20within%20the%20step's%20%60Vec%60%20is%20irrelevant%20for%20set%20membership.%20Both%20neurons%20are%20active%20on%20every%20step%20regardless%20of%20order.%0A%0AIf%20the%20intent%20is%20to%20explore%20first-spike%20or%20rate-based%20temporal%20coding%20in%20the%20future%2C%20a%20comment%20explaining%20this%20would%20clarify%20the%20design.%20Otherwise%2C%20simplifying%20to%20a%20single%20insertion%20order%20removes%20silent%20complexity%3A%0A%0A%60%60%60rust%0Afor%20step%20in%200..snn_steps%20%7B%0A%20%20%20%20spike_train%5Bstep%5D.push%28bank%5B0%5D%29%3B%0A%20%20%20%20spike_train%5Bstep%5D.push%28bank%5B1%5D%29%3B%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: implement telemetry funnel archite..."](https://github.com/spikenaut/corinth-canal/commit/3fadac9094bff865f6f456650855ad7091040eb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28307863)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->