### PR TITLE
gpu: add Blackwell kernel shim launch path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,64 @@
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const PTX_STUB: &str = ".version 8.5\n.target sm_80\n.address_size 64\n";
+const MYELIN_SHIM_STUB: &str = r#"
+#include <stdint.h>
+
+int myelin_launch_gif_step_weighted_f16(
+    void* stream,
+    unsigned int grid_x,
+    unsigned int block_x,
+    unsigned int shared_bytes,
+    void* membrane,
+    void* adaptation,
+    void* weights,
+    void* input_spikes,
+    void* refractory,
+    void* spikes_out,
+    int n_neurons,
+    int n_inputs)
+{
+    (void)stream;
+    (void)grid_x;
+    (void)block_x;
+    (void)shared_bytes;
+    (void)membrane;
+    (void)adaptation;
+    (void)weights;
+    (void)input_spikes;
+    (void)refractory;
+    (void)spikes_out;
+    (void)n_neurons;
+    (void)n_inputs;
+    return 1;
+}
+
+int myelin_launch_saaq_find_best_walker(
+    void* stream,
+    unsigned int grid_x,
+    unsigned int block_x,
+    unsigned int shared_bytes,
+    void* membrane,
+    void* adaptation,
+    void* best_walker_out,
+    int n_neurons,
+    float adaptation_scale)
+{
+    (void)stream;
+    (void)grid_x;
+    (void)block_x;
+    (void)shared_bytes;
+    (void)membrane;
+    (void)adaptation;
+    (void)best_walker_out;
+    (void)n_neurons;
+    (void)adaptation_scale;
+    return 1;
+}
+"#;
 
 fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -14,7 +69,12 @@ fn main() {
     println!("cargo:rerun-if-changed=src/gpu/kernels/spiking_network.cu");
     println!("cargo:rerun-if-changed=src/gpu/kernels/vector_similarity.cu");
     println!("cargo:rerun-if-changed=src/gpu/kernels/satsolver.cu");
+    println!("cargo:rerun-if-changed=src/gpu/kernels/myelin_shim.h");
+    println!("cargo:rerun-if-changed=src/gpu/kernels/myelin_shim.cu");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=CUDA_PATH");
+    println!("cargo:rerun-if-env-changed=NVCC");
 
     let kernels: &[(&str, &str)] = &[
         ("spiking_network.cu", "spiking_network_sm_120.ptx"),
@@ -22,48 +82,42 @@ fn main() {
         ("satsolver.cu", "satsolver_sm_120.ptx"),
     ];
 
-    let nvcc_ok = Command::new("nvcc")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-
-    if !nvcc_ok {
+    let Some(nvcc) = find_nvcc() else {
         println!(
-            "cargo:warning=nvcc not found — writing stub PTX files; GPU unavailable at runtime"
+            "cargo:warning=nvcc not found — writing stub PTX files and building shim stubs; GPU unavailable at runtime"
         );
         for &(_, ptx_name) in kernels {
             fs::write(out_dir.join(ptx_name), PTX_STUB)
                 .unwrap_or_else(|e| panic!("Failed to write stub PTX {ptx_name}: {e}"));
         }
+        build_myelin_shim_stub(&out_dir);
         return;
-    }
+    };
 
     for &(cu_name, ptx_name) in kernels {
         let source = cu_dir.join(cu_name);
         let output = out_dir.join(ptx_name);
 
-        let status = Command::new("nvcc")
-            .arg("-ptx")
-            .arg("-arch=sm_120")
-            .arg("-O3")
-            .arg("--use_fast_math")
-            .arg("--restrict")
-            .arg("--threads")
-            .arg("0")
-            .arg("-D__STRICT_ANSI__")
-            .arg("--allow-unsupported-compiler")
-            .arg("-I")
-            .arg(&cu_dir)
-            .arg("-o")
-            .arg(&output)
-            .arg(&source)
-            .status()
-            .unwrap_or_else(|e| panic!("Failed to invoke nvcc for {cu_name}: {e}"));
-
-        if !status.success() {
-            panic!("nvcc failed to compile {cu_name} → {ptx_name}");
-        }
+        run_nvcc(
+            &nvcc,
+            &[
+                "-ptx".into(),
+                "-arch=sm_120".into(),
+                "-O3".into(),
+                "--use_fast_math".into(),
+                "--restrict".into(),
+                "--threads".into(),
+                "0".into(),
+                "-D__STRICT_ANSI__".into(),
+                "--allow-unsupported-compiler".into(),
+                "-I".into(),
+                cu_dir.display().to_string(),
+                "-o".into(),
+                output.display().to_string(),
+                source.display().to_string(),
+            ],
+            cu_name,
+        );
 
         if !output.exists() {
             panic!("nvcc completed but {ptx_name} was not produced");
@@ -74,6 +128,9 @@ fn main() {
 
         println!("cargo:warning=✓ compiled {cu_name} → {ptx_name} (PTX version patched to 8.5)");
     }
+
+    build_myelin_shim(&nvcc, &cu_dir, &out_dir);
+    emit_cuda_runtime_linking(&nvcc);
 }
 
 fn patch_ptx_version(path: &std::path::Path, old_ver: &str, new_ver: &str) {
@@ -87,4 +144,120 @@ fn patch_ptx_version(path: &std::path::Path, old_ver: &str, new_ver: &str) {
         fs::write(path, patched)
             .unwrap_or_else(|e| panic!("Failed to patch PTX version in {}: {e}", path.display()));
     }
+}
+
+fn find_nvcc() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("NVCC") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    Command::new("sh")
+        .args(["-lc", "command -v nvcc"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            let path = String::from_utf8(output.stdout).ok()?;
+            let trimmed = path.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(trimmed))
+            }
+        })
+}
+
+fn run_nvcc(nvcc: &Path, args: &[String], label: &str) {
+    let status = Command::new(nvcc)
+        .args(args)
+        .status()
+        .unwrap_or_else(|e| panic!("Failed to invoke nvcc for {label}: {e}"));
+
+    if !status.success() {
+        panic!("nvcc failed while building {label}");
+    }
+}
+
+fn build_myelin_shim(nvcc: &Path, cu_dir: &Path, out_dir: &Path) {
+    let source = cu_dir.join("myelin_shim.cu");
+    let object = out_dir.join("myelin_shim.o");
+
+    run_nvcc(
+        nvcc,
+        &[
+            "-c".into(),
+            "-arch=sm_120".into(),
+            "-O3".into(),
+            "--use_fast_math".into(),
+            "--restrict".into(),
+            "--threads".into(),
+            "0".into(),
+            "--allow-unsupported-compiler".into(),
+            "-I".into(),
+            cu_dir.display().to_string(),
+            "-Xcompiler".into(),
+            "-fPIC".into(),
+            "-o".into(),
+            object.display().to_string(),
+            source.display().to_string(),
+        ],
+        "myelin_shim.cu",
+    );
+
+    cc::Build::new().cpp(true).object(&object).compile("myelin_shim");
+    println!("cargo:warning=✓ compiled myelin_shim.cu → libmyelin_shim.a");
+}
+
+fn build_myelin_shim_stub(out_dir: &Path) {
+    let stub_path = out_dir.join("myelin_shim_stub.c");
+    fs::write(&stub_path, MYELIN_SHIM_STUB)
+        .unwrap_or_else(|e| panic!("Failed to write myelin shim stub: {e}"));
+
+    cc::Build::new().file(&stub_path).compile("myelin_shim");
+    println!("cargo:warning=✓ compiled myelin shim stub → libmyelin_shim.a");
+}
+
+fn emit_cuda_runtime_linking(nvcc: &Path) {
+    for search_dir in cuda_library_search_paths(nvcc) {
+        println!("cargo:rustc-link-search=native={}", search_dir.display());
+    }
+    println!("cargo:rustc-link-lib=dylib=cudart");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    }
+}
+
+fn cuda_library_search_paths(nvcc: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    for env_var in ["CUDA_HOME", "CUDA_PATH"] {
+        if let Some(root) = env::var_os(env_var) {
+            let root = PathBuf::from(root);
+            candidates.push(root.join("lib64"));
+            candidates.push(root.join("lib"));
+            candidates.push(root.join("targets").join("x86_64-linux").join("lib"));
+        }
+    }
+
+    if let Some(root) = nvcc.parent().and_then(|bin| bin.parent()) {
+        candidates.push(root.join("lib64"));
+        candidates.push(root.join("lib"));
+        candidates.push(root.join("targets").join("x86_64-linux").join("lib"));
+    }
+
+    candidates.push(PathBuf::from("/usr/local/cuda/lib64"));
+    candidates.push(PathBuf::from("/usr/local/cuda/lib"));
+    candidates.push(PathBuf::from("/usr/lib/x86_64-linux-gnu"));
+
+    let mut deduped = Vec::new();
+    for candidate in candidates {
+        if candidate.exists() && !deduped.iter().any(|existing| existing == &candidate) {
+            deduped.push(candidate);
+        }
+    }
+    deduped
 }

