### PR TITLE
gpu: add real hardware smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ let output = model.forward_gpu_temporal(&mut accelerator, &TelemetrySnapshot::de
 // GIF adaptation drives sparsity pruning; CSV now logs spike_count, mean_adaptation, active_fraction for VRAM optimization and Julia symbolic regression
 ```
 
+## GPU Smoke Test
+
+To validate the actual Blackwell temporal path on hardware, use the dedicated smoke test:
+
+```bash
+OLMOE_PATH=/path/to/gguf cargo run --release --example gpu_smoke_test
+```
+
+This example exercises:
+
+- GGUF mmap plus `cuMemHostRegister_v2` host registration for `blk.0.attn_q.weight`
+- resident FP16 synapse upload into the GPU temporal state
+- `gif_step_weighted_f16`
+- the two-pass SAAQ reduction returning `best_walker`
+- per-tick timing output in microseconds
+
+This is the correct example for validating the real GPU temporal path. `saaq_latent_calibration` is CPU-side calibration logic and does not exercise the direct GPU temporal loop.
+
 ## OLMoE Modes
 
 | Mode | Behavior |

--- a/examples/gpu_smoke_test.rs
+++ b/examples/gpu_smoke_test.rs
@@ -1,0 +1,70 @@
+use corinth_canal::{
+    HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode, gpu::GpuAccelerator,
+};
+use std::io::Error;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model_path = std::env::var("OLMOE_PATH").unwrap_or_default();
+    if model_path.trim().is_empty() {
+        eprintln!("OLMOE_PATH must point to a GGUF checkpoint");
+        std::process::exit(1);
+    }
+
+    let mut accelerator = GpuAccelerator::new();
+    let mut model = HybridModel::new(HybridConfig {
+        olmoe_model_path: model_path.clone(),
+        gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
+        num_experts: 8,
+        top_k_experts: 1,
+        olmoe_execution_mode: OlmoeExecutionMode::SpikingSim,
+        snn_steps: 1,
+        projection_mode: ProjectionMode::SpikingTernary,
+    })?;
+
+    let target_neurons = model.projector_mut().input_neurons();
+    println!(
+        "startup model_path={} olmoe_loaded={} gpu_ready={} target_neurons={}",
+        model_path,
+        model.olmoe_loaded(),
+        accelerator.is_ready(),
+        target_neurons,
+    );
+
+    if !model.olmoe_loaded() {
+        return Err(Error::other("OLMoE model did not load from OLMOE_PATH").into());
+    }
+    if !accelerator.is_ready() {
+        return Err(Error::other("GpuAccelerator is not ready").into());
+    }
+
+    model.prepare_gpu_temporal(&mut accelerator)?;
+    println!("prepared gguf-backed temporal path; beginning 10 direct GPU ticks");
+
+    for tick in 0..10usize {
+        let phase = tick as f32 * 0.31;
+        let input_spikes: Vec<f32> = (0..target_neurons)
+            .map(|i| {
+                let wave = (i as f32 * 0.017 + phase).sin();
+                0.1 * (wave + 1.0) * 0.5
+            })
+            .collect();
+
+        let started = Instant::now();
+        let best_walker = model.tick_gpu_temporal(&mut accelerator, &input_spikes)?;
+        let elapsed_us = started.elapsed().as_micros();
+        println!(
+            "tick={} best_walker={} elapsed_us={}",
+            tick + 1,
+            best_walker,
+            elapsed_us
+        );
+    }
+
+    println!("completed 10 GPU ticks; dropping model before accelerator");
+    drop(model);
+    drop(accelerator);
+    println!("gpu smoke test finished cleanly");
+
+    Ok(())
+}

--- a/src/gpu/wrappers/accelerator.rs
+++ b/src/gpu/wrappers/accelerator.rs
@@ -91,9 +91,15 @@ impl GpuAccelerator {
         }
     }
 
-    /// `true` if a GPU context and all PTX modules are ready.
+    fn has_context(&self) -> bool {
+        self._ctx.is_some()
+    }
+
+    /// `true` if a CUDA context is available. PTX-backed helpers may still be
+    /// unavailable if module loading failed, but the shim-backed temporal F16
+    /// path can still run.
     pub fn is_ready(&self) -> bool {
-        self._ctx.is_some() && self.modules.is_some()
+        self.has_context()
     }
 
     /// Borrow the loaded kernel module, or return an error.
@@ -102,7 +108,7 @@ impl GpuAccelerator {
     }
 
     pub fn ensure_temporal_state(&mut self, neuron_count: usize) -> GpuResult<()> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
         if neuron_count == 0 {
@@ -192,7 +198,7 @@ impl GpuAccelerator {
     }
 
     pub fn temporal_spikes_to_vec(&self, neuron_count: usize) -> GpuResult<Vec<u32>> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
         let state = self
@@ -204,7 +210,7 @@ impl GpuAccelerator {
     }
 
     pub fn temporal_membrane_to_vec(&self, neuron_count: usize) -> GpuResult<Vec<f32>> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
         let state = self
@@ -217,7 +223,7 @@ impl GpuAccelerator {
 
     /// Download current adaptation values (GIF state) from device.
     pub fn temporal_adaptation_to_vec(&self, neuron_count: usize) -> GpuResult<Vec<f32>> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
         let state = self
@@ -226,6 +232,28 @@ impl GpuAccelerator {
             .ok_or_else(|| GpuError::MemoryError("temporal state not initialised".into()))?;
         Self::expect_len("temporal adaptation", state.adaptation.len(), neuron_count)?;
         state.adaptation.to_vec()
+    }
+
+    /// Upload a per-neuron temporal input vector into the resident `input_spikes` buffer.
+    pub(crate) fn upload_temporal_input_spikes(&mut self, input_spikes: &[f32]) -> GpuResult<()> {
+        if !self.has_context() {
+            return Err(GpuError::NoGpu);
+        }
+        let state = self
+            .temporal_state
+            .as_mut()
+            .ok_or_else(|| GpuError::MemoryError("temporal state not initialised".into()))?;
+        if input_spikes.len() != state.n_inputs {
+            return Err(GpuError::MemoryError(format!(
+                "temporal input_spikes length mismatch: expected {}, got {}",
+                state.n_inputs,
+                input_spikes.len()
+            )));
+        }
+        state
+            .input_spikes
+            .upload(input_spikes)
+            .map_err(|e| GpuError::MemoryError(format!("input_spikes upload failed: {e}")))
     }
 
     /// Load synapse weight matrix for GIF weighted kernel. Must match neuron_count * n_inputs.
@@ -239,7 +267,7 @@ impl GpuAccelerator {
         signature: &str,
         weights: &[f32],
     ) -> GpuResult<()> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
         let state = self
@@ -277,7 +305,7 @@ impl GpuAccelerator {
         signature: &str,
         weights: &[u16],
     ) -> GpuResult<()> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
         let state = self
@@ -326,7 +354,6 @@ impl GpuAccelerator {
     pub fn gif_step_weighted_tick(&mut self, neuron_count: usize) -> GpuResult<u32> {
         self.ensure_temporal_state(neuron_count)?;
 
-        let modules = self.modules.as_ref().ok_or(GpuError::NoGpu)?;
         let state = self
             .temporal_state
             .as_mut()
@@ -345,6 +372,7 @@ impl GpuAccelerator {
         unsafe {
             match state.synapse_precision {
                 SynapsePrecision::F32 => {
+                    let modules = self.modules.as_ref().ok_or(GpuError::NoGpu)?;
                     let gif_step = modules.get_function("gif_step_weighted")?;
                     launch!(gif_step<<<grid, TEMPORAL_BLOCK_SIZE, shared_bytes, stream>>>(
                         state.membrane.as_device_ptr(),
@@ -390,32 +418,37 @@ impl GpuAccelerator {
     }
 
     pub fn reset_temporal_state(&mut self) -> GpuResult<()> {
-        if !self.is_ready() {
+        if !self.has_context() {
             return Err(GpuError::NoGpu);
         }
 
         let Some(state) = self.temporal_state.as_mut() else {
             return Ok(());
         };
+        if let Some(modules) = self.modules.as_ref() {
+            let reset_membrane = modules.get_function("reset_membrane")?;
+            let stream = Self::new_stream()?;
+            // Hardcoded Blackwell alignment for 2048 neurons
+            let grid = TEMPORAL_GRID_SIZE;
 
-        let modules = self.modules.as_ref().ok_or(GpuError::NoGpu)?;
-        let reset_membrane = modules.get_function("reset_membrane")?;
-        let stream = Self::new_stream()?;
-        // Hardcoded Blackwell alignment for 2048 neurons
-        let grid = TEMPORAL_GRID_SIZE;
+            unsafe {
+                launch!(reset_membrane<<<grid, TEMPORAL_BLOCK_SIZE, TEMPORAL_SHARED_MEM_BYTES, stream>>>(
+                    state.membrane.as_device_ptr(),
+                    state.neuron_count as i32,
+                    0.0f32
+                ))
+                .map_err(|e| GpuError::LaunchFailed(format!("reset_membrane launch: {e:?}")))?;
+            }
 
-        unsafe {
-            launch!(reset_membrane<<<grid, TEMPORAL_BLOCK_SIZE, TEMPORAL_SHARED_MEM_BYTES, stream>>>(
-                state.membrane.as_device_ptr(),
-                state.neuron_count as i32,
-                0.0f32
-            ))
-            .map_err(|e| GpuError::LaunchFailed(format!("reset_membrane launch: {e:?}")))?;
+            stream
+                .synchronize()
+                .map_err(|e| GpuError::LaunchFailed(format!("reset_membrane sync: {e:?}")))?;
+        } else {
+            state
+                .membrane
+                .upload(&vec![0.0f32; state.neuron_count])
+                .map_err(|e| GpuError::MemoryError(format!("reset membrane upload failed: {e}")))?;
         }
-
-        stream
-            .synchronize()
-            .map_err(|e| GpuError::LaunchFailed(format!("reset_membrane sync: {e:?}")))?;
 
         state
             .refractory

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -69,7 +69,11 @@ impl HybridModel {
 
     pub fn forward(&mut self, snap: &TelemetrySnapshot) -> Result<HybridOutput> {
         let (spike_train, potentials, iz_potentials) = self.synthetic_activity(snap);
-        self.forward_activity(spike_train.as_slice(), potentials.as_slice(), iz_potentials.as_slice())
+        self.forward_activity(
+            spike_train.as_slice(),
+            potentials.as_slice(),
+            iz_potentials.as_slice(),
+        )
     }
 
     pub fn forward_activity(
@@ -113,6 +117,34 @@ impl HybridModel {
     /// Phase 2: gif_step_weighted_tick (with adaptation, dynamic threshold, weighted synapses)
     /// Downloads membrane + adaptation; uses existing projector (GIF-compatible via SpikingTernary).
     /// Fails fast with GpuError::NoGpu if GPU unavailable (no CPU fallback).
+    pub fn prepare_gpu_temporal(&mut self, accelerator: &mut GpuAccelerator) -> GpuResult<()> {
+        let neuron_count = self.projector.input_neurons();
+        accelerator.ensure_temporal_state(neuron_count)?;
+        self.ensure_temporal_synapse_weights(accelerator, neuron_count)?;
+        accelerator.reset_temporal_state()
+    }
+
+    /// Execute exactly one GPU temporal tick using an explicit per-neuron input vector.
+    /// Leaves all temporal state resident so repeated calls form a stateful temporal loop.
+    pub fn tick_gpu_temporal(
+        &mut self,
+        accelerator: &mut GpuAccelerator,
+        input_spikes: &[f32],
+    ) -> GpuResult<u32> {
+        let neuron_count = self.projector.input_neurons();
+        if input_spikes.len() != neuron_count {
+            return Err(GpuError::MemoryError(format!(
+                "gpu temporal input length mismatch: expected {neuron_count}, got {}",
+                input_spikes.len()
+            )));
+        }
+
+        accelerator.ensure_temporal_state(neuron_count)?;
+        self.ensure_temporal_synapse_weights(accelerator, neuron_count)?;
+        accelerator.upload_temporal_input_spikes(input_spikes)?;
+        accelerator.gif_step_weighted_tick(neuron_count)
+    }
+
     pub fn forward_gpu_temporal(
         &mut self,
         accelerator: &mut GpuAccelerator,
@@ -506,6 +538,35 @@ mod tests {
             .forward_gpu_temporal(&mut accelerator, &snap)
             .unwrap_err();
         assert!(matches!(err, GpuError::NoGpu));
+    }
+
+    #[test]
+    fn test_tick_gpu_temporal_requires_gpu() {
+        let mut accelerator = GpuAccelerator::new_stub_for_tests();
+        let mut model = HybridModel::new(HybridConfig::default()).unwrap();
+        let input = vec![0.1_f32; N_NEURONS];
+
+        let err = model
+            .tick_gpu_temporal(&mut accelerator, &input)
+            .unwrap_err();
+        assert!(matches!(err, GpuError::NoGpu));
+    }
+
+    #[test]
+    fn test_tick_gpu_temporal_rejects_wrong_input_length() {
+        let mut accelerator = GpuAccelerator::new_stub_for_tests();
+        let mut model = HybridModel::new(HybridConfig::default()).unwrap();
+        let input = vec![0.1_f32; 64];
+
+        let err = model
+            .tick_gpu_temporal(&mut accelerator, &input)
+            .unwrap_err();
+        assert!(matches!(err, GpuError::MemoryError(_)));
+        assert!(
+            err.to_string()
+                .contains("gpu temporal input length mismatch"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/hybrid/olmoe.rs
+++ b/src/hybrid/olmoe.rs
@@ -2,11 +2,11 @@
 
 use crate::error::{HybridError, Result};
 use crate::types::{EMBEDDING_DIM, OlmoeExecutionMode};
-use memmap2::Mmap;
+use memmap2::{MmapMut, MmapOptions};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::fs::File;
+use std::fs::OpenOptions;
 use std::slice;
 
 const OLMOE_HIDDEN: usize = 2048;
@@ -64,7 +64,7 @@ pub struct OlmoeOutput {
 
 #[derive(Debug)]
 struct MappedOlmoeCheckpoint {
-    mmap: Mmap,
+    mmap: MmapMut,
     tensors: HashMap<String, GgufTensorInfo>,
     registered_gpu_synapse: Option<RegisteredTensorSliceU16>,
 }
@@ -191,14 +191,22 @@ impl OLMoE {
     }
 
     fn probe_and_map(path: &str) -> Result<(OlmoeMetadata, MappedOlmoeCheckpoint)> {
-        let file = File::open(path).map_err(|e| HybridError::ModelLoad {
-            path: path.to_owned(),
-            reason: e.to_string(),
-        })?;
-        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| HybridError::ModelLoad {
-            path: path.to_owned(),
-            reason: format!("mmap failed: {e}"),
-        })?;
+        let file =
+            OpenOptions::new()
+                .read(true)
+                .open(path)
+                .map_err(|e| HybridError::ModelLoad {
+                    path: path.to_owned(),
+                    reason: e.to_string(),
+                })?;
+        // CUDA host registration rejects the shared file mapping used by `map`,
+        // but accepts a writable MAP_PRIVATE/COW file view without requiring any
+        // Vec staging or mutating the checkpoint on disk.
+        let mmap =
+            unsafe { MmapOptions::new().map_copy(&file) }.map_err(|e| HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: format!("copy-on-write mmap failed: {e}"),
+            })?;
 
         let parsed = parse_checkpoint_layout(&mmap, path)?;
         let routing =
@@ -460,7 +468,7 @@ impl MappedOlmoeCheckpoint {
 impl RegisteredTensorSliceU16 {
     fn register(
         tensor_name: &str,
-        mmap: &Mmap,
+        mmap: &MmapMut,
         absolute_offset: usize,
         n_elements: usize,
         path: &str,


### PR DESCRIPTION
## **User description**
## Summary
- add `HybridModel::prepare_gpu_temporal` and `HybridModel::tick_gpu_temporal` for direct stateful GPU ticks
- add `examples/gpu_smoke_test.rs` to validate the GGUF-backed Blackwell temporal path on real hardware
- update the GGUF synapse bridge to use a CUDA-registerable MAP_PRIVATE/COW file mapping for `cuMemHostRegister_v2`
- document the dedicated smoke test in `README.md`

## Validation
- `cargo check --all-targets`
- `cargo test --no-run`
- `cargo clippy --all-targets --all-features`
- `cargo test -q`
- `OLMOE_PATH=/home/raulmc/Downloads/SNN_Quantization/olmoe-0125-gguf/30dd013012d19b372bd71b825eea618140f9b3f1b72122efd4e78e29d6138545 cargo test -q test_real_checkpoint_probe_via_env -- --nocapture`
- `OLMOE_PATH=/home/raulmc/Downloads/SNN_Quantization/olmoe-0125-gguf/30dd013012d19b372bd71b825eea618140f9b3f1b72122efd4e78e29d6138545 cargo test -q test_registered_gpu_upload_via_env -- --nocapture`
- `OLMOE_PATH=/home/raulmc/Downloads/SNN_Quantization/olmoe-0125-gguf/30dd013012d19b372bd71b825eea618140f9b3f1b72122efd4e78e29d6138545 cargo run --release --example gpu_smoke_test`

## Notes
- the smoke test exercised the shim-backed FP16 temporal path successfully even though PTX JIT still reports `InvalidPtx` for `spiking_network`; the direct GIF F16 + two-pass SAAQ path completed 10 live ticks and returned device winners.


___

## **CodeAnt-AI Description**
**Add a direct GPU smoke test for the real temporal path**

### What Changed
- Added a dedicated example that runs 10 live GPU temporal ticks against a GGUF checkpoint and prints per-tick timing and the selected output
- Added a setup step for the GPU temporal path so the same loaded model can be reused across repeated ticks
- Rejects GPU ticks when the input size does not match the model’s neuron count, with a clear error message
- Made the GGUF-backed synapse path use a host-mapped checkpoint view that works with GPU registration
- Updated the README with the exact command to run the hardware smoke test and what it validates

### Impact
`✅ Easier real-hardware GPU validation`
`✅ Clearer errors for mismatched temporal input`
`✅ Fewer failed GGUF GPU smoke tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=rXJEhvXzI0n-xhCY9KgkTCqVrs-HUdFPnzneBp_4Xb8&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
