### PR TITLE
fix: apply L2 normalization to pooled embeddings in SAAQ calibration

### DIFF
--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -47,6 +47,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         pooled[i] /= tokens.len() as f32;
     }
 
+    // Apply L2 Normalization to prevent Routing Collapse from overpowering fatigue
+    let l2_norm = pooled.iter().map(|&v| v * v).sum::<f32>().sqrt();
+    if l2_norm > 1e-8 {
+        for v in pooled.iter_mut() {
+            *v /= l2_norm;
+        }
+    }
+
     let target_neurons = model.projector_mut().input_neurons();
     if pooled.len() != target_neurons {
         return Err(Error::other(format!(


### PR DESCRIPTION
## **User description**
Adds an L2 normalization step to the mean-pooled token embedding in `saaq_latent_calibration.rs` before it is passed to the SNN simulation loop.

## Fix
The real `token_embd.weight` tensors extracted directly from GGUF checkpoints have magnitudes that overpower the SNN fatigue mechanics, causing Routing Collapse (a single neuron firing continuously for all 10,000 ticks). 

Normalizing the `[f32; 2048]` pooled vector ensures the semantic pressure is properly scaled against the hardware fatigue parameters, allowing natural routing behavior to resume.


___

## **CodeAnt-AI Description**
Normalize pooled embeddings before they are sent into the calibration flow

### What Changed
- The pooled embedding vector is now normalized before calibration continues, so unusually large embedding values no longer overwhelm routing behavior
- Very small vectors are left unchanged to avoid dividing by near-zero values

### Impact
`✅ Fewer routing collapse cases`
`✅ More stable neuron firing during calibration`
`✅ Clearer calibration behavior with large embeddings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=CddkiS5NzwBRJzxUGnZUepxLFilzgpfU_QewKOGtEGk&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