--- a/src/gpu/kernels/myelin_shim.cu
+++ b/src/gpu/kernels/myelin_shim.cu
@@ -1,0 +1,64 @@
+#include "myelin_shim.h"
+
+#include "spiking_network.cu"
+
+extern "C" int myelin_launch_gif_step_weighted_f16(
+    void* stream,
+    unsigned int grid_x,
+    unsigned int block_x,
+    unsigned int shared_bytes,
+    void* membrane,
+    void* adaptation,
+    void* weights,
+    void* input_spikes,
+    void* refractory,
+    void* spikes_out,
+    int n_neurons,
+    int n_inputs)
+{
+    cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    float* membrane_ptr = reinterpret_cast<float*>(membrane);
+    float* adaptation_ptr = reinterpret_cast<float*>(adaptation);
+    const half* weights_ptr = reinterpret_cast<const half*>(weights);
+    const float* input_spikes_ptr = reinterpret_cast<const float*>(input_spikes);
+    unsigned int* refractory_ptr = reinterpret_cast<unsigned int*>(refractory);
+    unsigned int* spikes_out_ptr = reinterpret_cast<unsigned int*>(spikes_out);
+
+    gif_step_weighted_f16<<<grid_x, block_x, shared_bytes, cuda_stream>>>(
+        membrane_ptr,
+        adaptation_ptr,
+        weights_ptr,
+        input_spikes_ptr,
+        refractory_ptr,
+        spikes_out_ptr,
+        n_neurons,
+        n_inputs);
+
+    return static_cast<int>(cudaGetLastError());
+}
+
+extern "C" int myelin_launch_saaq_find_best_walker(
+    void* stream,
+    unsigned int grid_x,
+    unsigned int block_x,
+    unsigned int shared_bytes,
+    void* membrane,
+    void* adaptation,
+    void* best_walker_out,
+    int n_neurons,
+    float adaptation_scale)
+{
+    cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    const float* membrane_ptr = reinterpret_cast<const float*>(membrane);
+    const float* adaptation_ptr = reinterpret_cast<const float*>(adaptation);
+    unsigned int* best_walker_ptr = reinterpret_cast<unsigned int*>(best_walker_out);
+
+    saaq_find_best_walker<<<grid_x, block_x, shared_bytes, cuda_stream>>>(
+        membrane_ptr,
+        adaptation_ptr,
+        best_walker_ptr,
+        n_neurons,
+        adaptation_scale);
+
+    return static_cast<int>(cudaGetLastError());
+}

