### PR TITLE
Add latent telemetry calibration for symbolic regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,67 @@ cargo run --example csv_replay /path/to/canonical.csv
 - `global_step`
 - `olmoe_loaded`
 
+## Latent Telemetry Calibration
+
+The crate provides a separate calibration-only path for harvesting latent SNN metrics from canonical hardware telemetry. This maintains strict separation of concerns: the standard hardware telemetry file remains a pure, lightweight record of the physical machine, while latent metrics are generated on-demand during calibration passes for symbolic regression.
+
+### Latent Snapshot
+
+`SnnLatentSnapshot` captures internal SNN state and teacher targets:
+
+| Field | Description |
+|-------|-------------|
+| `timestamp_ms` | Wall-clock timestamp from hardware telemetry |
+| `avg_pop_firing_rate_hz` | Population-average firing rate of hidden neurons |
+| `membrane_dv_dt` | Row-to-row change in mean membrane potential |
+| `routing_entropy` | Normalized entropy of OLMoE expert weights |
+| `saaq_delta_q_prev` | Previous-step quantization delta (teacher history) |
+| `saaq_delta_q_target` | Target quantization delta (teacher signal) |
+
+### Latent Calibrator
+
+`SnnLatentCalibrator` derives latent features from runtime state:
+
+- **`avg_pop_firing_rate_hz`**: Computed from hidden-layer spike count over elapsed wall-clock time
+- **`membrane_dv_dt`**: Computed from row-to-row mean hidden membrane change
+- **`routing_entropy`**: Derived from normalized entropy of `HybridOutput.expert_weights`
+- **`saaq_delta_q_prev` / `saaq_delta_q_target`**: Deterministic first-pass calibration policy for bootstrapping symbolic regression
+
+### Latent CSV Exporter
+
+`SnnLatentCsvExporter` writes latent snapshots to CSV with the header:
+
+```text
+timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target
+```
+
+This format is compatible with Julia symbolic regression workflows (e.g., `SymbolicRegression.jl`).
+
+### Calibration Runner
+
+The `saaq_latent_calibration` example replays canonical hardware CSV through the funnel/model, computes latent metrics, and writes `snn_latent_telemetry.csv`:
+
+```bash
+cargo run --example saaq_latent_calibration /path/to/canonical.csv [output.csv]
+```
+
+Default output path: `snn_latent_telemetry.csv`
+
+The runner validates the canonical hardware CSV header strictly and prints:
+- `rows_processed`
+- `rows_skipped`
+- `global_step`
+- `olmoe_loaded`
+- Sample latent metrics for first 5 rows and every 100th row
+
+### Separation of Concerns
+
+The latent telemetry path:
+- Does not modify `TelemetrySnapshot` or the canonical hardware telemetry schema
+- Does not affect normal inference or replay performance
+- Runs only during calibration passes when generating symbolic regression datasets
+- Keeps the standard `telemetry.csv` contract lightweight and pure
+
 ## Project layout
 
 | Path | Responsibility |
@@ -223,8 +284,10 @@ cargo run --example csv_replay /path/to/canonical.csv
 | `src/hybrid/olmoe.rs` | GGUF-aware OLMoE simulation |
 | `src/funnel.rs` | TelemetryFunnel: encoder + split-bank bridge + sparse GIF hidden layer |
 | `src/hybrid/hybrid.rs` | deterministic front-end + projector + OLMoE orchestration |
+| `src/latent.rs` | `SnnLatentSnapshot`, `SnnLatentCalibrator`, `SnnLatentCsvExporter` for symbolic regression |
 | `examples/telemetry_bridge.rs` | end-to-end standalone example |
 | `examples/csv_replay.rs` | canonical CSV replay adapter (funnel-driven) |
