### PR TITLE
fix: handle F16 token_embd.weight in extract_token_embedding

### DIFF
--- a/src/hybrid/olmoe.rs
+++ b/src/hybrid/olmoe.rs
@@ -19,6 +19,21 @@ const GGUF_VERSION: u32 = 3;
 const GGML_TYPE_F32: u32 = 0;
 const GGML_TYPE_F16: u32 = 1;
 
+#[inline(always)]
+fn f16_to_f32(bits: u16) -> f32 {
+    let sign = ((bits as u32) & 0x8000) << 16;
+    let exp = ((bits as u32) & 0x7C00) >> 10;
+    let mant = ((bits as u32) & 0x03FF) << 13;
+    let val = if exp == 0 {
+        mant
+    } else if exp == 31 {
+        0x7F800000 | mant
+    } else {
+        ((exp + 127 - 15) << 23) | mant
+    };
+    f32::from_bits(sign | val)
+}
+
 const GGUF_VALUE_TYPE_UINT8: u32 = 0;
 const GGUF_VALUE_TYPE_INT8: u32 = 1;
 const GGUF_VALUE_TYPE_UINT16: u32 = 2;
@@ -188,40 +203,64 @@ impl OLMoE {
                 reason: "checkpoint not loaded".into(),
             })?;
 
-        let weights = checkpoint.f32_tensor("token_embd.weight", &path)?;
-        let info = checkpoint.tensor_info("token_embd.weight", &path)?;
-        
+        let info = checkpoint.tensor_info("token_embd.weight", &path)?.clone();
         let d0 = info.dims[0];
         let d1 = info.dims.get(1).copied().unwrap_or(0);
 
-        if d0 == EMBEDDING_DIM {
-            // Memory layout is contiguous per token.
-            if token_id >= d1 {
-                return Err(HybridError::InputLengthMismatch {
-                    expected: d1,
-                    got: token_id,
-                });
+        match info.ggml_type {
+            GGML_TYPE_F32 => {
+                let weights = checkpoint.f32_tensor("token_embd.weight", &path)?;
+                if d0 == EMBEDDING_DIM {
+                    if token_id >= d1 {
+                        return Err(HybridError::InputLengthMismatch { expected: d1, got: token_id });
+                    }
+                    let start = token_id * EMBEDDING_DIM;
+                    Ok(weights[start..start + EMBEDDING_DIM].to_vec())
+                } else if d1 == EMBEDDING_DIM {
+                    if token_id >= d0 {
+                        return Err(HybridError::InputLengthMismatch { expected: d0, got: token_id });
+                    }
+                    Ok((0..EMBEDDING_DIM).map(|dim| weights[dim * d0 + token_id]).collect())
+                } else {
+                    Err(HybridError::UnsupportedFormat(format!(
+                        "tensor 'token_embd.weight' has unexpected dimensions {:?}", info.dims
+                    )))
+                }
             }
-            let start = token_id * EMBEDDING_DIM;
-            let end = start + EMBEDDING_DIM;
-            Ok(weights[start..end].to_vec())
-        } else if d1 == EMBEDDING_DIM {
-            if token_id >= d0 {
-                return Err(HybridError::InputLengthMismatch {
-                    expected: d0,
-                    got: token_id,
-                });
+            GGML_TYPE_F16 => {
+                let byte_start = info.absolute_offset;
+                let byte_end = byte_start + info.n_elements * 2;
+                if byte_end > checkpoint.mmap.len() {
+                    return Err(HybridError::ModelLoad {
+                        path: path.clone(),
+                        reason: "token_embd.weight F16 tensor extends beyond mapped file".into(),
+                    });
+                }
+                let raw = &checkpoint.mmap[byte_start..byte_end];
+                let u16s: Vec<u16> = raw
+                    .chunks_exact(2)
+                    .map(|b| u16::from_le_bytes([b[0], b[1]]))
+                    .collect();
+                if d0 == EMBEDDING_DIM {
+                    if token_id >= d1 {
+                        return Err(HybridError::InputLengthMismatch { expected: d1, got: token_id });
+                    }
+                    let start = token_id * EMBEDDING_DIM;
+                    Ok(u16s[start..start + EMBEDDING_DIM].iter().map(|&b| f16_to_f32(b)).collect())
+                } else if d1 == EMBEDDING_DIM {
+                    if token_id >= d0 {
+                        return Err(HybridError::InputLengthMismatch { expected: d0, got: token_id });
+                    }
+                    Ok((0..EMBEDDING_DIM).map(|dim| f16_to_f32(u16s[dim * d0 + token_id])).collect())
+                } else {
+                    Err(HybridError::UnsupportedFormat(format!(
+                        "tensor 'token_embd.weight' has unexpected dimensions {:?}", info.dims
+                    )))
+                }
             }
-            let mut emb = Vec::with_capacity(EMBEDDING_DIM);
-            for dim in 0..EMBEDDING_DIM {
-                emb.push(weights[dim * d0 + token_id]);
-            }
-            Ok(emb)
-        } else {
-            Err(HybridError::UnsupportedFormat(format!(
-                "tensor 'token_embd.weight' has unexpected dimensions {:?}",
-                info.dims
-            )))
+            other => Err(HybridError::UnsupportedFormat(format!(
+                "tensor 'token_embd.weight' has unsupported ggml_type={other}"
+            ))),
         }
     }
 


### PR DESCRIPTION
## **User description**
Fixes `extract_token_embedding` to handle F16 `token_embd.weight` tensors.

## Changes
- **src/hybrid/olmoe.rs**: 
  - Added `f16_to_f32(bits: u16) -> f32` inline IEEE 754 converter (no external crate)
  - Updated `extract_token_embedding` to branch on `ggml_type`:
    - F32 (0): existing mmap slice path
    - F16 (1): reads raw bytes, converts each u16 to f32, then slices the token row
    - Other types: returns `UnsupportedFormat` error

## Root cause
The original implementation only accepted F32 tensors, but OLMoE GGUF checkpoints store `token_embd.weight` as F16 (ggml_type=1), causing a runtime crash.


___

## **CodeAnt-AI Description**
**Load token embeddings from F16 checkpoints without crashing**

### What Changed
- Token embeddings now load correctly when the model stores them as F16 instead of F32
- The embedding row is read and converted before use, so OLMoE checkpoints with F16 weights can run normally
- If the tensor has an unexpected format or size, the model now fails with a clear error instead of crashing

### Impact
`✅ Fewer model load crashes`
`✅ Wider checkpoint compatibility`
`✅ Clearer errors for unsupported embeddings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=u1sgu2I5koBVVlZSxvtvY2PdnCgcJntOhU0t6ZI3l_U&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