--- a/src/gpu/kernels/myelin_shim.h
+++ b/src/gpu/kernels/myelin_shim.h
@@ -1,0 +1,37 @@
+#ifndef MYELIN_SHIM_H
+#define MYELIN_SHIM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int myelin_launch_gif_step_weighted_f16(
+    void* stream,
+    unsigned int grid_x,
+    unsigned int block_x,
+    unsigned int shared_bytes,
+    void* membrane,
+    void* adaptation,
+    void* weights,
+    void* input_spikes,
+    void* refractory,
+    void* spikes_out,
+    int n_neurons,
+    int n_inputs);
+
+int myelin_launch_saaq_find_best_walker(
+    void* stream,
+    unsigned int grid_x,
+    unsigned int block_x,
+    unsigned int shared_bytes,
+    void* membrane,
+    void* adaptation,
+    void* best_walker_out,
+    int n_neurons,
+    float adaptation_scale);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MYELIN_SHIM_H

--- a/src/gpu/kernels/spiking_network.cu
+++ b/src/gpu/kernels/spiking_network.cu
@@ -319,7 +319,7 @@ extern "C" __global__
 void gif_step_weighted_f16(
     float* __restrict__        membrane,
     float* __restrict__        adaptation,
-    const unsigned short* __restrict__ weights,
+    const half* __restrict__   weights,
     const float* __restrict__  input_spikes,
     unsigned int* __restrict__ refract,
     unsigned int* __restrict__ spikes_out,
@@ -347,12 +347,10 @@ void gif_step_weighted_f16(
     } else {
         a *= GIF_ADAPTATION_DECAY;
 
-        const unsigned short* w_row = weights + (long)tid * n_inputs;
+        const half* w_row = weights + (long)tid * n_inputs;
         float drive = 0.0f;
-        for (int j = 0; j < n_inputs; ++j) {
-            float w = __half2float(*reinterpret_cast<const __half*>(&w_row[j]));
-            drive = fmaf(w, s_inputs[j], drive);
-        }
+        for (int j = 0; j < n_inputs; ++j)
+            drive = fmaf(__half2float(w_row[j]), s_inputs[j], drive);
 
         v = v * GIF_LEAK + drive * GIF_DRIVE_SCALE - a * GIF_ADAPTATION_TERM;
 

--- a/src/gpu/wrappers/accelerator.rs
+++ b/src/gpu/wrappers/accelerator.rs
@@ -11,6 +11,7 @@
 
 use super::context::GpuContext;
 use super::error::{GpuError, GpuResult};
+use super::ffi;
 use super::kernel::KernelModule;
 use super::memory::GpuBuffer;
 use crate::types::TelemetrySnapshot;
@@ -328,15 +329,11 @@ impl GpuAccelerator {
             .temporal_state
             .as_mut()
             .ok_or_else(|| GpuError::MemoryError("temporal state not initialised".into()))?;
-        let gif_step = match state.synapse_precision {
-            SynapsePrecision::F32 => modules.get_function("gif_step_weighted")?,
-            SynapsePrecision::F16 => modules.get_function("gif_step_weighted_f16")?,
-            SynapsePrecision::None => {
-                return Err(GpuError::MemoryError(
-                    "synapse weights must be loaded before gif_step_weighted_tick".into(),
-                ));
-            }
-        };
+        if state.synapse_precision == SynapsePrecision::None {
+            return Err(GpuError::MemoryError(
+                "synapse weights must be loaded before gif_step_weighted_tick".into(),
+            ));
+        }
         let stream = Self::new_stream()?;
         // Hardcoded Blackwell alignment: 8 blocks * 256 threads = 2048 neurons exact.
         // This maxes L1/shared memory bandwidth without warp divergence on sm_120.
@@ -346,6 +343,7 @@ impl GpuAccelerator {
         unsafe {
             match state.synapse_precision {
                 SynapsePrecision::F32 => {
+                    let gif_step = modules.get_function("gif_step_weighted")?;
                     launch!(gif_step<<<grid, TEMPORAL_BLOCK_SIZE, shared_bytes, stream>>>(
                         state.membrane.as_device_ptr(),
                         state.adaptation.as_device_ptr(),
@@ -364,7 +362,11 @@ impl GpuAccelerator {
                     let weights_f16 = state.weights_f16.as_ref().ok_or_else(|| {
                         GpuError::MemoryError("f16 synapse buffer not initialised".into())
                     })?;
-                    launch!(gif_step<<<grid, TEMPORAL_BLOCK_SIZE, shared_bytes, stream>>>(
+                    ffi::launch_gif_step_weighted_f16(
+                        &stream,
+                        grid,
+                        TEMPORAL_BLOCK_SIZE,
+                        shared_bytes,
                         state.membrane.as_device_ptr(),
                         state.adaptation.as_device_ptr(),
                         weights_f16.as_device_ptr(),
@@ -372,11 +374,8 @@ impl GpuAccelerator {
                         state.refractory.as_device_ptr(),
                         state.spikes_out.as_device_ptr(),
                         neuron_count as i32,
-                        state.n_inputs as i32
-                    ))
-                    .map_err(|e| {
-                        GpuError::LaunchFailed(format!("gif_step_weighted_f16 launch: {e:?}"))
-                    })?;
+                        state.n_inputs as i32,
+                    )?;
                 }
                 SynapsePrecision::None => unreachable!("validated above"),
             }
@@ -523,8 +522,6 @@ impl GpuAccelerator {
     ) -> GpuResult<u32> {
         self.ensure_temporal_state(neuron_count)?;
 
-        let modules = self.modules.as_ref().ok_or(GpuError::NoGpu)?;
-        let saaq_kernel = modules.get_function("saaq_find_best_walker")?;
         let state = self
             .temporal_state
             .as_mut()
@@ -532,16 +529,17 @@ impl GpuAccelerator {
 
         let adaptation_scale = 0.22f32; // matches GIF_ADAPTATION_SCALE from spiking_network.cu
 
-        unsafe {
-            launch!(saaq_kernel<<<TEMPORAL_GRID_SIZE, TEMPORAL_BLOCK_SIZE, 0, stream>>>(
-                state.membrane.as_device_ptr(),
-                state.adaptation.as_device_ptr(),
-                state.best_walker.as_device_ptr(),
-                neuron_count as i32,
-                adaptation_scale
-            ))
-            .map_err(|e| GpuError::LaunchFailed(format!("saaq_find_best_walker launch: {e:?}")))?;
-        }
+        ffi::launch_saaq_find_best_walker(
+            stream,
+            TEMPORAL_GRID_SIZE,
+            TEMPORAL_BLOCK_SIZE,
+            0,
+            state.membrane.as_device_ptr(),
+            state.adaptation.as_device_ptr(),
+            state.best_walker.as_device_ptr(),
+            neuron_count as i32,
+            adaptation_scale,
+        )?;
 
         stream
             .synchronize()

--- a/src/gpu/wrappers/ffi.rs
+++ b/src/gpu/wrappers/ffi.rs
@@ -1,0 +1,121 @@
+// ════════════════════════════════════════════════════════════════════
+//  gpu/ffi.rs — C ABI shim wrappers for Blackwell-critical kernels
+//
+//  Most kernels still launch through PTX/JIT in kernel.rs. The two
+//  latency-critical Blackwell paths below launch through a linked CUDA
+//  shim so Rust can pass raw driver handles into a runtime `<<<>>>` call.
+// ════════════════════════════════════════════════════════════════════
+
+use super::error::{GpuError, GpuResult};
+use cust::memory::{DeviceCopy, DevicePointer};
+use cust::stream::Stream;
+use std::ffi::c_void;
+
+unsafe extern "C" {
+    fn myelin_launch_gif_step_weighted_f16(
+        stream: *mut c_void,
+        grid_x: u32,
+        block_x: u32,
+        shared_bytes: u32,
+        membrane: *mut c_void,
+        adaptation: *mut c_void,
+        weights: *mut c_void,
+        input_spikes: *mut c_void,
+        refractory: *mut c_void,
+        spikes_out: *mut c_void,
+        n_neurons: i32,
+        n_inputs: i32,
+    ) -> i32;
+
+    fn myelin_launch_saaq_find_best_walker(
+        stream: *mut c_void,
+        grid_x: u32,
+        block_x: u32,
+        shared_bytes: u32,
+        membrane: *mut c_void,
+        adaptation: *mut c_void,
+        best_walker_out: *mut c_void,
+        n_neurons: i32,
+        adaptation_scale: f32,
+    ) -> i32;
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn launch_gif_step_weighted_f16(
+    stream: &Stream,
+    grid_x: u32,
+    block_x: u32,
+    shared_bytes: u32,
+    membrane: DevicePointer<f32>,
+    adaptation: DevicePointer<f32>,
+    weights: DevicePointer<u16>,
+    input_spikes: DevicePointer<f32>,
+    refractory: DevicePointer<u32>,
+    spikes_out: DevicePointer<u32>,
+    n_neurons: i32,
+    n_inputs: i32,
+) -> GpuResult<()> {
+    let code = unsafe {
+        myelin_launch_gif_step_weighted_f16(
+            stream.as_inner().cast::<c_void>(),
+            grid_x,
+            block_x,
+            shared_bytes,
+            device_ptr_to_void(membrane),
+            device_ptr_to_void(adaptation),
+            device_ptr_to_void(weights),
+            device_ptr_to_void(input_spikes),
+            device_ptr_to_void(refractory),
+            device_ptr_to_void(spikes_out),
+            n_neurons,
+            n_inputs,
+        )
+    };
+
+    if code == 0 {
+        Ok(())
+    } else {
+        Err(GpuError::LaunchFailed(format!(
+            "myelin_launch_gif_step_weighted_f16 failed with CUDA runtime error code {code}"
+        )))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn launch_saaq_find_best_walker(
+    stream: &Stream,
+    grid_x: u32,
+    block_x: u32,
+    shared_bytes: u32,
+    membrane: DevicePointer<f32>,
+    adaptation: DevicePointer<f32>,
+    best_walker_out: DevicePointer<u32>,
+    n_neurons: i32,
+    adaptation_scale: f32,
+) -> GpuResult<()> {
+    let code = unsafe {
+        myelin_launch_saaq_find_best_walker(
+            stream.as_inner().cast::<c_void>(),
+            grid_x,
+            block_x,
+            shared_bytes,
+            device_ptr_to_void(membrane),
+            device_ptr_to_void(adaptation),
+            device_ptr_to_void(best_walker_out),
+            n_neurons,
+            adaptation_scale,
+        )
+    };
+
+    if code == 0 {
+        Ok(())
+    } else {
+        Err(GpuError::LaunchFailed(format!(
+            "myelin_launch_saaq_find_best_walker failed with CUDA runtime error code {code}"
+        )))
+    }
+}
+
+fn device_ptr_to_void<T: DeviceCopy>(ptr: DevicePointer<T>) -> *mut c_void {
+    ptr.as_raw() as usize as *mut c_void
+}

--- a/src/gpu/wrappers/kernel.rs
+++ b/src/gpu/wrappers/kernel.rs
@@ -3,7 +3,9 @@
 //
 //  PTX files are compiled by myelin-accelerator/build.rs into OUT_DIR
 //  and embedded at compile time with include_str!.  There is no runtime
-//  file-system lookup — the bytes travel with the binary.
+//  file-system lookup — the bytes travel with the binary. Most kernels
+//  launch through PTX/JIT; the Blackwell-critical F16 GIF and SAAQ paths
+//  launch through a linked C ABI shim in ffi.rs instead.
 // ════════════════════════════════════════════════════════════════════
 
 use super::error::{GpuError, GpuResult};
@@ -66,7 +68,6 @@ impl KernelModule {
                 "lif_step",
                 "lif_step_weighted",
                 "gif_step_weighted",
-                "gif_step_weighted_f16",
                 "spike_rate",
                 "reset_membrane",
                 "stdp_update",
@@ -74,7 +75,6 @@ impl KernelModule {
                 "membrane_dv_dt_reduce_pass1",
                 "routing_entropy_reduce_pass1",
                 "latent_reduce_pass2",
-                "saaq_find_best_walker",
             ],
         )?;
 

--- a/src/gpu/wrappers/mod.rs
+++ b/src/gpu/wrappers/mod.rs
@@ -5,6 +5,7 @@
 pub mod accelerator;
 pub mod context;
 pub mod error;
+mod ffi;
 pub mod kernel;
 pub mod memory;
 


### PR DESCRIPTION
## **User description**
## Summary
- add an in-tree C ABI shim for the Blackwell-critical `gif_step_weighted_f16` and `saaq_find_best_walker` kernels
- compile and link the shim from `build.rs` with strict `-arch=sm_120`, plus a stub shim path when `nvcc` is unavailable
- route only the FP16 GIF temporal path and SAAQ reducer through Rust FFI, while keeping the rest of the GPU stack on PTX/JIT

## Validation
- `cargo check --all-targets`
- `cargo test --no-run`
- `cargo clippy --all-targets --all-features`
- `cargo test -q`


___

## **CodeAnt-AI Description**
**Route the Blackwell GIF F16 and SAAQ GPU paths through a linked shim**

### What Changed
- The F16 GIF step and SAAQ walker selection now launch through a CUDA shim instead of the usual PTX path
- The rest of the GPU kernels still use the existing PTX/JIT launch flow
- If `nvcc` is unavailable, the build now produces stub GPU artifacts so the project can still build, while GPU work remains unavailable at runtime
- The F16 GIF kernel now uses direct half-precision input handling inside the CUDA code

### Impact
`✅ Fewer Blackwell kernel launch failures`
`✅ Cleaner GPU startup on systems without nvcc`
`✅ Preserved existing PTX launches for the rest of the GPU stack`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=llMEJMg8AuV1MyFKsnSzyX_eC-bfBUmNROOy6i66Wqg&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