+| `examples/saaq_latent_calibration.rs` | calibration-only latent telemetry exporter |
 
 ## Acknowledgments
 

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -1,0 +1,162 @@
+use corinth_canal::{
+    FUNNEL_HIDDEN_NEURONS, HybridConfig, HybridError, HybridModel, OlmoeExecutionMode,
+    ProjectionMode, SnnLatentCalibrator, SnnLatentCsvExporter, TelemetryFunnel,
+    TelemetrySnapshot,
+};
+
+const EXPECTED_HEADER: &str =
+    "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
+const TELEMETRY_THRESHOLDS: [f32; 4] = [1.0, 5.0, 1.0, 5.0];
+
+fn parse_u64(v: &str) -> Option<u64> {
+    v.parse::<u64>().ok()
+}
+
+fn parse_f32(v: &str) -> Option<f32> {
+    let n = v.parse::<f32>().ok()?;
+    if n.is_finite() {
+        Some(n)
+    } else {
+        None
+    }
+}
+
+fn main() -> corinth_canal::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 || args.len() > 3 {
+        eprintln!(
+            "Usage: cargo run --example saaq_latent_calibration <telemetry.csv> [snn_latent_telemetry.csv]"
+        );
+        eprintln!("  CSV format: {}", EXPECTED_HEADER);
+        std::process::exit(1);
+    }
+
+    let csv_path = &args[1];
+    let output_path = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "snn_latent_telemetry.csv".to_owned());
+    let model_path = std::env::var("OLMOE_PATH").unwrap_or_default();
+
+    let cfg = HybridConfig {
+        olmoe_model_path: model_path,
+        snn_steps: 20,
+        num_experts: 8,
+        top_k_experts: 1,
+        olmoe_execution_mode: OlmoeExecutionMode::SpikingSim,
+        projection_mode: ProjectionMode::SpikingTernary,
+    };
+
+    let mut model = HybridModel::new_with_projector_neurons(cfg.clone(), FUNNEL_HIDDEN_NEURONS)?;
+    let mut funnel = TelemetryFunnel::new(TELEMETRY_THRESHOLDS, cfg.snn_steps);
+    let mut calibrator = SnnLatentCalibrator::new();
+    let mut exporter = SnnLatentCsvExporter::create(&output_path)?;
+
+    println!(
+        "olmoe_loaded={} olmoe_mode={:?} funnel_hidden_neurons={} latent_output={}",
+        model.olmoe_loaded(),
+        model.config().olmoe_execution_mode,
+        FUNNEL_HIDDEN_NEURONS,
+        output_path,
+    );
+
+    let csv_content = std::fs::read_to_string(csv_path)?;
+    let mut lines = csv_content.lines();
+
+    let header = lines
+        .next()
+        .ok_or_else(|| HybridError::InvalidConfig("empty CSV file".to_owned()))?
+        .trim();
+
+    if header != EXPECTED_HEADER {
+        return Err(HybridError::InvalidConfig(format!(
+            "invalid CSV header: expected '{EXPECTED_HEADER}', got '{header}'"
+        )));
+    }
+
+    let mut rows_processed = 0_usize;
+    let mut rows_skipped = 0_usize;
+
+    for (idx, raw_line) in lines.enumerate() {
+        let line_number = idx + 2;
+        let line = raw_line.trim();
+
+        if line.is_empty() {
+            rows_skipped += 1;
+            continue;
+        }
+
+        let fields: Vec<&str> = line.split(',').collect();
+        if fields.len() != 5 {
+            rows_skipped += 1;
+            eprintln!(
+                "Skipping malformed row {}: expected 5 columns, got {}",
+                line_number,
+                fields.len()
+            );
+            continue;
+        }
+
+        let parsed = (
+            parse_u64(fields[0]),
+            parse_f32(fields[1]),
+            parse_f32(fields[2]),
+            parse_f32(fields[3]),
+            parse_f32(fields[4]),
+        );
+
+        let (
+            Some(timestamp_ms),
+            Some(gpu_temp_c),
+            Some(gpu_power_w),
+            Some(cpu_tctl_c),
+            Some(cpu_package_power_w),
+        ) = parsed
+        else {
+            rows_skipped += 1;
+            eprintln!("Skipping malformed row {}: parse/finite check failed", line_number);
+            continue;
+        };
+
+        let snap = TelemetrySnapshot {
+            timestamp_ms,
+            gpu_temp_c,
+            gpu_power_w,
+            cpu_tctl_c,
+            cpu_package_power_w,
+        };
+
+        let activity = funnel.encode_snapshot(&snap);
+        let output = model.forward_activity(
+            &activity.spike_train,
+            &activity.potentials,
+            &activity.iz_potentials,
+        )?;
+        let latent = calibrator.observe(&snap, &activity, &output)?;
+        exporter.write_row(&latent)?;
+        rows_processed += 1;
+
+        if rows_processed % 100 == 0 || rows_processed <= 5 {
+            println!(
+                "step={:>4} avg_pop_firing_rate_hz={:.6} membrane_dv_dt={:.6} routing_entropy={:.6} saaq_delta_q_prev={:.6} saaq_delta_q_target={:.6}",
+                rows_processed,
+                latent.avg_pop_firing_rate_hz,
+                latent.membrane_dv_dt,
+                latent.routing_entropy,
+                latent.saaq_delta_q_prev,
+                latent.saaq_delta_q_target,
+            );
+        }
+    }
+
+    exporter.flush()?;
+
+    println!("\n=== Latent Calibration Summary ===");
+    println!("rows_processed={}", rows_processed);
+    println!("rows_skipped={}", rows_skipped);
+    println!("global_step={}", model.global_step());
+    println!("olmoe_loaded={}", model.olmoe_loaded());
+    println!("latent_csv={}", output_path);
+
+    Ok(())
+}

