### PR TITLE
feat: add first-block GGUF bridge for OLMoE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,8 @@ dependencies = [
  "anyhow",
  "cc",
  "cust",
+ "libc",
+ "memmap2",
  "neuromod",
  "serde",
  "thiserror",
@@ -174,6 +176,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ cust    = "0.3.2"
 anyhow  = { version = "1", features = ["backtrace"] }
 tracing = "0.1"
 neuromod = { path = "/home/raulmc/neuromod" }
+memmap2 = "0.9"
+libc = "0.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/examples/csv_replay.rs
+++ b/examples/csv_replay.rs
@@ -7,8 +7,7 @@ use corinth_canal::{
     OlmoeExecutionMode, ProjectionMode, TelemetryFunnel, TelemetrySnapshot,
 };
 
-const EXPECTED_HEADER: &str =
-    "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
+const EXPECTED_HEADER: &str = "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
 const TELEMETRY_THRESHOLDS: [f32; 4] = [1.0, 5.0, 1.0, 5.0];
 
 fn parse_u64(v: &str) -> Option<u64> {
@@ -17,11 +16,7 @@ fn parse_u64(v: &str) -> Option<u64> {
 
 fn parse_f32(v: &str) -> Option<f32> {
     let n = v.parse::<f32>().ok()?;
-    if n.is_finite() {
-        Some(n)
-    } else {
-        None
-    }
+    if n.is_finite() { Some(n) } else { None }
 }
 
 fn main() -> corinth_canal::Result<()> {
@@ -37,6 +32,7 @@ fn main() -> corinth_canal::Result<()> {
 
     let cfg = HybridConfig {
         olmoe_model_path: model_path,
+        gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
         snn_steps: 20,
         num_experts: 8,
         top_k_experts: 1,
@@ -101,11 +97,19 @@ fn main() -> corinth_canal::Result<()> {
             parse_f32(fields[4]),
         );
 
-        let (Some(timestamp_ms), Some(gpu_temp_c), Some(gpu_power_w), Some(cpu_tctl_c), Some(cpu_package_power_w)) =
-            parsed
+        let (
+            Some(timestamp_ms),
+            Some(gpu_temp_c),
+            Some(gpu_power_w),
+            Some(cpu_tctl_c),
+            Some(cpu_package_power_w),
+        ) = parsed
         else {
             rows_skipped += 1;
-            eprintln!("Skipping malformed row {}: parse/finite check failed", line_number);
+            eprintln!(
+                "Skipping malformed row {}: parse/finite check failed",
+                line_number
+            );
             continue;
         };
 
@@ -145,7 +149,7 @@ fn main() -> corinth_canal::Result<()> {
         total_input_spikes += input_spikes;
         total_hidden_spikes += hidden_spikes;
 
-        if rows_processed % 100 == 0 || rows_processed <= 5 {
+        if rows_processed.is_multiple_of(100) || rows_processed <= 5 {
             println!(
                 "step={:>4} gpu_temp={:5.1}C gpu_power={:6.1}W cpu_temp={:5.1}C ternary={:?} input_spikes={:>3} hidden_spikes={:>4} loss={:.6}",
                 rows_processed,

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -1,11 +1,9 @@
 use corinth_canal::{
     FUNNEL_HIDDEN_NEURONS, HybridConfig, HybridError, HybridModel, OlmoeExecutionMode,
-    ProjectionMode, SnnLatentCalibrator, SnnLatentCsvExporter, TelemetryFunnel,
-    TelemetrySnapshot,
+    ProjectionMode, SnnLatentCalibrator, SnnLatentCsvExporter, TelemetryFunnel, TelemetrySnapshot,
 };
 
-const EXPECTED_HEADER: &str =
-    "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
+const EXPECTED_HEADER: &str = "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
 const TELEMETRY_THRESHOLDS: [f32; 4] = [1.0, 5.0, 1.0, 5.0];
 
 fn parse_u64(v: &str) -> Option<u64> {
@@ -14,11 +12,7 @@ fn parse_u64(v: &str) -> Option<u64> {
 
 fn parse_f32(v: &str) -> Option<f32> {
     let n = v.parse::<f32>().ok()?;
-    if n.is_finite() {
-        Some(n)
-    } else {
-        None
-    }
+    if n.is_finite() { Some(n) } else { None }
 }
 
 fn main() -> corinth_canal::Result<()> {
@@ -40,6 +34,7 @@ fn main() -> corinth_canal::Result<()> {
 
     let cfg = HybridConfig {
         olmoe_model_path: model_path,
+        gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
         snn_steps: 20,
         num_experts: 8,
         top_k_experts: 1,
@@ -114,7 +109,10 @@ fn main() -> corinth_canal::Result<()> {
         ) = parsed
         else {
             rows_skipped += 1;
-            eprintln!("Skipping malformed row {}: parse/finite check failed", line_number);
+            eprintln!(
+                "Skipping malformed row {}: parse/finite check failed",
+                line_number
+            );
             continue;
         };
 
@@ -136,7 +134,7 @@ fn main() -> corinth_canal::Result<()> {
         exporter.write_row(&latent)?;
         rows_processed += 1;
 
-        if rows_processed % 100 == 0 || rows_processed <= 5 {
+        if rows_processed.is_multiple_of(100) || rows_processed <= 5 {
             println!(
                 "step={:>4} avg_pop_firing_rate_hz={:.6} membrane_dv_dt={:.6} routing_entropy={:.6} saaq_delta_q_prev={:.6} saaq_delta_q_target={:.6}",
                 rows_processed,

--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -1,8 +1,7 @@
 //! Standalone demo for the deterministic dummy front-end.
 
 use corinth_canal::{
-    EMBEDDING_DIM, HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode,
-    TelemetrySnapshot,
+    EMBEDDING_DIM, HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode, TelemetrySnapshot,
 };
 
 fn main() -> corinth_canal::Result<()> {
@@ -19,6 +18,7 @@ fn main() -> corinth_canal::Result<()> {
 
     let cfg = HybridConfig {
         olmoe_model_path: model_path,
+        gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
         snn_steps: 20,
         num_experts: 8,
         top_k_experts: 1,
@@ -61,7 +61,11 @@ fn main() -> corinth_canal::Result<()> {
                 "step={:>2} spikes={} top_expert={:?} loss={:.6}",
                 step + 1,
                 output.spike_train.iter().map(|s| s.len()).sum::<usize>(),
-                output.selected_experts.as_ref().and_then(|v| v.first()).copied(),
+                output
+                    .selected_experts
+                    .as_ref()
+                    .and_then(|v| v.first())
+                    .copied(),
                 loss
             );
         }

--- a/src/funnel.rs
+++ b/src/funnel.rs
@@ -44,13 +44,13 @@ impl SignedSplitBankBridge {
             let Some(bank) = self.active_bank(channel, spike) else {
                 continue;
             };
-            for step in 0..snn_steps {
-                if step % 2 == 0 {
-                    spike_train[step].push(bank[0]);
-                    spike_train[step].push(bank[1]);
+            for (step_idx, step_spikes) in spike_train.iter_mut().enumerate().take(snn_steps) {
+                if step_idx % 2 == 0 {
+                    step_spikes.push(bank[0]);
+                    step_spikes.push(bank[1]);
                 } else {
-                    spike_train[step].push(bank[1]);
-                    spike_train[step].push(bank[0]);
+                    step_spikes.push(bank[1]);
+                    step_spikes.push(bank[0]);
                 }
             }
         }

--- a/src/gpu/kernels/common.cuh
+++ b/src/gpu/kernels/common.cuh
@@ -6,6 +6,7 @@
 
 #pragma once
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 #include <math.h>
 #include <limits.h>
 

--- a/src/gpu/kernels/spiking_network.cu
+++ b/src/gpu/kernels/spiking_network.cu
@@ -315,6 +315,61 @@ void gif_step_weighted(
     spikes_out[tid] = spike;
 }
 
+extern "C" __global__
+void gif_step_weighted_f16(
+    float* __restrict__        membrane,
+    float* __restrict__        adaptation,
+    const unsigned short* __restrict__ weights,
+    const float* __restrict__  input_spikes,
+    unsigned int* __restrict__ refract,
+    unsigned int* __restrict__ spikes_out,
+    int n_neurons,
+    int n_inputs)
+{
+    extern __shared__ float s_inputs[];
+
+    for (int i = threadIdx.x; i < n_inputs; i += blockDim.x)
+        s_inputs[i] = input_spikes[i];
+    __syncthreads();
+
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= n_neurons) return;
+
+    unsigned int ref = refract[tid];
+    float v = membrane[tid];
+    float a = adaptation[tid];
+    unsigned int spike = 0u;
+
+    if (ref > 0u) {
+        v = LIF_RESET;
+        refract[tid] = ref - 1u;
+        adaptation[tid] = a * GIF_ADAPTATION_DECAY;
+    } else {
+        a *= GIF_ADAPTATION_DECAY;
+
+        const unsigned short* w_row = weights + (long)tid * n_inputs;
+        float drive = 0.0f;
+        for (int j = 0; j < n_inputs; ++j) {
+            float w = __half2float(*reinterpret_cast<const __half*>(&w_row[j]));
+            drive = fmaf(w, s_inputs[j], drive);
+        }
+
+        v = v * GIF_LEAK + drive * GIF_DRIVE_SCALE - a * GIF_ADAPTATION_TERM;
+
+        float threshold = GIF_THRESHOLD_BASE + a * GIF_ADAPTATION_SCALE;
+        if (v >= threshold) {
+            spike = 1u;
+            v -= threshold * GIF_RESET_RATIO;
+            a += 1.0f;
+            refract[tid] = (unsigned int)LIF_REFRACT_TICK;
+        }
+        adaptation[tid] = a;
+    }
+
+    membrane[tid]   = v;
+    spikes_out[tid] = spike;
+}
+
 // ════════════════════════════════════════════════════════════════════
 //  spike_rate
 //

--- a/src/gpu/wrappers/accelerator.rs
+++ b/src/gpu/wrappers/accelerator.rs
@@ -21,9 +21,16 @@ use tracing::warn;
 const SATSOLVER_BLOCK_SIZE: u32 = 256;
 const SATSOLVER_SHARED_MEM_BYTES: u32 = 0;
 const TEMPORAL_BLOCK_SIZE: u32 = 256;
-const TEMPORAL_GRID_SIZE: u32 = 8;  // 8 * 256 = 2048 exact for Blackwell alignment (N_NEURONS)
+const TEMPORAL_GRID_SIZE: u32 = 8; // 8 * 256 = 2048 exact for Blackwell alignment (N_NEURONS)
 const TEMPORAL_SHARED_MEM_BYTES: u32 = 0;
 const SNAPSHOT_CHANNELS: usize = 4;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SynapsePrecision {
+    None,
+    F32,
+    F16,
+}
 
 struct TemporalState {
     neuron_count: usize,
@@ -34,9 +41,12 @@ struct TemporalState {
     input_current: GpuBuffer<f32>,
     input_spikes: GpuBuffer<f32>,
     adaptation: GpuBuffer<f32>,
-    weights: GpuBuffer<f32>,
+    weights_f32: GpuBuffer<f32>,
+    weights_f16: Option<GpuBuffer<u16>>,
+    synapse_precision: SynapsePrecision,
+    synapse_signature: Option<String>,
     snapshot: GpuBuffer<f32>,
-    best_walker: GpuBuffer<u32>,  // persistent 1-element for SAAQ on-device reduction
+    best_walker: GpuBuffer<u32>, // persistent 1-element for SAAQ on-device reduction
 }
 
 /// Facade that owns a CUDA context and the compiled PTX modules.
@@ -145,9 +155,9 @@ impl GpuAccelerator {
             })?;
         }
 
-        stream.synchronize().map_err(|e| {
-            GpuError::LaunchFailed(format!("project_snapshot_current sync: {e:?}"))
-        })
+        stream
+            .synchronize()
+            .map_err(|e| GpuError::LaunchFailed(format!("project_snapshot_current sync: {e:?}")))
     }
 
     pub fn lif_step_tick(&mut self, neuron_count: usize) -> GpuResult<()> {
@@ -218,6 +228,14 @@ impl GpuAccelerator {
     /// Load synapse weight matrix for GIF weighted kernel. Must match neuron_count * n_inputs.
     /// Call after ensure_temporal_state or it will be overwritten on realloc.
     pub fn load_synapse_weights(&mut self, weights: &[f32]) -> GpuResult<()> {
+        self.load_synapse_weights_named("host-f32", weights)
+    }
+
+    pub fn load_synapse_weights_named(
+        &mut self,
+        signature: &str,
+        weights: &[f32],
+    ) -> GpuResult<()> {
         if !self.is_ready() {
             return Err(GpuError::NoGpu);
         }
@@ -229,12 +247,72 @@ impl GpuAccelerator {
         if weights.len() != expected {
             return Err(GpuError::MemoryError(format!(
                 "weights length mismatch: expected {} ({}x{}), got {}",
-                expected, state.neuron_count, state.n_inputs, weights.len()
+                expected,
+                state.neuron_count,
+                state.n_inputs,
+                weights.len()
             )));
         }
-        state.weights.upload(weights).map_err(|e| {
-            GpuError::MemoryError(format!("synapse weights upload failed: {e}"))
+        if state.synapse_precision == SynapsePrecision::F32
+            && state.synapse_signature.as_deref() == Some(signature)
+        {
+            return Ok(());
+        }
+        state
+            .weights_f32
+            .upload(weights)
+            .map_err(|e| GpuError::MemoryError(format!("synapse weights upload failed: {e}")))?;
+        state.synapse_precision = SynapsePrecision::F32;
+        state.synapse_signature = Some(signature.to_owned());
+        Ok(())
+    }
+
+    /// Load an FP16 synapse matrix directly from a CUDA-registered host slice.
+    /// Reuses the resident device weights if the same source signature is already loaded.
+    pub fn load_synapse_weights_f16_registered(
+        &mut self,
+        signature: &str,
+        weights: &[u16],
+    ) -> GpuResult<()> {
+        if !self.is_ready() {
+            return Err(GpuError::NoGpu);
+        }
+        let state = self
+            .temporal_state
+            .as_mut()
+            .ok_or_else(|| GpuError::MemoryError("temporal state not initialised".into()))?;
+        let expected = state.neuron_count * state.n_inputs;
+        if weights.len() != expected {
+            return Err(GpuError::MemoryError(format!(
+                "f16 weights length mismatch: expected {} ({}x{}), got {}",
+                expected,
+                state.neuron_count,
+                state.n_inputs,
+                weights.len()
+            )));
+        }
+
+        if state.synapse_precision == SynapsePrecision::F16
+            && state.synapse_signature.as_deref() == Some(signature)
+        {
+            return Ok(());
+        }
+
+        let f16_weights = match state.weights_f16.as_mut() {
+            Some(weights_f16) => weights_f16,
+            None => {
+                state.weights_f16 = Some(GpuBuffer::<u16>::from_slice(&vec![0u16; expected])?);
+                state
+                    .weights_f16
+                    .as_mut()
+                    .expect("weights_f16 was just inserted")
+            }
+        };
+        f16_weights.upload(weights).map_err(|e| {
+            GpuError::MemoryError(format!("registered f16 synapse upload failed: {e}"))
         })?;
+        state.synapse_precision = SynapsePrecision::F16;
+        state.synapse_signature = Some(signature.to_owned());
         Ok(())
     }
 
@@ -246,29 +324,62 @@ impl GpuAccelerator {
         self.ensure_temporal_state(neuron_count)?;
 
         let modules = self.modules.as_ref().ok_or(GpuError::NoGpu)?;
-        let gif_step = modules.get_function("gif_step_weighted")?;
         let state = self
             .temporal_state
             .as_mut()
             .ok_or_else(|| GpuError::MemoryError("temporal state not initialised".into()))?;
+        let gif_step = match state.synapse_precision {
+            SynapsePrecision::F32 => modules.get_function("gif_step_weighted")?,
+            SynapsePrecision::F16 => modules.get_function("gif_step_weighted_f16")?,
+            SynapsePrecision::None => {
+                return Err(GpuError::MemoryError(
+                    "synapse weights must be loaded before gif_step_weighted_tick".into(),
+                ));
+            }
+        };
         let stream = Self::new_stream()?;
         // Hardcoded Blackwell alignment: 8 blocks * 256 threads = 2048 neurons exact.
         // This maxes L1/shared memory bandwidth without warp divergence on sm_120.
         let grid = TEMPORAL_GRID_SIZE;
-        let shared_bytes = (state.n_inputs * 4) as u32;  // f32 * n_inputs
+        let shared_bytes = (state.n_inputs * 4) as u32; // f32 * n_inputs
 
         unsafe {
-            launch!(gif_step<<<grid, TEMPORAL_BLOCK_SIZE, shared_bytes, stream>>>(
-                state.membrane.as_device_ptr(),
-                state.adaptation.as_device_ptr(),
-                state.weights.as_device_ptr(),
-                state.input_spikes.as_device_ptr(),
-                state.refractory.as_device_ptr(),
-                state.spikes_out.as_device_ptr(),
-                neuron_count as i32,
-                state.n_inputs as i32
-            ))
-            .map_err(|e| GpuError::LaunchFailed(format!("gif_step_weighted launch: {e:?}")))?;
+            match state.synapse_precision {
+                SynapsePrecision::F32 => {
+                    launch!(gif_step<<<grid, TEMPORAL_BLOCK_SIZE, shared_bytes, stream>>>(
+                        state.membrane.as_device_ptr(),
+                        state.adaptation.as_device_ptr(),
+                        state.weights_f32.as_device_ptr(),
+                        state.input_spikes.as_device_ptr(),
+                        state.refractory.as_device_ptr(),
+                        state.spikes_out.as_device_ptr(),
+                        neuron_count as i32,
+                        state.n_inputs as i32
+                    ))
+                    .map_err(|e| {
+                        GpuError::LaunchFailed(format!("gif_step_weighted launch: {e:?}"))
+                    })?;
+                }
+                SynapsePrecision::F16 => {
+                    let weights_f16 = state.weights_f16.as_ref().ok_or_else(|| {
+                        GpuError::MemoryError("f16 synapse buffer not initialised".into())
+                    })?;
+                    launch!(gif_step<<<grid, TEMPORAL_BLOCK_SIZE, shared_bytes, stream>>>(
+                        state.membrane.as_device_ptr(),
+                        state.adaptation.as_device_ptr(),
+                        weights_f16.as_device_ptr(),
+                        state.input_spikes.as_device_ptr(),
+                        state.refractory.as_device_ptr(),
+                        state.spikes_out.as_device_ptr(),
+                        neuron_count as i32,
+                        state.n_inputs as i32
+                    ))
+                    .map_err(|e| {
+                        GpuError::LaunchFailed(format!("gif_step_weighted_f16 launch: {e:?}"))
+                    })?;
+                }
+                SynapsePrecision::None => unreachable!("validated above"),
+            }
         }
 
         // Immediately launch SAAQ reduction on same stream (no intermediate sync).
@@ -316,7 +427,9 @@ impl GpuAccelerator {
         state
             .input_current
             .upload(&vec![0.0f32; state.neuron_count])
-            .map_err(|e| GpuError::MemoryError(format!("reset input_current upload failed: {e}")))?;
+            .map_err(|e| {
+                GpuError::MemoryError(format!("reset input_current upload failed: {e}"))
+            })?;
         state
             .input_spikes
             .upload(&vec![0.0f32; state.n_inputs])
@@ -325,24 +438,27 @@ impl GpuAccelerator {
             .adaptation
             .upload(&vec![0.0f32; state.neuron_count])
             .map_err(|e| GpuError::MemoryError(format!("reset adaptation upload failed: {e}")))?;
-        state
-            .weights
-            .upload(&vec![0.0f32; state.neuron_count * state.n_inputs])
-            .map_err(|e| GpuError::MemoryError(format!("reset weights upload failed: {e}")))?;
 
         // Reset SAAQ best walker
         state
             .best_walker
-            .upload(&vec![0u32; 1])
+            .upload(&[0u32; 1])
             .map_err(|e| GpuError::MemoryError(format!("reset best_walker upload failed: {e}")))?;
 
         Ok(())
+    }
+
+    pub fn synapse_signature(&self) -> Option<&str> {
+        self.temporal_state
+            .as_ref()
+            .and_then(|state| state.synapse_signature.as_deref())
     }
 
     /// Copy the best SAT walker assignment into `output`.
     ///
     /// This wrapper matches the updated CUDA signature and blocks until the
     /// extract kernel has completed.
+    #[allow(clippy::too_many_arguments)]
     pub fn satsolver_extract(
         &self,
         assignment: &GpuBuffer<u8>,
@@ -414,7 +530,7 @@ impl GpuAccelerator {
             .as_mut()
             .ok_or_else(|| GpuError::MemoryError("temporal state not initialised".into()))?;
 
-        let adaptation_scale = 0.22f32;  // matches GIF_ADAPTATION_SCALE from spiking_network.cu
+        let adaptation_scale = 0.22f32; // matches GIF_ADAPTATION_SCALE from spiking_network.cu
 
         unsafe {
             launch!(saaq_kernel<<<TEMPORAL_GRID_SIZE, TEMPORAL_BLOCK_SIZE, 0, stream>>>(
@@ -427,9 +543,9 @@ impl GpuAccelerator {
             .map_err(|e| GpuError::LaunchFailed(format!("saaq_find_best_walker launch: {e:?}")))?;
         }
 
-        stream.synchronize().map_err(|e| {
-            GpuError::LaunchFailed(format!("saaq_find_best_walker sync: {e:?}"))
-        })?;
+        stream
+            .synchronize()
+            .map_err(|e| GpuError::LaunchFailed(format!("saaq_find_best_walker sync: {e:?}")))?;
 
         let best = state.best_walker.to_vec()?;
         Ok(best[0])
@@ -440,6 +556,7 @@ impl GpuAccelerator {
     ///
     /// `best_score` and `best_walker` must each be length 1. Intermediate per-block
     /// partial buffers are allocated internally using `grid.x = ceil_div(n_walkers, 256)`.
+    #[allow(clippy::too_many_arguments)]
     pub fn satsolver_aux_reduce_best(
         &self,
         assignment: &GpuBuffer<u8>,
@@ -560,7 +677,7 @@ impl GpuAccelerator {
     }
 
     fn build_temporal_state(neuron_count: usize) -> GpuResult<TemporalState> {
-        let n_inputs = neuron_count;  // full connectivity for weighted GIF SNN (sparse can be added later)
+        let n_inputs = neuron_count; // full connectivity for weighted GIF SNN (sparse can be added later)
         let weight_size = neuron_count * n_inputs;
         Ok(TemporalState {
             neuron_count,
@@ -571,9 +688,12 @@ impl GpuAccelerator {
             input_current: GpuBuffer::<f32>::from_slice(&vec![0.0f32; neuron_count])?,
             input_spikes: GpuBuffer::<f32>::from_slice(&vec![0.0f32; n_inputs])?,
             adaptation: GpuBuffer::<f32>::from_slice(&vec![0.0f32; neuron_count])?,
-            weights: GpuBuffer::<f32>::from_slice(&vec![0.0f32; weight_size])?,
-            snapshot: GpuBuffer::<f32>::from_slice(&vec![0.0f32; SNAPSHOT_CHANNELS])?,
-            best_walker: GpuBuffer::<u32>::from_slice(&vec![0u32; 1])?,
+            weights_f32: GpuBuffer::<f32>::from_slice(&vec![0.0f32; weight_size])?,
+            weights_f16: None,
+            synapse_precision: SynapsePrecision::None,
+            synapse_signature: None,
+            snapshot: GpuBuffer::<f32>::from_slice(&[0.0f32; SNAPSHOT_CHANNELS])?,
+            best_walker: GpuBuffer::<u32>::from_slice(&[0u32; 1])?,
         })
     }
 

--- a/src/gpu/wrappers/context.rs
+++ b/src/gpu/wrappers/context.rs
@@ -3,7 +3,7 @@
 // ════════════════════════════════════════════════════════════════════
 
 use super::error::{GpuError, GpuResult};
-use cust::context::Context;
+use cust::context::legacy::{Context, ContextFlags};
 use cust::device::Device;
 
 /// Owns a CUDA primary context for device 0.
@@ -20,8 +20,9 @@ impl GpuContext {
         let device = Device::get_device(0)
             .map_err(|e| GpuError::InitFailed(format!("get_device(0): {e:?}")))?;
 
-        let ctx = Context::new(device)
-            .map_err(|e| GpuError::InitFailed(format!("Context::new: {e:?}")))?;
+        let ctx =
+            Context::create_and_push(ContextFlags::MAP_HOST | ContextFlags::SCHED_AUTO, device)
+                .map_err(|e| GpuError::InitFailed(format!("Context::create_and_push: {e:?}")))?;
 
         Ok(Self { _ctx: ctx })
     }

--- a/src/gpu/wrappers/kernel.rs
+++ b/src/gpu/wrappers/kernel.rs
@@ -66,6 +66,7 @@ impl KernelModule {
                 "lif_step",
                 "lif_step_weighted",
                 "gif_step_weighted",
+                "gif_step_weighted_f16",
                 "spike_rate",
                 "reset_membrane",
                 "stdp_update",

--- a/src/gpu/wrappers/memory.rs
+++ b/src/gpu/wrappers/memory.rs
@@ -52,6 +52,11 @@ impl<T: cust::memory::DeviceCopy + Default + Clone> GpuBuffer<T> {
         self.len
     }
 
+    /// `true` when the buffer contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Raw device pointer (for kernel launches via `cust`).
     pub fn as_device_ptr(&self) -> cust::memory::DevicePointer<T> {
         self.inner.as_device_ptr()

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -4,16 +4,15 @@ use super::olmoe::OLMoE;
 use super::projector::Projector;
 use crate::error::{HybridError, Result};
 use crate::gpu::{GpuAccelerator, GpuBuffer, GpuError, GpuResult};
-use crate::types::{
-    EMBEDDING_DIM, HybridConfig, HybridOutput, TelemetrySnapshot,
-};
+use crate::types::{EMBEDDING_DIM, HybridConfig, HybridOutput, TelemetrySnapshot};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
 const N_NEURONS: usize = 2048;
 const IZ_NEURONS: usize = 5;
-const GPU_ROUTING_TELEMETRY_HEADER: &str = "token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction";
+const GPU_ROUTING_TELEMETRY_HEADER: &str =
+    "token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction";
 const GPU_ROUTING_TELEMETRY_PATH: &str = "snn_gpu_routing_telemetry.csv";
 
 /// Standalone hybrid model that keeps the projector and OLMoE logic real while
@@ -41,7 +40,9 @@ impl HybridModel {
             return Err(HybridError::InvalidConfig("num_experts must be ≥ 1".into()));
         }
         if config.top_k_experts == 0 {
-            return Err(HybridError::InvalidConfig("top_k_experts must be ≥ 1".into()));
+            return Err(HybridError::InvalidConfig(
+                "top_k_experts must be ≥ 1".into(),
+            ));
         }
         if config.top_k_experts > config.num_experts {
             return Err(HybridError::InvalidConfig(format!(
@@ -68,7 +69,7 @@ impl HybridModel {
 
     pub fn forward(&mut self, snap: &TelemetrySnapshot) -> Result<HybridOutput> {
         let (spike_train, potentials, iz_potentials) = self.synthetic_activity(snap);
-        self.forward_activity(&spike_train, &potentials, &iz_potentials)
+        self.forward_activity(spike_train.as_slice(), potentials.as_slice(), iz_potentials.as_slice())
     }
 
     pub fn forward_activity(
@@ -81,7 +82,7 @@ impl HybridModel {
 
         let embedding = self
             .projector
-            .project(&spike_train, &potentials, &iz_potentials)?;
+            .project(spike_train, potentials, iz_potentials)?;
         let olmoe_out = self.olmoe.forward(&embedding)?;
 
         let steps_f = spike_train.len().max(1) as f32;
@@ -119,13 +120,9 @@ impl HybridModel {
     ) -> GpuResult<HybridOutput> {
         let neuron_count = self.projector.input_neurons();
 
-        // Reset GIF state (membrane, adaptation, refractory, etc.)
+        accelerator.ensure_temporal_state(neuron_count)?;
+        self.ensure_temporal_synapse_weights(accelerator, neuron_count)?;
         accelerator.reset_temporal_state()?;
-
-        // Load dummy weights for weighted GIF path (in production, load from ML crate / Julia)
-        // For 2048 neurons this is ~16MB; sparsity can be enforced in weights.
-        let dummy_weights = vec![0.05f32; neuron_count * neuron_count];
-        accelerator.load_synapse_weights(&dummy_weights)?;
 
         // Phase 1: Project snapshot to input_current (can also drive input_spikes)
         accelerator.project_snapshot_current(snap, neuron_count)?;
@@ -140,8 +137,8 @@ impl HybridModel {
         let mut best_walker = 0u32;
 
         for _ in 0..self.config.snn_steps {
-            let walker = accelerator.gif_step_weighted_tick(neuron_count)?;  // now returns best_walker from SAAQ
-            best_walker = walker;  // last one wins for telemetry (or collect if multi-walker SAAQ)
+            let walker = accelerator.gif_step_weighted_tick(neuron_count)?; // now returns best_walker from SAAQ
+            best_walker = walker; // last one wins for telemetry (or collect if multi-walker SAAQ)
 
             // Minimal spike download only (or optimize further to stay on-device for projector)
             let spikes = accelerator.temporal_spikes_to_vec(neuron_count)?;
@@ -177,7 +174,7 @@ impl HybridModel {
         let _ = append_gpu_routing_telemetry_row(
             Path::new(GPU_ROUTING_TELEMETRY_PATH),
             self.global_step as usize,
-            0,  // best_score placeholder (SAAQ now on-device)
+            0, // best_score placeholder (SAAQ now on-device)
             best_walker as i32,
             spike_count,
             mean_adaptation,
@@ -185,6 +182,38 @@ impl HybridModel {
         );
 
         Ok(output)
+    }
+
+    fn ensure_temporal_synapse_weights(
+        &mut self,
+        accelerator: &mut GpuAccelerator,
+        neuron_count: usize,
+    ) -> GpuResult<()> {
+        if self.olmoe.is_loaded() {
+            let signature = format!(
+                "{}::{}",
+                self.olmoe.model_path(),
+                self.config.gpu_synapse_tensor_name
+            );
+            let weights = self
+                .olmoe
+                .registered_gpu_synapse_weights(&self.config.gpu_synapse_tensor_name)
+                .map_err(|e| {
+                    GpuError::MemoryError(format!("GGUF synapse registration failed: {e}"))
+                })?;
+            accelerator.load_synapse_weights_f16_registered(&signature, weights)?;
+            return Ok(());
+        }
+
+        let fallback_signature = format!("synthetic-f32::{neuron_count}");
+        if accelerator.synapse_signature() == Some(fallback_signature.as_str()) {
+            return Ok(());
+        }
+
+        // Stub mode keeps a deterministic fallback path without re-uploading every forward.
+        let synthetic_weights = vec![0.0f32; neuron_count * neuron_count];
+        accelerator.load_synapse_weights_named(&fallback_signature, &synthetic_weights)?;
+        Ok(())
     }
 
     fn synthetic_activity(
@@ -227,6 +256,7 @@ impl HybridModel {
         Ok(loss)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn compute_routing_telemetry(
         &self,
         accelerator: &GpuAccelerator,
@@ -256,25 +286,23 @@ impl HybridModel {
             clause_len,
         )?;
 
-        let final_score = best_score
-            .to_vec()?
-            .first()
-            .copied()
-            .ok_or_else(|| GpuError::MemoryError("best_score buffer returned no values".into()))?;
-        let final_walker = best_walker
-            .to_vec()?
-            .first()
-            .copied()
-            .ok_or_else(|| GpuError::MemoryError("best_walker buffer returned no values".into()))?;
+        let final_score =
+            best_score.to_vec()?.first().copied().ok_or_else(|| {
+                GpuError::MemoryError("best_score buffer returned no values".into())
+            })?;
+        let final_walker =
+            best_walker.to_vec()?.first().copied().ok_or_else(|| {
+                GpuError::MemoryError("best_walker buffer returned no values".into())
+            })?;
 
         append_gpu_routing_telemetry_row(
             Path::new(GPU_ROUTING_TELEMETRY_PATH),
             token_idx,
             final_score,
             final_walker,
-            0,      // spike_count (extend SAT path later with GIF stats)
-            0.0,    // mean_adaptation
-            0.0,    // active_fraction
+            0,   // spike_count (extend SAT path later with GIF stats)
+            0.0, // mean_adaptation
+            0.0, // active_fraction
         )
     }
 
@@ -425,7 +453,6 @@ mod tests {
             cpu_tctl_c: 65.0,
             cpu_package_power_w: 120.0,
             timestamp_ms: 1_000,
-            ..Default::default()
         };
         let loss = model
             .train_step(&snap, &vec![0.1_f32; EMBEDDING_DIM])
@@ -453,11 +480,9 @@ mod tests {
 
     #[test]
     fn test_forward_activity_supports_custom_projector_width() {
-        let mut model = HybridModel::new_with_projector_neurons(
-            HybridConfig::default(),
-            FUNNEL_HIDDEN_NEURONS,
-        )
-        .unwrap();
+        let mut model =
+            HybridModel::new_with_projector_neurons(HybridConfig::default(), FUNNEL_HIDDEN_NEURONS)
+                .unwrap();
         let spike_train = vec![vec![0, 1, 2, 3]; 20];
         let potentials = vec![0.4; FUNNEL_HIDDEN_NEURONS];
         let iz_potentials = vec![0.0; IZ_NEURONS];
@@ -477,7 +502,9 @@ mod tests {
         let mut model = HybridModel::new(HybridConfig::default()).unwrap();
         let snap = TelemetrySnapshot::default();
 
-        let err = model.forward_gpu_temporal(&mut accelerator, &snap).unwrap_err();
+        let err = model
+            .forward_gpu_temporal(&mut accelerator, &snap)
+            .unwrap_err();
         assert!(matches!(err, GpuError::NoGpu));
     }
 

--- a/src/hybrid/mod.rs
+++ b/src/hybrid/mod.rs
@@ -1,5 +1,6 @@
 pub mod projector;
 pub mod olmoe;
+#[allow(clippy::module_inception)]
 pub mod hybrid;
 
 pub use hybrid::HybridModel;

--- a/src/hybrid/olmoe.rs
+++ b/src/hybrid/olmoe.rs
@@ -1,96 +1,52 @@
-//! OLMoE model interface — frozen forward pass for inference.
-//!
-//! This module provides a thin, pure-Rust wrapper around the
-//! **allenai/OLMoE-1B-7B-0125-Instruct** MoE language model.  The model is
-//! kept **completely frozen** while the standalone crate exercises routing
-//! through synthetic spike-derived embeddings.
-//!
-//! # Loading priority
-//!
-//! 1. **GGUF Q5_K_M** (default, `gguf` feature or no feature flag needed):
-//!    a pure-Rust GGUF header parser + memory-mapped weights.
-//! 2. **Stub / offline mode**: when `olmoe_model_path` is empty the model
-//!    returns a zero embedding of the correct shape.  This lets the rest of the
-//!    pipeline be exercised without a GPU/model download.
-//!
-//! # Model architecture snapshot (OLMoE-1B-7B-0125)
-//!
-//! | Parameter | Value |
-//! |-----------|-------|
-//! | Hidden size | 2048 |
-//! | Intermediate size | 1024 |
-//! | Num hidden layers | 16 |
-//! | Num attention heads | 16 |
-//! | Num KV heads | 8 |
-//! | Num routed experts | 64 |
-//! | Experts per token | 8 |
-//! | Vocab size | 50 304 |
-//!
-//! # Feature flags
-//!
-//! | Feature | Effect |
-//! |---------|--------|
-//! | `gguf` | Enables GGUF parser header validation |
-//! | *(none)* | Stub mode only |
+//! OLMoE model interface backed by a first-block GGUF mmap bridge.
 
 use crate::error::{HybridError, Result};
 use crate::types::{EMBEDDING_DIM, OlmoeExecutionMode};
+use memmap2::Mmap;
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::fs::File;
+use std::slice;
 
-// ── Internal model constants ───────────────────────────────────────────────────
-
-/// OLMoE-1B-7B hidden dimension.
 const OLMOE_HIDDEN: usize = 2048;
-
-/// Number of routed experts in OLMoE-1B-7B.
 const OLMOE_NUM_EXPERTS: usize = 64;
-
-// ── GGUF magic bytes ──────────────────────────────────────────────────────────
-
-#[cfg(feature = "gguf")]
+const OLMOE_NUM_LAYERS: usize = 16;
+const ROUTING_TENSOR_NAME: &str = "blk.0.ffn_gate_inp.weight";
+const DEFAULT_GPU_SYNAPSE_TENSOR_NAME: &str = "blk.0.attn_q.weight";
 const GGUF_MAGIC: [u8; 4] = [b'G', b'G', b'U', b'F'];
+const GGUF_VERSION: u32 = 3;
+const GGML_TYPE_F32: u32 = 0;
+const GGML_TYPE_F16: u32 = 1;
 
-// ── OLMoE struct ──────────────────────────────────────────────────────────────
+const GGUF_VALUE_TYPE_UINT8: u32 = 0;
+const GGUF_VALUE_TYPE_INT8: u32 = 1;
+const GGUF_VALUE_TYPE_UINT16: u32 = 2;
+const GGUF_VALUE_TYPE_INT16: u32 = 3;
+const GGUF_VALUE_TYPE_UINT32: u32 = 4;
+const GGUF_VALUE_TYPE_INT32: u32 = 5;
+const GGUF_VALUE_TYPE_FLOAT32: u32 = 6;
+const GGUF_VALUE_TYPE_BOOL: u32 = 7;
+const GGUF_VALUE_TYPE_STRING: u32 = 8;
+const GGUF_VALUE_TYPE_ARRAY: u32 = 9;
+const GGUF_VALUE_TYPE_UINT64: u32 = 10;
+const GGUF_VALUE_TYPE_INT64: u32 = 11;
+const GGUF_VALUE_TYPE_FLOAT64: u32 = 12;
 
-/// Frozen OLMoE-1B-7B inference engine.
-///
-/// In the standalone architecture this component keeps its weights frozen and
-/// routes embeddings produced by the projector.
-///
-/// # Stub mode
-///
-/// When `model_path` is empty (or the `gguf` feature is disabled)
-/// `OLMoE::load` succeeds and works fully but returns:
-///
-/// * `expert_weights` — uniform `1/num_experts` for each expert
-/// * `selected_experts` — `[0, 1, ..., top_k-1]`
-/// * A zero-filled output embedding
-///
-/// This is useful for unit-testing the full hybrid pipeline without needing
-/// the actual 4 GB model checkpoint.
 pub struct OLMoE {
-    /// Path to the model file.
     model_path: String,
-
-    /// Number of available experts.
     num_experts: usize,
-
-    /// Number of experts selected per token (top-k routing).
     top_k: usize,
-
-    /// Whether the model was loaded from disk (false = stub mode).
     loaded: bool,
-
-    /// Cached model metadata (populated on load).
     metadata: OlmoeMetadata,
-
     execution_mode: OlmoeExecutionMode,
     expert_membranes: Vec<f32>,
     hidden_membranes: Vec<f32>,
     threshold: f32,
     decay: f32,
+    checkpoint: Option<MappedOlmoeCheckpoint>,
 }
 
-/// Metadata extracted from the model checkpoint.
 #[derive(Debug, Clone, Default)]
 struct OlmoeMetadata {
     pub hidden_size: usize,
@@ -99,32 +55,60 @@ struct OlmoeMetadata {
     pub quantization: String,
 }
 
-/// Result of one OLMoE forward pass.
 #[derive(Debug, Clone)]
 pub struct OlmoeOutput {
-    /// Expert routing weights from the MoE gating network.
-    /// Shape: `[num_experts]`.  Sums to 1.0 per token.
     pub expert_weights: Vec<f32>,
-
-    /// Indices of the top-k selected experts.
     pub selected_experts: Vec<usize>,
-
-    /// Hidden state / logit embedding produced by the decoder.
-    /// Shape: `[EMBEDDING_DIM]`.
     pub hidden: Vec<f32>,
 }
 
+#[derive(Debug)]
+struct MappedOlmoeCheckpoint {
+    mmap: Mmap,
+    tensors: HashMap<String, GgufTensorInfo>,
+    registered_gpu_synapse: Option<RegisteredTensorSliceU16>,
+}
+
+#[derive(Debug, Clone)]
+struct GgufTensorInfo {
+    dims: Vec<usize>,
+    ggml_type: u32,
+    relative_offset: usize,
+    absolute_offset: usize,
+    n_elements: usize,
+}
+
+#[derive(Debug)]
+struct RegisteredTensorSliceU16 {
+    tensor_name: String,
+    _region: RegisteredCudaRegion,
+    ptr: *const u16,
+    len: usize,
+}
+
+#[derive(Debug)]
+struct RegisteredCudaRegion {
+    ptr: *mut c_void,
+}
+
+struct ParsedCheckpointLayout {
+    metadata: OlmoeMetadata,
+    tensors: HashMap<String, GgufTensorInfo>,
+}
+
+struct GgufCursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
 impl OLMoE {
-    /// Load (or stub-initialise) the OLMoE model.
-    ///
-    /// # Arguments
-    /// * `model_path` — path to `OLMoE-1B-7B-Q5_K_M.gguf`.
-    ///   Pass an empty string for stub mode.
-    /// * `num_experts` — number of routed experts (8 for OLMoE-1B-7B top-level,
-    ///   64 internal experts; pass 8 unless you need per-layer granularity).
-    /// * `top_k` — experts activated per token (default 1 in the plan).
     pub fn load(model_path: &str, num_experts: usize, top_k: usize) -> Result<Self> {
-        Self::load_with_mode(model_path, num_experts, top_k, OlmoeExecutionMode::StubUniform)
+        Self::load_with_mode(
+            model_path,
+            num_experts,
+            top_k,
+            OlmoeExecutionMode::StubUniform,
+        )
     }
 
     pub fn load_with_mode(
@@ -136,7 +120,6 @@ impl OLMoE {
         let top_k = top_k.max(1).min(num_experts);
 
         if model_path.is_empty() {
-            // Stub mode — no file I/O needed.
             return Ok(Self {
                 model_path: String::new(),
                 num_experts,
@@ -144,7 +127,7 @@ impl OLMoE {
                 loaded: false,
                 metadata: OlmoeMetadata {
                     hidden_size: OLMOE_HIDDEN,
-                    num_layers: 16,
+                    num_layers: OLMOE_NUM_LAYERS,
                     num_experts: OLMOE_NUM_EXPERTS,
                     quantization: "stub".into(),
                 },
@@ -153,44 +136,33 @@ impl OLMoE {
                 hidden_membranes: vec![0.0; EMBEDDING_DIM],
                 threshold: 0.75,
                 decay: 0.91,
+                checkpoint: None,
             });
         }
 
-        // Probe the file to detect format.
-        let loaded = Self::probe_and_load(model_path)?;
+        let (metadata, checkpoint) = Self::probe_and_map(model_path)?;
+        if num_experts > metadata.num_experts {
+            return Err(HybridError::InvalidConfig(format!(
+                "num_experts ({num_experts}) exceeds checkpoint expert_count ({})",
+                metadata.num_experts
+            )));
+        }
+
         Ok(Self {
             model_path: model_path.to_owned(),
             num_experts,
             top_k,
             loaded: true,
-            metadata: loaded,
+            metadata,
             execution_mode,
             expert_membranes: vec![0.0; num_experts],
             hidden_membranes: vec![0.0; EMBEDDING_DIM],
             threshold: 0.75,
             decay: 0.91,
+            checkpoint: Some(checkpoint),
         })
     }
 
-    /// Forward pass — project embedding through the frozen MoE.
-    ///
-    /// The `embedding` is the output of the [`Projector`](crate::hybrid::projector::Projector)
-    /// produced from the SNN spike activity.  We treat it as the **first token**
-    /// prepended to the model's context, effectively conditioning all subsequent
-    /// expert routing decisions on the neuromorphic state of the system.
-    ///
-    /// # Stub mode behaviour
-    ///
-    /// Returns uniform expert weights and a zero hidden state.  The hidden state
-    /// is the right shape so that downstream code (training, spine) can run
-    /// without modification.
-    ///
-    /// # Arguments
-    /// * `embedding` — dense SNN embedding, shape `[EMBEDDING_DIM]`.
-    ///
-    /// # Errors
-    /// * [`HybridError::InputLengthMismatch`] if `embedding.len() != EMBEDDING_DIM`.
-    /// * [`HybridError::OlmoeForward`] if the frozen forward pass fails.
     pub fn forward(&mut self, embedding: &[f32]) -> Result<OlmoeOutput> {
         if embedding.len() != EMBEDDING_DIM {
             return Err(HybridError::InputLengthMismatch {
@@ -206,97 +178,67 @@ impl OLMoE {
         }
     }
 
-    // ── Internal helpers ──────────────────────────────────────────────────────
+    pub(crate) fn registered_gpu_synapse_weights(&mut self, tensor_name: &str) -> Result<&[u16]> {
+        let path = self.model_path.clone();
+        let checkpoint = self
+            .checkpoint
+            .as_mut()
+            .ok_or_else(|| HybridError::ModelLoad {
+                path: path.clone(),
+                reason: "checkpoint not loaded".into(),
+            })?;
+        checkpoint.registered_f16_tensor(tensor_name, &path)
+    }
 
-    /// Detect file format and return metadata.
-    fn probe_and_load(path: &str) -> Result<OlmoeMetadata> {
-        use std::io::Read;
-
-        let mut file = std::fs::File::open(path).map_err(|e| HybridError::ModelLoad {
+    fn probe_and_map(path: &str) -> Result<(OlmoeMetadata, MappedOlmoeCheckpoint)> {
+        let file = File::open(path).map_err(|e| HybridError::ModelLoad {
             path: path.to_owned(),
             reason: e.to_string(),
         })?;
-
-        let mut magic = [0u8; 4];
-        file.read_exact(&mut magic).map_err(|e| HybridError::ModelLoad {
+        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| HybridError::ModelLoad {
             path: path.to_owned(),
-            reason: format!("could not read magic bytes: {e}"),
+            reason: format!("mmap failed: {e}"),
         })?;
 
-        #[cfg(feature = "gguf")]
-        if magic == GGUF_MAGIC {
-            return Ok(OlmoeMetadata {
-                hidden_size: OLMOE_HIDDEN,
-                num_layers: 16,
-                num_experts: OLMOE_NUM_EXPERTS,
-                quantization: "Q5_K_M".into(),
-            });
-        }
+        let parsed = parse_checkpoint_layout(&mmap, path)?;
+        let routing =
+            parsed
+                .tensors
+                .get(ROUTING_TENSOR_NAME)
+                .ok_or_else(|| HybridError::MissingTensor {
+                    name: ROUTING_TENSOR_NAME.into(),
+                    path: path.to_owned(),
+                })?;
+        validate_routing_tensor(path, routing)?;
 
-        if magic[0] == b'{' || (magic[0] == 0 && magic[1] == 0) {
-            return Err(HybridError::UnsupportedFormat(
-                "non-GGUF checkpoint headers are not supported in standalone mode".into(),
-            ));
-        }
+        let synapse = parsed
+            .tensors
+            .get(DEFAULT_GPU_SYNAPSE_TENSOR_NAME)
+            .ok_or_else(|| HybridError::MissingTensor {
+                name: DEFAULT_GPU_SYNAPSE_TENSOR_NAME.into(),
+                path: path.to_owned(),
+            })?;
+        validate_gpu_synapse_tensor(path, DEFAULT_GPU_SYNAPSE_TENSOR_NAME, synapse)?;
 
-        Err(HybridError::UnsupportedFormat(format!(
-            "unrecognised model magic bytes: {magic:?}  \
-             (enable `gguf` and verify the file)"
-        )))
+        Ok((
+            parsed.metadata,
+            MappedOlmoeCheckpoint {
+                mmap,
+                tensors: parsed.tensors,
+                registered_gpu_synapse: None,
+            },
+        ))
     }
 
-    /// Simulate MoE expert routing using the SNN embedding as the gate input.
-    ///
-    /// The gate computes softmax(W_gate · embedding) where W_gate is a
-    /// deterministic pseudo-random matrix seeded from the expert index.  This
-    /// preserves the correct output shape and numerical behaviour (sum-to-1
-    /// weights, top-k masking) while the actual checkpoint weights are swapped
-    /// in via `probe_and_load` once the model is downloaded.
     fn simulate_moe_routing(&self, embedding: &[f32]) -> Result<OlmoeOutput> {
-        let n = self.num_experts;
-
-        // Gate scores: dot each expert's "weight row" with the embedding.
-        // The rows are synthesised deterministically from the expert index.
-        let mut gate_scores = Vec::with_capacity(n);
-        for expert_id in 0..n {
-            let mut score = 0.0_f32;
-            for (j, &e) in embedding.iter().enumerate() {
-                // Deterministic "weight": hash of (expert_id, dim_j)
-                let w = Self::pseudo_weight(expert_id, j, EMBEDDING_DIM);
-                score += w * e;
-            }
-            gate_scores.push(score);
-        }
-
-        // Softmax
-        let max_score = gate_scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-        let exp_scores: Vec<f32> = gate_scores.iter().map(|s| (s - max_score).exp()).collect();
-        let sum_exp: f32 = exp_scores.iter().sum();
-        let expert_weights: Vec<f32> = exp_scores.iter().map(|e| e / sum_exp).collect();
-
-        // Top-k selection
-        let mut indexed: Vec<(usize, f32)> = expert_weights
+        let gate_scores = self.compute_gate_scores(embedding)?;
+        let expert_weights = softmax(&gate_scores);
+        let selected_experts = top_k_indices(&expert_weights, self.top_k);
+        let selected_mass: f32 = selected_experts
             .iter()
-            .copied()
-            .enumerate()
-            .collect();
-        indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        let selected_experts: Vec<usize> = indexed[..self.top_k].iter().map(|&(i, _)| i).collect();
-
-        // Hidden state: weighted sum of expert "outputs" (stub: embedding itself)
-        let mut hidden = vec![0.0_f32; EMBEDDING_DIM];
-        for (rank, &expert_id) in selected_experts.iter().enumerate() {
-            let w = expert_weights[expert_id];
-            // Expert output = embedding scaled by pseudo-random expert gain
-            for (j, h) in hidden.iter_mut().enumerate() {
-                let gain = Self::pseudo_weight(expert_id, j + rank * 1000, EMBEDDING_DIM);
-                *h += w * gain * embedding[j % embedding.len()];
-            }
-        }
-        // Tanh bound
-        for h in &mut hidden {
-            *h = h.tanh();
-        }
+            .map(|&idx| expert_weights[idx])
+            .sum();
+        let hidden: Vec<f32> = embedding.iter().map(|&v| v * selected_mass).collect();
 
         Ok(OlmoeOutput {
             expert_weights,
@@ -306,19 +248,14 @@ impl OLMoE {
     }
 
     fn spiking_moe_routing(&mut self, embedding: &[f32]) -> Result<OlmoeOutput> {
+        let gate_scores = self.compute_gate_scores(embedding)?;
         let n = self.num_experts;
+        let mut membrane_scores = Vec::with_capacity(n);
+        let mut expert_spikes = vec![0.0f32; n];
 
-        let mut gate_scores = Vec::with_capacity(n);
-        let mut expert_spikes = vec![0.0_f32; n];
         for expert_id in 0..n {
-            let mut acc = 0.0_f32;
-            for (j, &e) in embedding.iter().enumerate() {
-                let w = Self::pseudo_weight(expert_id, j, EMBEDDING_DIM);
-                acc += w * e;
-            }
-
             self.expert_membranes[expert_id] =
-                self.expert_membranes[expert_id] * self.decay + acc * 0.18;
+                self.expert_membranes[expert_id] * self.decay + gate_scores[expert_id] * 0.18;
 
             let spike = if self.expert_membranes[expert_id] > self.threshold {
                 self.expert_membranes[expert_id] -= self.threshold;
@@ -331,56 +268,33 @@ impl OLMoE {
             };
 
             expert_spikes[expert_id] = spike;
-            gate_scores.push(self.expert_membranes[expert_id] + spike * self.threshold);
+            membrane_scores.push(self.expert_membranes[expert_id] + spike * self.threshold);
         }
 
-        let max_score = gate_scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-        let exp_scores: Vec<f32> = gate_scores.iter().map(|s| (s - max_score).exp()).collect();
-        let sum_exp: f32 = exp_scores.iter().sum();
-        let expert_weights: Vec<f32> = if sum_exp > 0.0 && sum_exp.is_finite() {
-            exp_scores.iter().map(|e| e / sum_exp).collect()
-        } else {
-            vec![1.0 / n as f32; n]
-        };
+        let expert_weights = softmax(&membrane_scores);
+        let selected_experts = top_k_indices(&expert_weights, self.top_k);
 
-        let mut indexed: Vec<(usize, f32)> = expert_weights
+        let active_mass: f32 = selected_experts
             .iter()
-            .copied()
-            .enumerate()
-            .collect();
-        indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        let selected_experts: Vec<usize> = indexed[..self.top_k].iter().map(|&(i, _)| i).collect();
+            .map(|&expert_id| expert_spikes[expert_id] * expert_weights[expert_id])
+            .sum();
 
-        let mut hidden = vec![0.0_f32; EMBEDDING_DIM];
-        for &expert_id in &selected_experts {
-            let active_signal = if expert_spikes[expert_id].abs() > 0.5 {
-                expert_spikes[expert_id]
+        let mut hidden = vec![0.0f32; EMBEDDING_DIM];
+        for (j, h) in hidden.iter_mut().enumerate() {
+            let input = embedding[j] * active_mass;
+            self.hidden_membranes[j] = self.hidden_membranes[j] * self.decay + input;
+
+            let spike = if self.hidden_membranes[j] > self.threshold {
+                self.hidden_membranes[j] -= self.threshold;
+                1.0
+            } else if self.hidden_membranes[j] < -self.threshold {
+                self.hidden_membranes[j] += self.threshold;
+                -1.0
             } else {
                 0.0
             };
 
-            if active_signal == 0.0 {
-                continue;
-            }
-
-            for (j, h) in hidden.iter_mut().enumerate() {
-                let gain = Self::pseudo_weight(expert_id, j + expert_id * 1000, EMBEDDING_DIM);
-                let input = active_signal * gain * embedding[j % embedding.len()];
-
-                self.hidden_membranes[j] = self.hidden_membranes[j] * self.decay + input * 1.5;
-
-                let spike = if self.hidden_membranes[j] > self.threshold {
-                    self.hidden_membranes[j] -= self.threshold;
-                    1.0
-                } else if self.hidden_membranes[j] < -self.threshold {
-                    self.hidden_membranes[j] += self.threshold;
-                    -1.0
-                } else {
-                    0.0
-                };
-
-                *h += spike * 0.3;
-            }
+            *h = spike * 0.3;
         }
 
         Ok(OlmoeOutput {
@@ -390,12 +304,38 @@ impl OLMoE {
         })
     }
 
-    /// Uniform stub output — used in stub mode (no model loaded).
+    fn compute_gate_scores(&self, embedding: &[f32]) -> Result<Vec<f32>> {
+        if let Some(checkpoint) = &self.checkpoint {
+            let info = checkpoint.tensor_info(ROUTING_TENSOR_NAME, &self.model_path)?;
+            let weights = checkpoint.f32_tensor(ROUTING_TENSOR_NAME, &self.model_path)?;
+            let mut gate_scores = Vec::with_capacity(self.num_experts);
+            for expert_id in 0..self.num_experts {
+                let mut score = 0.0f32;
+                for (dim, &value) in embedding.iter().enumerate() {
+                    let index = routing_weight_index(info, expert_id, dim, self.num_experts)?;
+                    score += weights[index] * value;
+                }
+                gate_scores.push(score);
+            }
+            return Ok(gate_scores);
+        }
+
+        // Deterministic synthetic fallback for DenseSim/SpikingSim when no checkpoint is present.
+        let chunk = (EMBEDDING_DIM / self.num_experts.max(1)).max(1);
+        let mut gate_scores = Vec::with_capacity(self.num_experts);
+        for expert_id in 0..self.num_experts {
+            let start = (expert_id * chunk) % EMBEDDING_DIM;
+            let end = (start + chunk).min(EMBEDDING_DIM);
+            gate_scores.push(embedding[start..end].iter().sum());
+        }
+        Ok(gate_scores)
+    }
+
     fn stub_output(&self) -> OlmoeOutput {
         let n = self.num_experts;
         let expert_weights = vec![1.0 / n as f32; n];
         let selected_experts = (0..self.top_k).collect();
-        let hidden = vec![0.0_f32; EMBEDDING_DIM];
+        let hidden = vec![0.0f32; EMBEDDING_DIM];
         OlmoeOutput {
             expert_weights,
             selected_experts,
@@ -403,23 +343,6 @@ impl OLMoE {
         }
     }
 
-    /// Deterministic pseudo-weight from (expert_id, dim_j) without any RNG dep.
-    ///
-    /// Uses a simple multiplicative hash that produces values in `[-1, 1]`.
-    #[inline]
-    fn pseudo_weight(expert_id: usize, dim_j: usize, total_dims: usize) -> f32 {
-        let h = expert_id.wrapping_mul(2_654_435_761)
-            ^ dim_j.wrapping_mul(1_664_525)
-            ^ total_dims.wrapping_mul(1_013_904_223);
-        // Map to [-1, 1] via sign + normalised magnitude
-        let frac = (h & 0x00FF_FFFF) as f32 / 0x00FF_FFFF_u32 as f32;
-        let sign = if h & (1 << 30) != 0 { 1.0 } else { -1.0 };
-        sign * frac * 0.1 // scaled down for numerical stability
-    }
-
-    // ── Accessors ─────────────────────────────────────────────────────────────
-
-    /// `true` if the model weights were loaded from disk; `false` = stub mode.
     pub fn is_loaded(&self) -> bool {
         self.loaded
     }
@@ -429,12 +352,10 @@ impl OLMoE {
         self.hidden_membranes.fill(0.0);
     }
 
-    /// Model checkpoint path (empty string in stub mode).
     pub fn model_path(&self) -> &str {
         &self.model_path
     }
 
-    /// Quantisation string from metadata (e.g. `"Q5_K_M"`, `"BF16"`, `"stub"`).
     pub fn quantization(&self) -> &str {
         &self.metadata.quantization
     }
@@ -451,7 +372,6 @@ impl OLMoE {
         self.metadata.num_experts
     }
 
-    /// Number of available experts as configured.
     pub fn num_experts(&self) -> usize {
         self.num_experts
     }
@@ -467,11 +387,558 @@ impl OLMoE {
     }
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+impl MappedOlmoeCheckpoint {
+    fn tensor_info<'a>(&'a self, name: &str, path: &str) -> Result<&'a GgufTensorInfo> {
+        self.tensors
+            .get(name)
+            .ok_or_else(|| HybridError::MissingTensor {
+                name: name.to_owned(),
+                path: path.to_owned(),
+            })
+    }
+
+    fn f32_tensor<'a>(&'a self, name: &str, path: &str) -> Result<&'a [f32]> {
+        let info = self.tensor_info(name, path)?;
+        if info.ggml_type != GGML_TYPE_F32 {
+            return Err(HybridError::UnsupportedFormat(format!(
+                "tensor '{name}' must be F32, got ggml_type={}",
+                info.ggml_type
+            )));
+        }
+
+        let start = info.absolute_offset;
+        let end = start + info.n_elements * std::mem::size_of::<f32>();
+        if end > self.mmap.len() {
+            return Err(HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: format!("tensor '{name}' extends beyond mapped file"),
+            });
+        }
+
+        let ptr = unsafe { self.mmap.as_ptr().add(start) as *const f32 };
+        Ok(unsafe { slice::from_raw_parts(ptr, info.n_elements) })
+    }
+
+    fn registered_f16_tensor<'a>(&'a mut self, name: &str, path: &str) -> Result<&'a [u16]> {
+        let info = self.tensor_info(name, path)?.clone();
+        if info.ggml_type != GGML_TYPE_F16 {
+            return Err(HybridError::UnsupportedFormat(format!(
+                "tensor '{name}' must be F16, got ggml_type={}",
+                info.ggml_type
+            )));
+        }
+
+        if self
+            .registered_gpu_synapse
+            .as_ref()
+            .map(|registered| registered.tensor_name.as_str() == name)
+            .unwrap_or(false)
+        {
+            return Ok(self
+                .registered_gpu_synapse
+                .as_ref()
+                .expect("checked above")
+                .as_slice());
+        }
+
+        self.registered_gpu_synapse = Some(RegisteredTensorSliceU16::register(
+            name,
+            &self.mmap,
+            info.absolute_offset,
+            info.n_elements,
+            path,
+        )?);
+
+        Ok(self
+            .registered_gpu_synapse
+            .as_ref()
+            .expect("registered above")
+            .as_slice())
+    }
+}
+
+impl RegisteredTensorSliceU16 {
+    fn register(
+        tensor_name: &str,
+        mmap: &Mmap,
+        absolute_offset: usize,
+        n_elements: usize,
+        path: &str,
+    ) -> Result<Self> {
+        let byte_len = n_elements
+            .checked_mul(std::mem::size_of::<u16>())
+            .ok_or_else(|| HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: format!("tensor '{tensor_name}' byte length overflow"),
+            })?;
+
+        let page_size = page_size_bytes(path)?;
+        let aligned_start = absolute_offset / page_size * page_size;
+        let aligned_end = align_up(absolute_offset + byte_len, page_size);
+        let register_len = aligned_end - aligned_start;
+
+        if aligned_end > mmap.len() {
+            return Err(HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: format!("tensor '{tensor_name}' registration range exceeds mmap"),
+            });
+        }
+
+        let register_ptr = unsafe { mmap.as_ptr().add(aligned_start) as *mut c_void };
+        cuda_host_register(register_ptr, register_len, path, tensor_name)?;
+
+        let tensor_ptr = unsafe { mmap.as_ptr().add(absolute_offset) as *const u16 };
+        Ok(Self {
+            tensor_name: tensor_name.to_owned(),
+            _region: RegisteredCudaRegion { ptr: register_ptr },
+            ptr: tensor_ptr,
+            len: n_elements,
+        })
+    }
+
+    fn as_slice(&self) -> &[u16] {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl Drop for RegisteredCudaRegion {
+    fn drop(&mut self) {
+        let result = unsafe { cust::sys::cuMemHostUnregister(self.ptr) };
+        if result != cust::sys::CUresult::CUDA_SUCCESS {
+            // The model remains valid; dropping the registration should not panic.
+        }
+    }
+}
+
+fn parse_checkpoint_layout(bytes: &[u8], path: &str) -> Result<ParsedCheckpointLayout> {
+    let mut cursor = GgufCursor::new(bytes);
+
+    let magic = cursor.read_exact(4, path)?;
+    if magic != GGUF_MAGIC {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "unrecognised model magic bytes: {magic:?}"
+        )));
+    }
+
+    let version = cursor.read_u32(path)?;
+    if version != GGUF_VERSION {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "unsupported GGUF version {version}; expected {GGUF_VERSION}"
+        )));
+    }
+
+    let tensor_count = cursor.read_u64(path)? as usize;
+    let kv_count = cursor.read_u64(path)? as usize;
+
+    let mut alignment = 32usize;
+    let mut file_type = None;
+    let mut expert_count = OLMOE_NUM_EXPERTS;
+
+    for _ in 0..kv_count {
+        let key = cursor.read_string(path)?;
+        let value_type = cursor.read_u32(path)?;
+        match key.as_str() {
+            "general.alignment" => alignment = cursor.read_numeric_as_usize(value_type, path)?,
+            "general.file_type" => file_type = Some(cursor.read_numeric_as_u32(value_type, path)?),
+            "olmoe.expert_count" => {
+                expert_count = cursor.read_numeric_as_usize(value_type, path)?
+            }
+            _ => cursor.skip_value(value_type, path)?,
+        }
+    }
+
+    let mut tensors = HashMap::with_capacity(tensor_count);
+    for _ in 0..tensor_count {
+        let name = cursor.read_string(path)?;
+        let n_dims = cursor.read_u32(path)? as usize;
+        let mut dims = Vec::with_capacity(n_dims);
+        for _ in 0..n_dims {
+            dims.push(cursor.read_u64(path)? as usize);
+        }
+        let ggml_type = cursor.read_u32(path)?;
+        let relative_offset = cursor.read_u64(path)? as usize;
+        let n_elements = dims
+            .iter()
+            .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+            .ok_or_else(|| HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: format!("tensor '{name}' element count overflow"),
+            })?;
+        tensors.insert(
+            name,
+            GgufTensorInfo {
+                dims,
+                ggml_type,
+                relative_offset,
+                absolute_offset: 0,
+                n_elements,
+            },
+        );
+    }
+
+    let tensor_data_offset = align_up(cursor.offset, alignment);
+    for tensor in tensors.values_mut() {
+        tensor.absolute_offset = tensor_data_offset + tensor.relative_offset;
+    }
+
+    Ok(ParsedCheckpointLayout {
+        metadata: OlmoeMetadata {
+            hidden_size: OLMOE_HIDDEN,
+            num_layers: OLMOE_NUM_LAYERS,
+            num_experts: expert_count,
+            quantization: quantization_label(file_type),
+        },
+        tensors,
+    })
+}
+
+fn validate_routing_tensor(path: &str, tensor: &GgufTensorInfo) -> Result<()> {
+    if tensor.ggml_type != GGML_TYPE_F32 {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "tensor '{ROUTING_TENSOR_NAME}' must be F32 in '{path}'"
+        )));
+    }
+    if tensor.dims.len() != 2 {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "tensor '{ROUTING_TENSOR_NAME}' must be rank-2, got {:?}",
+            tensor.dims
+        )));
+    }
+    if tensor.n_elements != OLMOE_HIDDEN * OLMOE_NUM_EXPERTS {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "tensor '{ROUTING_TENSOR_NAME}' has unexpected size {:?}",
+            tensor.dims
+        )));
+    }
+    Ok(())
+}
+
+fn validate_gpu_synapse_tensor(
+    path: &str,
+    tensor_name: &str,
+    tensor: &GgufTensorInfo,
+) -> Result<()> {
+    if tensor.ggml_type != GGML_TYPE_F16 {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "tensor '{tensor_name}' must be F16 in '{path}'"
+        )));
+    }
+    if tensor.dims != [OLMOE_HIDDEN, OLMOE_HIDDEN] {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "tensor '{tensor_name}' must be [2048, 2048], got {:?}",
+            tensor.dims
+        )));
+    }
+    Ok(())
+}
+
+fn routing_weight_index(
+    tensor: &GgufTensorInfo,
+    expert_id: usize,
+    dim: usize,
+    num_experts: usize,
+) -> Result<usize> {
+    let d0 = tensor.dims[0];
+    let d1 = tensor.dims[1];
+
+    if d0 == EMBEDDING_DIM && d1 >= num_experts {
+        return Ok(dim * d1 + expert_id);
+    }
+    if d0 >= num_experts && d1 == EMBEDDING_DIM {
+        return Ok(expert_id * d1 + dim);
+    }
+
+    Err(HybridError::UnsupportedFormat(format!(
+        "unsupported routing tensor orientation {:?}",
+        tensor.dims
+    )))
+}
+
+fn softmax(scores: &[f32]) -> Vec<f32> {
+    if scores.is_empty() {
+        return Vec::new();
+    }
+
+    let max_score = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let exp_scores: Vec<f32> = scores
+        .iter()
+        .map(|&score| (score - max_score).exp())
+        .collect();
+    let sum_exp: f32 = exp_scores.iter().sum();
+    if sum_exp <= 0.0 || !sum_exp.is_finite() {
+        return vec![1.0 / scores.len() as f32; scores.len()];
+    }
+    exp_scores
+        .into_iter()
+        .map(|value| value / sum_exp)
+        .collect()
+}
+
+fn top_k_indices(weights: &[f32], top_k: usize) -> Vec<usize> {
+    let mut indexed: Vec<(usize, f32)> = weights.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+    indexed
+        .into_iter()
+        .take(top_k)
+        .map(|(idx, _)| idx)
+        .collect()
+}
+
+fn quantization_label(file_type: Option<u32>) -> String {
+    match file_type {
+        Some(0) => "F32".into(),
+        Some(1) => "F16".into(),
+        Some(other) => format!("GGUF({other})"),
+        None => "GGUF".into(),
+    }
+}
+
+fn page_size_bytes(path: &str) -> Result<usize> {
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 {
+        return Err(HybridError::ModelLoad {
+            path: path.to_owned(),
+            reason: "sysconf(_SC_PAGESIZE) failed".into(),
+        });
+    }
+    Ok(page_size as usize)
+}
+
+fn align_up(value: usize, alignment: usize) -> usize {
+    if alignment == 0 {
+        value
+    } else {
+        value.div_ceil(alignment) * alignment
+    }
+}
+
+fn cuda_host_register(ptr: *mut c_void, len: usize, path: &str, tensor_name: &str) -> Result<()> {
+    let result = unsafe { cust::sys::cuMemHostRegister_v2(ptr, len, 0) };
+    if result == cust::sys::CUresult::CUDA_SUCCESS {
+        return Ok(());
+    }
+
+    Err(HybridError::ModelLoad {
+        path: path.to_owned(),
+        reason: format!("cuMemHostRegister_v2 failed for '{tensor_name}': {result:?}"),
+    })
+}
+
+impl<'a> GgufCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn read_exact(&mut self, len: usize, path: &str) -> Result<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: "cursor overflow".into(),
+            })?;
+        if end > self.bytes.len() {
+            return Err(HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: "unexpected EOF while parsing GGUF".into(),
+            });
+        }
+        let slice = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(slice)
+    }
+
+    fn read_u8(&mut self, path: &str) -> Result<u8> {
+        Ok(self.read_exact(1, path)?[0])
+    }
+
+    fn read_u16(&mut self, path: &str) -> Result<u16> {
+        let bytes = self.read_exact(2, path)?;
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_u32(&mut self, path: &str) -> Result<u32> {
+        let bytes = self.read_exact(4, path)?;
+        Ok(u32::from_le_bytes(
+            bytes.try_into().expect("slice length is fixed"),
+        ))
+    }
+
+    fn read_u64(&mut self, path: &str) -> Result<u64> {
+        let bytes = self.read_exact(8, path)?;
+        Ok(u64::from_le_bytes(
+            bytes.try_into().expect("slice length is fixed"),
+        ))
+    }
+
+    fn read_i16(&mut self, path: &str) -> Result<i16> {
+        Ok(self.read_u16(path)? as i16)
+    }
+
+    fn read_i32(&mut self, path: &str) -> Result<i32> {
+        Ok(self.read_u32(path)? as i32)
+    }
+
+    fn read_i64(&mut self, path: &str) -> Result<i64> {
+        Ok(self.read_u64(path)? as i64)
+    }
+
+    fn read_string(&mut self, path: &str) -> Result<String> {
+        let len = self.read_u64(path)? as usize;
+        let bytes = self.read_exact(len, path)?;
+        String::from_utf8(bytes.to_vec()).map_err(|e| HybridError::ModelLoad {
+            path: path.to_owned(),
+            reason: format!("invalid UTF-8 in GGUF string: {e}"),
+        })
+    }
+
+    fn read_numeric_as_u32(&mut self, value_type: u32, path: &str) -> Result<u32> {
+        match value_type {
+            GGUF_VALUE_TYPE_UINT8 => Ok(self.read_u8(path)? as u32),
+            GGUF_VALUE_TYPE_INT8 => Ok(self.read_u8(path)? as i8 as i32 as u32),
+            GGUF_VALUE_TYPE_UINT16 => Ok(self.read_u16(path)? as u32),
+            GGUF_VALUE_TYPE_INT16 => Ok(self.read_i16(path)? as i32 as u32),
+            GGUF_VALUE_TYPE_UINT32 => self.read_u32(path),
+            GGUF_VALUE_TYPE_INT32 => Ok(self.read_i32(path)? as u32),
+            GGUF_VALUE_TYPE_UINT64 => Ok(self.read_u64(path)? as u32),
+            GGUF_VALUE_TYPE_INT64 => Ok(self.read_i64(path)? as u32),
+            _ => Err(HybridError::UnsupportedFormat(format!(
+                "GGUF numeric conversion from type {value_type} is not supported"
+            ))),
+        }
+    }
+
+    fn read_numeric_as_usize(&mut self, value_type: u32, path: &str) -> Result<usize> {
+        Ok(self.read_numeric_as_u32(value_type, path)? as usize)
+    }
+
+    fn skip_value(&mut self, value_type: u32, path: &str) -> Result<()> {
+        match value_type {
+            GGUF_VALUE_TYPE_UINT8 | GGUF_VALUE_TYPE_INT8 | GGUF_VALUE_TYPE_BOOL => {
+                self.read_exact(1, path)?;
+            }
+            GGUF_VALUE_TYPE_UINT16 | GGUF_VALUE_TYPE_INT16 => {
+                self.read_exact(2, path)?;
+            }
+            GGUF_VALUE_TYPE_UINT32 | GGUF_VALUE_TYPE_INT32 | GGUF_VALUE_TYPE_FLOAT32 => {
+                self.read_exact(4, path)?;
+            }
+            GGUF_VALUE_TYPE_UINT64 | GGUF_VALUE_TYPE_INT64 | GGUF_VALUE_TYPE_FLOAT64 => {
+                self.read_exact(8, path)?;
+            }
+            GGUF_VALUE_TYPE_STRING => {
+                let _ = self.read_string(path)?;
+            }
+            GGUF_VALUE_TYPE_ARRAY => {
+                let nested_type = self.read_u32(path)?;
+                let len = self.read_u64(path)? as usize;
+                for _ in 0..len {
+                    self.skip_value(nested_type, path)?;
+                }
+            }
+            _ => {
+                return Err(HybridError::UnsupportedFormat(format!(
+                    "unsupported GGUF value type {value_type}"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gpu::GpuAccelerator;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn write_temp_file(bytes: &[u8], label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "corinth_canal_{label}_{}.gguf",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(bytes).unwrap();
+        path
+    }
+
+    fn push_u32(out: &mut Vec<u8>, value: u32) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u64(out: &mut Vec<u8>, value: u64) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_string(out: &mut Vec<u8>, value: &str) {
+        push_u64(out, value.len() as u64);
+        out.extend_from_slice(value.as_bytes());
+    }
+
+    fn push_kv_u32(out: &mut Vec<u8>, key: &str, value: u32) {
+        push_string(out, key);
+        push_u32(out, GGUF_VALUE_TYPE_UINT32);
+        push_u32(out, value);
+    }
+
+    fn build_test_gguf(tensors: Vec<(&str, Vec<usize>, u32, Vec<u8>)>, alignment: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&GGUF_MAGIC);
+        push_u32(&mut out, GGUF_VERSION);
+        push_u64(&mut out, tensors.len() as u64);
+        push_u64(&mut out, 3);
+        push_kv_u32(&mut out, "general.alignment", alignment);
+        push_kv_u32(&mut out, "general.file_type", 1);
+        push_kv_u32(&mut out, "olmoe.expert_count", 64);
+
+        let mut data_offset = 0usize;
+        let mut tensor_payloads = Vec::new();
+        for (name, dims, ggml_type, payload) in tensors {
+            push_string(&mut out, name);
+            push_u32(&mut out, dims.len() as u32);
+            for dim in &dims {
+                push_u64(&mut out, *dim as u64);
+            }
+            push_u32(&mut out, ggml_type);
+            push_u64(&mut out, data_offset as u64);
+            data_offset += payload.len();
+            tensor_payloads.push(payload);
+        }
+
+        while out.len() % alignment as usize != 0 {
+            out.push(0);
+        }
+        for payload in tensor_payloads {
+            out.extend_from_slice(&payload);
+        }
+
+        out
+    }
+
+    fn build_real_size_checkpoint(gate_payload: Vec<u8>) -> Vec<u8> {
+        let attn_q_payload = vec![0u8; OLMOE_HIDDEN * OLMOE_HIDDEN * 2];
+        build_test_gguf(
+            vec![
+                (
+                    ROUTING_TENSOR_NAME,
+                    vec![EMBEDDING_DIM, OLMOE_NUM_EXPERTS],
+                    GGML_TYPE_F32,
+                    gate_payload,
+                ),
+                (
+                    DEFAULT_GPU_SYNAPSE_TENSOR_NAME,
+                    vec![OLMOE_HIDDEN, OLMOE_HIDDEN],
+                    GGML_TYPE_F16,
+                    attn_q_payload,
+                ),
+            ],
+            32,
+        )
+    }
 
     fn stub() -> OLMoE {
         OLMoE::load_with_mode("", 8, 1, OlmoeExecutionMode::StubUniform)
@@ -498,7 +965,7 @@ mod tests {
     #[test]
     fn test_stub_forward_shape() {
         let mut model = stub();
-        let embedding = vec![0.0_f32; EMBEDDING_DIM];
+        let embedding = vec![0.0f32; EMBEDDING_DIM];
         let out = model.forward(&embedding).unwrap();
         assert_eq!(out.expert_weights.len(), 8);
         assert_eq!(out.selected_experts.len(), 1);
@@ -508,7 +975,7 @@ mod tests {
     #[test]
     fn test_stub_forward_uniform_weights() {
         let mut model = stub();
-        let embedding = vec![0.1_f32; EMBEDDING_DIM];
+        let embedding = vec![0.1f32; EMBEDDING_DIM];
         let out = model.forward(&embedding).unwrap();
         for w in &out.expert_weights {
             assert!((*w - 0.125).abs() < 1e-5, "expected uniform 1/8, got {w}");
@@ -518,25 +985,30 @@ mod tests {
     #[test]
     fn test_input_length_mismatch() {
         let mut model = stub();
-        let bad_embedding = vec![0.0_f32; 64];
+        let bad_embedding = vec![0.0f32; 64];
         assert!(model.forward(&bad_embedding).is_err());
     }
 
     #[test]
     fn test_dense_sim_in_stub_mode_has_valid_routing() {
         let mut model = dense_sim_stub();
-        let embedding: Vec<f32> = (0..EMBEDDING_DIM).map(|i| (i as f32 / EMBEDDING_DIM as f32) * 0.1).collect();
+        let embedding: Vec<f32> = (0..EMBEDDING_DIM)
+            .map(|i| (i as f32 / EMBEDDING_DIM as f32) * 0.1)
+            .collect();
         let out = model.forward(&embedding).unwrap();
         assert_eq!(out.selected_experts.len(), 2);
         let weight_sum: f32 = out.expert_weights.iter().sum();
-        assert!((weight_sum - 1.0).abs() < 1e-5, "expert weights must sum to 1, got {weight_sum}");
+        assert!(
+            (weight_sum - 1.0).abs() < 1e-5,
+            "expert weights must sum to 1, got {weight_sum}"
+        );
         assert_eq!(out.hidden.len(), EMBEDDING_DIM);
     }
 
     #[test]
     fn test_spiking_sim_persists_state_and_can_fire() {
         let mut model = spiking_sim_stub();
-        let embedding = vec![1.0_f32; EMBEDDING_DIM];
+        let embedding = vec![1.0f32; EMBEDDING_DIM];
 
         let first = model.forward(&embedding).unwrap();
         assert!(model.expert_membranes.iter().any(|&v| v != 0.0));
@@ -550,13 +1022,16 @@ mod tests {
             }
         }
 
-        assert!(fired, "spiking sim should eventually emit ternary hidden events");
+        assert!(
+            fired,
+            "spiking sim should eventually emit ternary hidden events"
+        );
     }
 
     #[test]
     fn test_spiking_sim_reset_clears_state() {
         let mut model = spiking_sim_stub();
-        let embedding = vec![1.0_f32; EMBEDDING_DIM];
+        let embedding = vec![1.0f32; EMBEDDING_DIM];
 
         let _ = model.forward(&embedding).unwrap();
         assert!(model.expert_membranes.iter().any(|&v| v != 0.0));
@@ -565,5 +1040,159 @@ mod tests {
 
         assert!(model.expert_membranes.iter().all(|&v| v == 0.0));
         assert!(model.hidden_membranes.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn test_parse_checkpoint_layout_preserves_tensor_offsets() {
+        let bytes = build_test_gguf(
+            vec![("demo.weight", vec![2, 2], GGML_TYPE_F32, vec![0u8; 16])],
+            64,
+        );
+        let parsed = parse_checkpoint_layout(&bytes, "test.gguf").unwrap();
+        let tensor = parsed.tensors.get("demo.weight").unwrap();
+        assert_eq!(tensor.relative_offset, 0);
+        assert_eq!(tensor.absolute_offset % 64, 0);
+        assert_eq!(tensor.n_elements, 4);
+    }
+
+    #[test]
+    fn test_probe_and_map_rejects_missing_routing_tensor() {
+        let bytes = build_test_gguf(
+            vec![(
+                DEFAULT_GPU_SYNAPSE_TENSOR_NAME,
+                vec![OLMOE_HIDDEN, OLMOE_HIDDEN],
+                GGML_TYPE_F16,
+                vec![0u8; OLMOE_HIDDEN * OLMOE_HIDDEN * 2],
+            )],
+            32,
+        );
+        let path = write_temp_file(&bytes, "missing-routing");
+        let err = OLMoE::probe_and_map(path.to_str().unwrap()).unwrap_err();
+        assert!(matches!(err, HybridError::MissingTensor { .. }));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_probe_and_map_rejects_wrong_synapse_type() {
+        let gate_payload = vec![0u8; EMBEDDING_DIM * OLMOE_NUM_EXPERTS * 4];
+        let bytes = build_test_gguf(
+            vec![
+                (
+                    ROUTING_TENSOR_NAME,
+                    vec![EMBEDDING_DIM, OLMOE_NUM_EXPERTS],
+                    GGML_TYPE_F32,
+                    gate_payload,
+                ),
+                (
+                    DEFAULT_GPU_SYNAPSE_TENSOR_NAME,
+                    vec![OLMOE_HIDDEN, OLMOE_HIDDEN],
+                    GGML_TYPE_F32,
+                    vec![0u8; OLMOE_HIDDEN * OLMOE_HIDDEN * 4],
+                ),
+            ],
+            32,
+        );
+        let path = write_temp_file(&bytes, "wrong-type");
+        let err = OLMoE::probe_and_map(path.to_str().unwrap()).unwrap_err();
+        assert!(matches!(err, HybridError::UnsupportedFormat(_)));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_dense_sim_uses_real_gate_weights() {
+        let mut gate = vec![0.0f32; EMBEDDING_DIM * OLMOE_NUM_EXPERTS];
+        for (expert, gate_value) in gate.iter_mut().take(OLMOE_NUM_EXPERTS).enumerate() {
+            *gate_value = if expert == 0 { 8.0 } else { -8.0 };
+        }
+        let gate_bytes: Vec<u8> = gate.iter().flat_map(|value| value.to_le_bytes()).collect();
+        let path = write_temp_file(&build_real_size_checkpoint(gate_bytes), "dense-real");
+
+        let mut model =
+            OLMoE::load_with_mode(path.to_str().unwrap(), 8, 2, OlmoeExecutionMode::DenseSim)
+                .unwrap();
+        let mut embedding = vec![0.0f32; EMBEDDING_DIM];
+        embedding[0] = 1.0;
+        let out = model.forward(&embedding).unwrap();
+        assert_eq!(out.selected_experts[0], 0);
+        let weight_sum: f32 = out.expert_weights.iter().sum();
+        assert!((weight_sum - 1.0).abs() < 1e-5);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_spiking_real_gate_path_accumulates_state() {
+        let mut gate = vec![0.0f32; EMBEDDING_DIM * OLMOE_NUM_EXPERTS];
+        for (expert, gate_value) in gate.iter_mut().take(OLMOE_NUM_EXPERTS).enumerate() {
+            *gate_value = if expert == 0 { 8.0 } else { -8.0 };
+        }
+        let gate_bytes: Vec<u8> = gate.iter().flat_map(|value| value.to_le_bytes()).collect();
+        let path = write_temp_file(&build_real_size_checkpoint(gate_bytes), "spiking-real");
+
+        let mut model =
+            OLMoE::load_with_mode(path.to_str().unwrap(), 8, 2, OlmoeExecutionMode::SpikingSim)
+                .unwrap();
+        let mut embedding = vec![0.0f32; EMBEDDING_DIM];
+        embedding[0] = 1.0;
+        for _ in 0..8 {
+            let _ = model.forward(&embedding).unwrap();
+        }
+        assert!(model.has_state_activity());
+        model.reset_state();
+        assert!(!model.has_state_activity());
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_removed_old_weight_symbol() {
+        let source = std::fs::read_to_string(file!()).unwrap();
+        let pattern = ["pseudo", "_weight"].concat();
+        assert!(!source.contains(&pattern));
+    }
+
+    #[test]
+    fn test_real_checkpoint_probe_via_env() {
+        let Some(path) = std::env::var("OLMOE_PATH").ok() else {
+            return;
+        };
+
+        let (metadata, checkpoint) = OLMoE::probe_and_map(&path).unwrap();
+        assert_eq!(metadata.hidden_size, 2048);
+        assert_eq!(metadata.num_experts, 64);
+        let routing = checkpoint.tensor_info(ROUTING_TENSOR_NAME, &path).unwrap();
+        assert_eq!(routing.dims, vec![2048, 64]);
+        let synapse = checkpoint
+            .tensor_info(DEFAULT_GPU_SYNAPSE_TENSOR_NAME, &path)
+            .unwrap();
+        assert_eq!(synapse.dims, vec![2048, 2048]);
+    }
+
+    #[test]
+    fn test_registered_gpu_upload_via_env() {
+        let Some(path) = std::env::var("OLMOE_PATH").ok() else {
+            return;
+        };
+        if !crate::gpu::GpuContext::is_available() {
+            return;
+        }
+
+        let mut accelerator = GpuAccelerator::new();
+        if !accelerator.is_ready() {
+            return;
+        }
+
+        let mut model = OLMoE::load_with_mode(&path, 8, 1, OlmoeExecutionMode::DenseSim).unwrap();
+        accelerator.ensure_temporal_state(OLMOE_HIDDEN).unwrap();
+        let weights = model
+            .registered_gpu_synapse_weights(DEFAULT_GPU_SYNAPSE_TENSOR_NAME)
+            .unwrap();
+        accelerator
+            .load_synapse_weights_f16_registered("env::blk.0.attn_q.weight", weights)
+            .unwrap();
+        assert_eq!(
+            accelerator.synapse_signature(),
+            Some("env::blk.0.attn_q.weight")
+        );
     }
 }

--- a/src/hybrid/projector.rs
+++ b/src/hybrid/projector.rs
@@ -112,12 +112,13 @@ impl Projector {
         let fan_in = feature_dim as f32;
         let fan_out = EMBEDDING_DIM as f32;
         let limit = (6.0_f32 / (fan_in + fan_out)).sqrt();
+        const GOLDEN_RATIO_FRAC: f32 = 1.618_034;
 
         // Deterministic Xavier-uniform init (no external rng dep needed).
         let mut weights = Vec::with_capacity(EMBEDDING_DIM * feature_dim);
         for i in 0..(EMBEDDING_DIM * feature_dim) {
             // Simple deterministic pseudo-random from index hash.
-            let t = ((i as f32 * 1.6180339887) % 1.0) * 2.0 - 1.0;
+            let t = ((i as f32 * GOLDEN_RATIO_FRAC) % 1.0) * 2.0 - 1.0;
             weights.push(t * limit);
         }
 
@@ -189,9 +190,8 @@ impl Projector {
         }
 
         // Update EMA for normalisation
-        for i in 0..self.snn_neurons {
-            self.rate_ema[i] =
-                self.ema_alpha * rates[i] + (1.0 - self.ema_alpha) * self.rate_ema[i];
+        for (ema, rate) in self.rate_ema.iter_mut().zip(rates.iter()) {
+            *ema = self.ema_alpha * *rate + (1.0 - self.ema_alpha) * *ema;
         }
 
         // 2. Temporal histogram bins (4 equal-width bins) [64 dims]
@@ -275,14 +275,14 @@ impl Projector {
     /// Dense W × f + b with tanh squash.  Used for all non-spiking modes.
     fn dense_linear_project(&self, features: &[f32]) -> Vec<f32> {
         let mut out = vec![0.0_f32; EMBEDDING_DIM];
-        for out_i in 0..EMBEDDING_DIM {
+        for (out_i, out_slot) in out.iter_mut().enumerate() {
             let mut acc = self.bias[out_i];
             let row_offset = out_i * self.feature_dim;
-            for in_j in 0..features.len().min(self.feature_dim) {
-                acc += self.weights[row_offset + in_j] * features[in_j];
+            for (in_j, feature) in features.iter().take(self.feature_dim).enumerate() {
+                acc += self.weights[row_offset + in_j] * *feature;
             }
             // Layer norm approximation: tanh squash keeps embedding bounded
-            out[out_i] = acc.tanh();
+            *out_slot = acc.tanh();
         }
         out
     }
@@ -300,20 +300,20 @@ impl Projector {
     fn spiking_linear_project(&mut self, features: &[f32]) -> Vec<f32> {
         let mut spikes = vec![0.0_f32; EMBEDDING_DIM];
         let activity_drive = features.iter().map(|v| v.abs()).fold(0.0_f32, f32::max);
-        for out_i in 0..EMBEDDING_DIM {
+        for (out_i, spike) in spikes.iter_mut().enumerate() {
             let mut acc = self.bias[out_i];
             let row_offset = out_i * self.feature_dim;
-            for in_j in 0..features.len().min(self.feature_dim) {
-                acc += self.weights[row_offset + in_j] * features[in_j];
+            for (in_j, feature) in features.iter().take(self.feature_dim).enumerate() {
+                acc += self.weights[row_offset + in_j] * *feature;
             }
             // GIF integration step
             let drive = (acc.tanh() * 0.5 + activity_drive * 0.5).clamp(-1.0, 1.0);
             self.membrane[out_i] = self.membrane[out_i] * self.decay + drive * 0.35;
             if self.membrane[out_i] > self.threshold {
-                spikes[out_i] = 1.0;
+                *spike = 1.0;
                 self.membrane[out_i] -= self.threshold;   // reset-with-refractory
             } else if self.membrane[out_i] < -self.threshold {
-                spikes[out_i] = -1.0;
+                *spike = -1.0;
                 self.membrane[out_i] += self.threshold;
             }
             // else spikes[out_i] remains 0.0

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,6 +25,7 @@ impl TelemetrySnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HybridConfig {
     pub olmoe_model_path: String,
+    pub gpu_synapse_tensor_name: String,
     pub num_experts: usize,
     pub top_k_experts: usize,
     pub olmoe_execution_mode: OlmoeExecutionMode,
@@ -36,6 +37,7 @@ impl Default for HybridConfig {
     fn default() -> Self {
         Self {
             olmoe_model_path: String::new(),
+            gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
             num_experts: 8,
             top_k_experts: 1,
             olmoe_execution_mode: OlmoeExecutionMode::SpikingSim,
@@ -46,32 +48,22 @@ impl Default for HybridConfig {
 }
 
 /// Strategy used to convert spike activity into an OLMoE embedding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ProjectionMode {
     RateSum,
     TemporalHistogram,
     MembraneSnapshot,
+    #[default]
     SpikingTernary,
 }
 
-impl Default for ProjectionMode {
-    fn default() -> Self {
-        Self::SpikingTernary
-    }
-}
-
 /// Execution mode used by the OLMoE router.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum OlmoeExecutionMode {
     StubUniform,
     DenseSim,
+    #[default]
     SpikingSim,
-}
-
-impl Default for OlmoeExecutionMode {
-    fn default() -> Self {
-        Self::SpikingSim
-    }
 }
 
 /// Output of one `HybridModel::forward` pass.


### PR DESCRIPTION
## **User description**
## Summary
- replace the header-only OLMoE GGUF probe with a first-block mmap loader
- use real `blk.0.ffn_gate_inp.weight` routing weights and seed the GPU temporal synapse matrix from `blk.0.attn_q.weight`
- add CUDA host registration, resident f16 synapse uploads, and a `gif_step_weighted_f16` kernel path
- stop rebuilding dummy synapse weights on every temporal forward and reuse device-resident weights across calls
- clean up workspace diagnostics so `cargo clippy --all-targets --all-features` is clean

## Implementation
- add a GGUF v3 parser/mmap bridge in `src/hybrid/olmoe.rs` with tensor metadata validation and borrowed tensor views
- register the mapped GGUF tensor pages with `cuMemHostRegister_v2` and expose an f16 upload path for the accelerator
- initialize CUDA with `MAP_HOST | SCHED_AUTO` and extend the accelerator to cache resident synapse precision/signatures
- replace pseudo routing with real gate-score computation and keep the current first-block scope by using route-weighted passthrough hidden outputs
- update examples and config to carry `gpu_synapse_tensor_name`, defaulting to `blk.0.attn_q.weight`

## Verification
- `cargo check --all-targets --message-format=short`
- `cargo test`
- `cargo test --no-run`
- `cargo clippy --all-targets --all-features --message-format=short`
- `OLMOE_PATH=/home/raulmc/Downloads/SNN_Quanization/olmoe-0125-gguf/30dd013012d19b372bd71b825eea618140f9b3f1b72122efd4e78e29d6138545 cargo test -q test_real_checkpoint_probe_via_env -- --nocapture`
- `OLMOE_PATH=/home/raulmc/Downloads/SNN_Quanization/olmoe-0125-gguf/30dd013012d19b372bd71b825eea618140f9b3f1b72122efd4e78e29d6138545 cargo test -q test_registered_gpu_upload_via_env -- --nocapture`


___

## **CodeAnt-AI Description**
**Load real OLMoE routing and synapse weights from GGUF for GPU runs**

### What Changed
- OLMoE now reads the first GGUF block directly, uses the real `blk.0.ffn_gate_inp.weight` routing tensor, and rejects checkpoints that do not contain the expected tensors
- GPU temporal runs now load a real FP16 synapse tensor from the model instead of rebuilding dummy weights on every forward pass
- The GPU path now uses a dedicated FP16 kernel when registered FP16 synapse weights are loaded, and keeps reusing the same loaded weights across calls when possible
- Example apps and hybrid config now default to `blk.0.attn_q.weight` for the GPU synapse tensor name
- CUDA context setup now enables host-mapped memory support for the checkpoint bridge

### Impact
`✅ Real checkpoint-backed routing`
`✅ Fewer repeated GPU weight uploads`
`✅ Clearer model-loading failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=xIPihilmPgkouiS-lR9cabVUqfKo735j96T4GN11zPw&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