--- a/src/latent.rs
+++ b/src/latent.rs
@@ -1,0 +1,242 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{HybridError, Result};
+use crate::funnel::{FunnelActivity, FUNNEL_HIDDEN_NEURONS};
+use crate::types::{HybridOutput, TelemetrySnapshot};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SnnLatentSnapshot {
+    pub timestamp_ms: u64,
+    pub avg_pop_firing_rate_hz: f32,
+    pub membrane_dv_dt: f32,
+    pub routing_entropy: f32,
+    pub saaq_delta_q_prev: f32,
+    pub saaq_delta_q_target: f32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SnnLatentCalibrator {
+    prev_timestamp_ms: Option<u64>,
+    prev_mean_membrane: Option<f32>,
+    prev_delta_q: f32,
+}
+
+impl SnnLatentCalibrator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn observe(
+        &mut self,
+        snap: &TelemetrySnapshot,
+        activity: &FunnelActivity,
+        output: &HybridOutput,
+    ) -> Result<SnnLatentSnapshot> {
+        let dt_ms = self.window_dt_ms(snap.timestamp_ms);
+        let dt_seconds = (dt_ms as f32 / 1000.0).max(1e-3);
+        let total_hidden_spikes = activity.spike_train.iter().map(Vec::len).sum::<usize>() as f32;
+        let avg_pop_firing_rate_hz =
+            total_hidden_spikes / FUNNEL_HIDDEN_NEURONS as f32 / dt_seconds;
+
+        let mean_membrane = mean(&activity.potentials);
+        let previous_mean_membrane = self.prev_mean_membrane.unwrap_or(mean_membrane);
+        let membrane_dv_dt = (mean_membrane - previous_mean_membrane) / dt_seconds;
+
+        let expert_weights = output
+            .expert_weights
+            .as_deref()
+            .ok_or_else(|| HybridError::OlmoeForward("missing expert_weights in HybridOutput".into()))?;
+        let routing_entropy = normalized_entropy(expert_weights);
+
+        let saaq_delta_q_prev = self.prev_delta_q;
+        let activity_pressure = (avg_pop_firing_rate_hz / 24.0).clamp(0.0, 1.0);
+        let membrane_pressure = (membrane_dv_dt / 12.0).clamp(-1.0, 1.0);
+        let saaq_delta_q_target = 0.52 * saaq_delta_q_prev
+            + 0.28 * activity_pressure
+            + 0.12 * membrane_pressure
+            + 0.20 * routing_entropy
+            - 0.18;
+
+        self.prev_timestamp_ms = Some(snap.timestamp_ms);
+        self.prev_mean_membrane = Some(mean_membrane);
+        self.prev_delta_q = saaq_delta_q_target;
+
+        Ok(SnnLatentSnapshot {
+            timestamp_ms: snap.timestamp_ms,
+            avg_pop_firing_rate_hz,
+            membrane_dv_dt,
+            routing_entropy,
+            saaq_delta_q_prev,
+            saaq_delta_q_target,
+        })
+    }
+
+    fn window_dt_ms(&self, timestamp_ms: u64) -> u64 {
+        match self.prev_timestamp_ms {
+            Some(prev_timestamp_ms) if timestamp_ms > prev_timestamp_ms => {
+                timestamp_ms - prev_timestamp_ms
+            }
+            _ => 1,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SnnLatentCsvExporter {
+    writer: BufWriter<File>,
+}
+
+impl SnnLatentCsvExporter {
+    pub fn create<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let mut writer = BufWriter::new(File::create(path)?);
+        writeln!(
+            writer,
+            "timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target"
+        )?;
+        Ok(Self { writer })
+    }
+
+    pub fn write_row(&mut self, snapshot: &SnnLatentSnapshot) -> Result<()> {
+        writeln!(
+            self.writer,
+            "{},{:.6},{:.6},{:.6},{:.6},{:.6}",
+            snapshot.timestamp_ms,
+            snapshot.avg_pop_firing_rate_hz,
+            snapshot.membrane_dv_dt,
+            snapshot.routing_entropy,
+            snapshot.saaq_delta_q_prev,
+            snapshot.saaq_delta_q_target,
+        )?;
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+fn mean(values: &[f32]) -> f32 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f32>() / values.len() as f32
+    }
+}
+
+fn normalized_entropy(weights: &[f32]) -> f32 {
+    if weights.len() <= 1 {
+        return 0.0;
+    }
+
+    let entropy = weights
+        .iter()
+        .copied()
+        .filter(|weight| weight.is_finite() && *weight > 0.0)
+        .map(|weight| -weight * weight.ln())
+        .sum::<f32>();
+    let max_entropy = (weights.len() as f32).ln();
+
+    if max_entropy > 0.0 {
+        (entropy / max_entropy).clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_activity(hidden_spike_count: usize, mean_potential: f32) -> FunnelActivity {
+        FunnelActivity {
+            ternary_events: [1, 0, -1, 1],
+            input_spike_train: vec![vec![0, 1]; 4],
+            spike_train: vec![vec![0; hidden_spike_count]; 4],
+            potentials: vec![mean_potential; FUNNEL_HIDDEN_NEURONS],
+            iz_potentials: vec![0.0; 5],
+        }
+    }
+
+    fn sample_output(expert_weights: Vec<f32>) -> HybridOutput {
+        HybridOutput {
+            spike_train: vec![vec![0, 1]; 4],
+            firing_rates: vec![0.5; FUNNEL_HIDDEN_NEURONS],
+            membrane_potentials: vec![0.25; FUNNEL_HIDDEN_NEURONS],
+            embedding: vec![0.0; 2048],
+            expert_weights: Some(expert_weights),
+            selected_experts: Some(vec![0]),
+            reasoning: None,
+        }
+    }
+
+    #[test]
+    fn calibrator_emits_expected_latent_fields() {
+        let mut calibrator = SnnLatentCalibrator::new();
+        let snap_a = TelemetrySnapshot {
+            timestamp_ms: 1_000,
+            gpu_temp_c: 60.0,
+            gpu_power_w: 250.0,
+            cpu_tctl_c: 70.0,
+            cpu_package_power_w: 120.0,
+        };
+        let snap_b = TelemetrySnapshot {
+            timestamp_ms: 1_100,
+            ..snap_a.clone()
+        };
+        let output = sample_output(vec![0.7, 0.2, 0.1]);
+
+        let first = calibrator
+            .observe(&snap_a, &sample_activity(0, 0.20), &output)
+            .unwrap();
+        let second = calibrator
+            .observe(&snap_b, &sample_activity(8, 0.35), &output)
+            .unwrap();
+
+        assert_eq!(first.timestamp_ms, 1_000);
+        assert_eq!(first.saaq_delta_q_prev, 0.0);
+        assert!(first.routing_entropy > 0.0);
+        assert!(second.avg_pop_firing_rate_hz > 0.0);
+        assert!(second.membrane_dv_dt > 0.0);
+        assert!((second.saaq_delta_q_prev - first.saaq_delta_q_target).abs() < 1e-6);
+    }
+
+    #[test]
+    fn exporter_writes_expected_header_and_row_count() {
+        let path = std::env::temp_dir().join(format!(
+            "corinth_canal_latent_{}.csv",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        let mut exporter = SnnLatentCsvExporter::create(&path).unwrap();
+        exporter
+            .write_row(&SnnLatentSnapshot {
+                timestamp_ms: 42,
+                avg_pop_firing_rate_hz: 1.0,
+                membrane_dv_dt: -0.5,
+                routing_entropy: 0.7,
+                saaq_delta_q_prev: 0.1,
+                saaq_delta_q_target: 0.2,
+            })
+            .unwrap();
+        exporter.flush().unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let mut lines = contents.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target"
+        );
+        assert!(lines.next().is_some());
+        assert!(lines.next().is_none());
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod error;
 pub mod funnel;
 pub mod hybrid;
+pub mod latent;
 pub mod telemetry;
 pub mod tensor;
 pub mod transformer;
@@ -44,6 +45,7 @@ pub use funnel::{
     FUNNEL_HIDDEN_NEURONS, FUNNEL_INPUT_NEURONS,
 };
 pub use hybrid::{HybridModel, OLMoE, Projector};
+pub use latent::{SnnLatentCalibrator, SnnLatentCsvExporter, SnnLatentSnapshot};
 pub use telemetry::TelemetryEncoder;
 pub use types::{
     EMBEDDING_DIM, HybridConfig, HybridOutput, OlmoeExecutionMode, ProjectionMode,


### PR DESCRIPTION
This PR adds a separate calibration-only path for harvesting latent SNN metrics from canonical hardware telemetry. The new path maintains strict separation of concerns:
 
**Changes:**
- Added `src/latent.rs` with `SnnLatentSnapshot`, `SnnLatentCalibrator`, and `SnnLatentCsvExporter`
- Added `examples/saaq_latent_calibration.rs` for calibration-only CSV generation
- Updated `src/lib.rs` to export latent types
- Updated README.md with documentation
 
**Key Features:**
- Does not modify `TelemetrySnapshot` or canonical telemetry.csv schema
- Derives `avg_pop_firing_rate_hz`, `membrane_dv_dt`, `routing_entropy` from runtime state
- Implements deterministic first-pass policy for `saaq_delta_q_prev/target` teacher signals
- Generates `snn_latent_telemetry.csv` compatible with SymbolicRegression.jl
 
**Usage:**
```bash
cargo run --example saaq_latent_calibration /path/to/canonical.csv [output.csv]
```