### PR TITLE
[codex] Add GGUF checkpoint probing and labeled calibration runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "libc",
  "memmap2",
  "serde",
+ "serde_json",
  "thiserror",
  "tracing",
 ]
@@ -136,6 +137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +153,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -257,6 +270,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,3 +378,9 @@ dependencies = [
  "num-traits",
  "rustc_version",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["docs/"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0"
 cust    = "0.3.2"
 anyhow  = { version = "1", features = ["backtrace"] }

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ TelemetrySnapshot
 
 ## GGUF First-Block Bridge
 
-The current OLMoE integration is intentionally scoped to a first-block bridge:
+The current GGUF integration is intentionally scoped to a first-block bridge:
 
-- `blk.0.ffn_gate_inp.weight` is used as the real routing matrix for `DenseSim` and `SpikingSim`
-- `blk.0.attn_q.weight` is the default recurrent synapse matrix for `forward_gpu_temporal`
-- the GGUF file is memory-mapped and the GPU synapse slice is registered with CUDA via `cuMemHostRegister_v2`
-- the temporal GPU path reuses resident device weights across forwards instead of rebuilding dummy weights
+- `blk.0.ffn_gate_inp.weight` is preferred as the real routing matrix for `DenseSim` and `SpikingSim`
+- `blk.0.ffn_gate.weight` is accepted when it exposes an explicit expert axis compatible with the checkpoint metadata
+- `blk.0.attn_q.weight` remains the default recurrent synapse tensor when the checkpoint exposes a square F16 slice
+- if the checkpoint does not expose a compatible recurrent synapse tensor, the temporal path falls back to the synthetic SNN weight matrix while still using the real GGUF routing bridge
 
-This phase does not implement the full expert MLP block. Hidden outputs remain a route-weighted passthrough of the projector embedding so the repo can exercise real routing without pretending to be a full multi-layer OLMoE runtime.
+This phase does not implement the full expert MLP block. Hidden outputs remain a route-weighted passthrough of the projector embedding so the repo can exercise real routing without pretending to be a full multi-layer MoE runtime.
 
 ## Quick start
 
@@ -214,7 +214,7 @@ let output = model.forward_gpu_temporal(&mut accelerator, &TelemetrySnapshot::de
 To validate the actual Blackwell temporal path on hardware, use the dedicated smoke test:
 
 ```bash
-OLMOE_PATH=/path/to/gguf cargo run --release --example gpu_smoke_test
+MOE_GGUF_PATH=/path/to/gguf cargo run --release --example gpu_smoke_test
 ```
 
 This example exercises:
@@ -225,7 +225,7 @@ This example exercises:
 - the two-pass SAAQ reduction returning `best_walker`
 - per-tick timing output in microseconds
 
-This is the correct example for validating the real GPU temporal path. `saaq_latent_calibration` is CPU-side calibration logic and does not exercise the direct GPU temporal loop.
+This is the correct example for validating the real GPU temporal path.
 
 ## OLMoE Modes
 
@@ -244,7 +244,7 @@ cargo run --example telemetry_bridge
 With a real GGUF checkpoint:
 
 ```bash
-OLMOE_PATH=/models/olmoe.gguf \
+MOE_GGUF_PATH=/models/model.gguf \
   cargo run --example telemetry_bridge --release
 ```
 
@@ -276,22 +276,34 @@ The crate provides a separate calibration path for driving the GPU temporal SNN 
 
 ### Direct Token Embedding Extraction
 
-Rather than bringing in a heavy text tokenizer dependency, the `saaq_latent_calibration` example bypasses text parsing entirely:
+Rather than bringing in a heavy tokenizer dependency, the `saaq_latent_calibration` example accepts model-specific token IDs and works directly from the GGUF checkpoint:
 
-1. It memory-maps the `token_embd.weight` tensor from the provided OLMoE GGUF checkpoint.
-2. It extracts the raw 2048-dimensional embedding rows for a hard-coded sequence of token IDs (representing the prompt: *"Let's teach this MoE model the language of SNN"*).
-3. It mean-pools these tokens into a single `[f32; 2048]` context vector.
-4. It feeds this single context vector continuously into the direct GPU temporal loop (`tick_gpu_temporal`) for 10,000 ticks.
+1. It probes the checkpoint metadata and selects a compatible first-block routing tensor.
+2. It extracts token embeddings from `token_embd.weight`, truncating wider checkpoints down to the 2048-neuron SNN width when necessary.
+3. It mean-pools the selected token rows into a single `[f32; 2048]` context vector.
+4. It feeds this context vector into the direct GPU temporal loop and exports labeled research artifacts for each run.
 
 ### Calibration Runner
 
-Run the calibration test by pointing it to your local OLMoE checkpoint:
+Run the calibration test by pointing it to your local GGUF checkpoint:
 
 ```bash
-OLMOE_PATH=/path/to/olmoe.gguf cargo run --example saaq_latent_calibration --release
+MOE_GGUF_PATH=/path/to/model.gguf \
+PROMPT_SLUG=math_logic \
+PROMPT_TEXT="The derivative of a constant is mathematically zero." \
+PROMPT_TOKEN_IDS=402,11492,286,257,4568,318,12056,4202,13 \
+RUN_OUTPUT_ROOT=/path/to/Metis-SMoE-Latent-Telemetry/routing \
+cargo run --example saaq_latent_calibration --release
 ```
 
-The runner will output the per-tick performance and the winning SAAQ walker ID selected by the on-device reduction:
+The runner writes a labeled run directory:
+
+- `tick_telemetry.txt`
+- `latent_telemetry.csv`
+- `run_manifest.json`
+- expected `routing_map.png` target path for the downstream Julia plot step
+
+It also streams the per-tick performance and the winning SAAQ walker ID selected by the on-device reduction:
 
 ```text
 tick=1 best_walker=12 elapsed_us=850

--- a/examples/csv_replay.rs
+++ b/examples/csv_replay.rs
@@ -10,6 +10,12 @@ use corinth_canal::{
 const EXPECTED_HEADER: &str = "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
 const TELEMETRY_THRESHOLDS: [f32; 4] = [1.0, 5.0, 1.0, 5.0];
 
+fn model_path() -> String {
+    std::env::var("MOE_GGUF_PATH")
+        .or_else(|_| std::env::var("OLMOE_PATH"))
+        .unwrap_or_default()
+}
+
 fn parse_u64(v: &str) -> Option<u64> {
     v.parse::<u64>().ok()
 }
@@ -28,7 +34,7 @@ fn main() -> corinth_canal::Result<()> {
     }
 
     let csv_path = &args[1];
-    let model_path = std::env::var("OLMOE_PATH").unwrap_or_default();
+    let model_path = model_path();
 
     let cfg = HybridConfig {
         olmoe_model_path: model_path,

--- a/examples/gpu_smoke_test.rs
+++ b/examples/gpu_smoke_test.rs
@@ -4,10 +4,16 @@ use corinth_canal::{
 use std::io::Error;
 use std::time::Instant;
 
+fn model_path() -> String {
+    std::env::var("MOE_GGUF_PATH")
+        .or_else(|_| std::env::var("OLMOE_PATH"))
+        .unwrap_or_default()
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model_path = std::env::var("OLMOE_PATH").unwrap_or_default();
+    let model_path = model_path();
     if model_path.trim().is_empty() {
-        eprintln!("OLMOE_PATH must point to a GGUF checkpoint");
+        eprintln!("MOE_GGUF_PATH (or OLMOE_PATH) must point to a GGUF checkpoint");
         std::process::exit(1);
     }
 
@@ -32,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     if !model.olmoe_loaded() {
-        return Err(Error::other("OLMoE model did not load from OLMOE_PATH").into());
+        return Err(Error::other("GGUF model did not load from MOE_GGUF_PATH/OLMOE_PATH").into());
     }
     if !accelerator.is_ready() {
         return Err(Error::other("GpuAccelerator is not ready").into());

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -1,87 +1,293 @@
 use corinth_canal::{
-    HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode, EMBEDDING_DIM,
-    gpu::GpuAccelerator,
+    FunnelActivity, HybridConfig, HybridModel, OLMoE, OlmoeExecutionMode, ProjectionMode,
+    SnnLatentCalibrator, SnnLatentCsvExporter, TelemetrySnapshot, gpu::GpuAccelerator,
 };
-use std::io::Error;
-use std::time::Instant;
+use serde::Serialize;
+use std::fs::{self, File};
+use std::io::{BufWriter, Error, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+const DEFAULT_PROMPT_SLUG: &str = "math_logic";
+const DEFAULT_PROMPT_TEXT: &str = "The derivative of a constant is mathematically zero.";
+const DEFAULT_RUN_TAG: &str = "run01";
+const DEFAULT_TICKS: usize = 10_000;
+const DEFAULT_GPU_SYNAPSE_TENSOR_NAME: &str = "blk.0.attn_q.weight";
+const DEFAULT_TOKEN_IDS: [usize; 9] = [402, 11492, 286, 257, 4568, 318, 12056, 4202, 13];
+
+#[derive(Debug, Serialize)]
+struct RunManifest {
+    model_name: String,
+    model_slug: String,
+    model_path: String,
+    model_architecture: String,
+    checkpoint_hidden_size: usize,
+    snn_hidden_size: usize,
+    checkpoint_num_experts: usize,
+    checkpoint_expert_used_count: Option<usize>,
+    top_k_experts: usize,
+    routing_tensor_name: String,
+    quantization: String,
+    prompt_slug: String,
+    prompt_text: String,
+    prompt_token_ids: Vec<usize>,
+    run_tag: String,
+    run_id: String,
+    ticks: usize,
+    started_at_unix_ms: u64,
+    generated_files: Vec<String>,
+    expected_plot_path: String,
+}
+
+fn env_or(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        std::env::var(name)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn required_model_path() -> Result<String, Box<dyn std::error::Error>> {
+    env_or(&["MOE_GGUF_PATH", "OLMOE_PATH"]).ok_or_else(|| {
+        Error::other("MOE_GGUF_PATH (or OLMOE_PATH) must point to a GGUF checkpoint").into()
+    })
+}
+
+fn default_output_root() -> PathBuf {
+    PathBuf::from("outputs/routing")
+}
+
+fn slugify(value: &str) -> String {
+    let mut slug = String::with_capacity(value.len());
+    let mut last_was_sep = false;
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            slug.push('_');
+            last_was_sep = true;
+        }
+    }
+    slug.trim_matches('_').to_owned()
+}
+
+fn parse_usize_env(name: &str, default: usize) -> Result<usize, Box<dyn std::error::Error>> {
+    match env_or(&[name]) {
+        Some(value) => Ok(value.parse::<usize>()?),
+        None => Ok(default),
+    }
+}
+
+fn parse_token_ids() -> Result<Vec<usize>, Box<dyn std::error::Error>> {
+    let Some(raw) = env_or(&["PROMPT_TOKEN_IDS"]) else {
+        return Ok(DEFAULT_TOKEN_IDS.to_vec());
+    };
+
+    raw.split(',')
+        .map(|part| part.trim().parse::<usize>().map_err(|err| err.into()))
+        .collect()
+}
+
+fn prepare_run_dir(root: &Path, model_slug: &str, prompt_slug: &str, run_id: &str) -> std::io::Result<PathBuf> {
+    let run_dir = root.join(model_slug).join(prompt_slug).join(run_id);
+    fs::create_dir_all(&run_dir)?;
+    Ok(run_dir)
+}
+
+fn writer_for(path: &Path) -> Result<BufWriter<File>, Box<dyn std::error::Error>> {
+    Ok(BufWriter::new(File::create(path)?))
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model_path = std::env::var("OLMOE_PATH").unwrap_or_default();
-    if model_path.trim().is_empty() {
-        eprintln!("OLMOE_PATH must point to a GGUF checkpoint");
-        std::process::exit(1);
-    }
+    let model_path = required_model_path()?;
+    let checkpoint = OLMoE::probe_checkpoint(&model_path)?;
+    let ticks = parse_usize_env("TICKS", DEFAULT_TICKS)?;
+    let prompt_text = env_or(&["PROMPT_TEXT"]).unwrap_or_else(|| DEFAULT_PROMPT_TEXT.to_owned());
+    let prompt_slug =
+        env_or(&["PROMPT_SLUG"]).unwrap_or_else(|| DEFAULT_PROMPT_SLUG.to_owned());
+    let prompt_token_ids = parse_token_ids()?;
+    let run_tag = env_or(&["RUN_TAG"]).unwrap_or_else(|| DEFAULT_RUN_TAG.to_owned());
+    let model_slug = env_or(&["MODEL_SLUG"]).unwrap_or_else(|| {
+        Path::new(&model_path)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .map(slugify)
+            .unwrap_or_else(|| "model".to_owned())
+    });
+    let output_root = env_or(&["RUN_OUTPUT_ROOT", "RESEARCH_OUTPUT_ROOT"])
+        .map(PathBuf::from)
+        .unwrap_or_else(default_output_root);
+    let num_experts = parse_usize_env("NUM_EXPERTS", checkpoint.num_experts)?;
+    let top_k_experts = parse_usize_env(
+        "TOP_K_EXPERTS",
+        checkpoint.expert_used_count.unwrap_or(1).max(1),
+    )?
+    .min(num_experts);
+    let started_at_unix_ms = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis() as u64;
+    let run_id = format!(
+        "{}_{}_{}_{}",
+        started_at_unix_ms / 1000,
+        model_slug,
+        slugify(&prompt_slug),
+        slugify(&run_tag)
+    );
+    let run_dir = prepare_run_dir(&output_root, &model_slug, &prompt_slug, &run_id)?;
+    let tick_path = run_dir.join("tick_telemetry.txt");
+    let latent_path = run_dir.join("latent_telemetry.csv");
+    let manifest_path = run_dir.join("run_manifest.json");
+    let plot_path = run_dir.join("routing_map.png");
+
+    let mut tick_writer = writer_for(&tick_path)?;
+    let mut latent_exporter = SnnLatentCsvExporter::create(&latent_path)?;
+    let mut calibrator = SnnLatentCalibrator::new();
 
     let mut accelerator = GpuAccelerator::new();
     let mut model = HybridModel::new(HybridConfig {
         olmoe_model_path: model_path.clone(),
-        gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
-        num_experts: 8,
-        top_k_experts: 1,
+        gpu_synapse_tensor_name: env_or(&["GPU_SYNAPSE_TENSOR_NAME"])
+            .unwrap_or_else(|| DEFAULT_GPU_SYNAPSE_TENSOR_NAME.to_owned()),
+        num_experts,
+        top_k_experts,
         olmoe_execution_mode: OlmoeExecutionMode::SpikingSim,
         snn_steps: 1,
         projection_mode: ProjectionMode::SpikingTernary,
     })?;
 
     if !model.olmoe_loaded() {
-        return Err(Error::other("OLMoE model did not load from OLMOE_PATH").into());
+        return Err(Error::other("GGUF model did not load from MOE_GGUF_PATH/OLMOE_PATH").into());
     }
     if !accelerator.is_ready() {
         return Err(Error::other("GpuAccelerator is not ready").into());
     }
 
-    // 1. Extract embeddings for token IDs: [1045, 2099, 450, 8000, 12]
-    // These represent the prompt: "Let's teach this MoE model the language of SNN"
-    let token_ids = vec![402, 11492, 286, 257, 4568, 318, 12056, 4202, 13]; // Simulates: The derivate of a constant is mathematically zero.
-    let mut pooled = vec![0.0f32; EMBEDDING_DIM];
+    let target_neurons = model.projector_mut().input_neurons();
+    println!(
+        "startup model_path={} architecture={} checkpoint_hidden_size={} snn_hidden_size={} checkpoint_experts={} top_k={} routing_tensor={} gpu_ready={} output_dir={}",
+        model_path,
+        model.checkpoint_architecture(),
+        model.checkpoint_source_hidden_size(),
+        model.checkpoint_hidden_size(),
+        model.checkpoint_num_experts(),
+        top_k_experts,
+        model.routing_tensor_name(),
+        accelerator.is_ready(),
+        run_dir.display(),
+    );
 
-    for &token in &token_ids {
+    let mut pooled = vec![0.0f32; target_neurons];
+    for &token in &prompt_token_ids {
         let emb = model.extract_token_embedding(token)?;
-        for i in 0..EMBEDDING_DIM {
-            pooled[i] += emb[i];
+        if emb.len() != target_neurons {
+            return Err(Error::other(format!(
+                "token embedding length mismatch: expected {target_neurons}, got {}",
+                emb.len()
+            ))
+            .into());
+        }
+        for (dst, src) in pooled.iter_mut().zip(emb.iter()) {
+            *dst += *src;
         }
     }
-
-    // 2. Mean-pool into a single [f32; 2048] vector
-    for i in 0..EMBEDDING_DIM {
-        pooled[i] /= token_ids.len() as f32;
+    for value in &mut pooled {
+        *value /= prompt_token_ids.len() as f32;
     }
-
-    // Apply L2 Normalization to prevent Routing Collapse from overpowering fatigue
     let l2_norm = pooled.iter().map(|&v| v * v).sum::<f32>().sqrt();
     if l2_norm > 1e-8 {
-        for v in pooled.iter_mut() {
-            *v /= l2_norm;
+        for value in &mut pooled {
+            *value /= l2_norm;
         }
     }
 
-    let target_neurons = model.projector_mut().input_neurons();
-    if pooled.len() != target_neurons {
-        return Err(Error::other(format!(
-            "Dimension mismatch: pooled len {} != target_neurons {}",
-            pooled.len(),
-            target_neurons
-        ))
-        .into());
-    }
-
-    // 3. Prepare GPU temporal state
     model.prepare_gpu_temporal(&mut accelerator)?;
 
-    // 4. Run the 10,000-tick loop using the single pooled context vector continuously
-    for tick in 0..10_000usize {
+    let zero_iz = vec![0.0f32; 5];
+    for tick in 0..ticks {
         let started = Instant::now();
         let best_walker = model.tick_gpu_temporal(&mut accelerator, &pooled)?;
         let elapsed_us = started.elapsed().as_micros();
-        println!(
+        writeln!(
+            tick_writer,
             "tick={} best_walker={} elapsed_us={}",
             tick + 1,
             best_walker,
             elapsed_us
-        );
+        )?;
+
+        let spikes = accelerator.temporal_spikes_to_vec(target_neurons)?;
+        let membrane = accelerator.temporal_membrane_to_vec(target_neurons)?;
+        let active_neurons: Vec<usize> = spikes
+            .iter()
+            .enumerate()
+            .filter(|(_, value)| **value != 0)
+            .map(|(idx, _)| idx)
+            .collect();
+        let potentials: Vec<f32> = membrane.iter().map(|&value| value.clamp(0.0, 1.0)).collect();
+        let activity = FunnelActivity {
+            ternary_events: [0, 0, 0, 0],
+            input_spike_train: vec![Vec::new()],
+            spike_train: vec![active_neurons],
+            potentials: potentials.clone(),
+            iz_potentials: zero_iz.clone(),
+        };
+        let output = model.forward_activity(
+            &activity.spike_train,
+            &activity.potentials,
+            &activity.iz_potentials,
+        )?;
+        let snap = TelemetrySnapshot {
+            timestamp_ms: started_at_unix_ms + tick as u64,
+            ..TelemetrySnapshot::default()
+        };
+        let latent = calibrator.observe(&snap, &activity, &output)?;
+        latent_exporter.write_row(&latent)?;
     }
 
-    // Maintain strict drop order
+    tick_writer.flush()?;
+    latent_exporter.flush()?;
+
+    let manifest = RunManifest {
+        model_name: Path::new(&model_path)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("checkpoint")
+            .to_owned(),
+        model_slug,
+        model_path,
+        model_architecture: model.checkpoint_architecture().to_owned(),
+        checkpoint_hidden_size: model.checkpoint_source_hidden_size(),
+        snn_hidden_size: model.checkpoint_hidden_size(),
+        checkpoint_num_experts: model.checkpoint_num_experts(),
+        checkpoint_expert_used_count: model.checkpoint_expert_used_count(),
+        top_k_experts,
+        routing_tensor_name: model.routing_tensor_name().to_owned(),
+        quantization: checkpoint.quantization,
+        prompt_slug,
+        prompt_text,
+        prompt_token_ids,
+        run_tag,
+        run_id,
+        ticks,
+        started_at_unix_ms,
+        generated_files: vec![
+            "tick_telemetry.txt".into(),
+            "latent_telemetry.csv".into(),
+            "run_manifest.json".into(),
+        ],
+        expected_plot_path: plot_path.display().to_string(),
+    };
+    fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?)?;
+
+    println!("saved tick telemetry to {}", tick_path.display());
+    println!("saved latent telemetry to {}", latent_path.display());
+    println!("saved manifest to {}", manifest_path.display());
+    println!(
+        "to generate the plot: julia plot_latent_space.jl {} {}",
+        tick_path.display(),
+        plot_path.display()
+    );
+
     drop(model);
     drop(accelerator);
 

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -128,7 +128,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let started_at_unix_ms = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis() as u64;
     let run_id = format!(
         "{}_{}_{}_{}",
-        started_at_unix_ms / 1000,
+        started_at_unix_ms,
         model_slug,
         slugify(&prompt_slug),
         slugify(&run_tag)

--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -4,8 +4,14 @@ use corinth_canal::{
     EMBEDDING_DIM, HybridConfig, HybridModel, OlmoeExecutionMode, ProjectionMode, TelemetrySnapshot,
 };
 
+fn model_path() -> String {
+    std::env::var("MOE_GGUF_PATH")
+        .or_else(|_| std::env::var("OLMOE_PATH"))
+        .unwrap_or_default()
+}
+
 fn main() -> corinth_canal::Result<()> {
-    let model_path = std::env::var("OLMOE_PATH").unwrap_or_default();
+    let model_path = model_path();
     let olmoe_execution_mode = match std::env::var("OLMOE_MODE")
         .unwrap_or_else(|_| "spiking".into())
         .to_ascii_lowercase()

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -227,14 +227,19 @@ impl HybridModel {
                 self.olmoe.model_path(),
                 self.config.gpu_synapse_tensor_name
             );
-            let weights = self
+            match self
                 .olmoe
                 .registered_gpu_synapse_weights(&self.config.gpu_synapse_tensor_name)
-                .map_err(|e| {
-                    GpuError::MemoryError(format!("GGUF synapse registration failed: {e}"))
-                })?;
-            accelerator.load_synapse_weights_f16_registered(&signature, weights)?;
-            return Ok(());
+            {
+                Ok(weights) => {
+                    accelerator.load_synapse_weights_f16_registered(&signature, weights)?;
+                    return Ok(());
+                }
+                Err(_) => {
+                    // Some GGUF checkpoints keep the routing bridge usable but do not expose a
+                    // square F16 attention tensor for direct GPU synapse upload.
+                }
+            }
         }
 
         let fallback_signature = format!("synthetic-f32::{neuron_count}");
@@ -354,6 +359,30 @@ impl HybridModel {
 
     pub fn olmoe_loaded(&self) -> bool {
         self.olmoe.is_loaded()
+    }
+
+    pub fn checkpoint_architecture(&self) -> &str {
+        self.olmoe.architecture()
+    }
+
+    pub fn checkpoint_hidden_size(&self) -> usize {
+        self.olmoe.hidden_size()
+    }
+
+    pub fn checkpoint_source_hidden_size(&self) -> usize {
+        self.olmoe.source_hidden_size()
+    }
+
+    pub fn checkpoint_num_experts(&self) -> usize {
+        self.olmoe.checkpoint_num_experts()
+    }
+
+    pub fn checkpoint_expert_used_count(&self) -> Option<usize> {
+        self.olmoe.expert_used_count()
+    }
+
+    pub fn routing_tensor_name(&self) -> &str {
+        self.olmoe.routing_tensor_name()
     }
 
     /// Extract the embedding vector for a single token ID from the GGUF `token_embd.weight` tensor.

--- a/src/hybrid/hybrid.rs
+++ b/src/hybrid/hybrid.rs
@@ -235,10 +235,11 @@ impl HybridModel {
                     accelerator.load_synapse_weights_f16_registered(&signature, weights)?;
                     return Ok(());
                 }
-                Err(_) => {
+                Err(HybridError::UnsupportedFormat(_)) | Err(HybridError::MissingTensor { .. }) => {
                     // Some GGUF checkpoints keep the routing bridge usable but do not expose a
                     // square F16 attention tensor for direct GPU synapse upload.
                 }
+                Err(e) => return Err(e),
             }
         }
 

--- a/src/hybrid/olmoe.rs
+++ b/src/hybrid/olmoe.rs
@@ -12,12 +12,15 @@ use std::slice;
 const OLMOE_HIDDEN: usize = 2048;
 const OLMOE_NUM_EXPERTS: usize = 64;
 const OLMOE_NUM_LAYERS: usize = 16;
-const ROUTING_TENSOR_NAME: &str = "blk.0.ffn_gate_inp.weight";
-const DEFAULT_GPU_SYNAPSE_TENSOR_NAME: &str = "blk.0.attn_q.weight";
+const ROUTING_TENSOR_CANDIDATES: [&str; 2] =
+    ["blk.0.ffn_gate_inp.weight", "blk.0.ffn_gate.weight"];
 const GGUF_MAGIC: [u8; 4] = [b'G', b'G', b'U', b'F'];
 const GGUF_VERSION: u32 = 3;
 const GGML_TYPE_F32: u32 = 0;
 const GGML_TYPE_F16: u32 = 1;
+const GGML_TYPE_Q8_0: u32 = 8;
+const GGML_Q8_0_BLOCK_SIZE: usize = 32;
+const GGML_Q8_0_BLOCK_BYTES: usize = 34;
 
 #[inline(always)]
 fn f16_to_f32(bits: u16) -> f32 {
@@ -32,6 +35,42 @@ fn f16_to_f32(bits: u16) -> f32 {
         ((exp + 127 - 15) << 23) | mant
     };
     f32::from_bits(sign | val)
+}
+
+fn decode_q8_0_row(
+    raw: &[u8],
+    source_hidden_size: usize,
+    active_hidden_size: usize,
+) -> Result<Vec<f32>> {
+    if !source_hidden_size.is_multiple_of(GGML_Q8_0_BLOCK_SIZE) {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "Q8_0 row width {source_hidden_size} is not divisible by {}",
+            GGML_Q8_0_BLOCK_SIZE
+        )));
+    }
+
+    let blocks_per_row = source_hidden_size / GGML_Q8_0_BLOCK_SIZE;
+    let expected_bytes = blocks_per_row * GGML_Q8_0_BLOCK_BYTES;
+    if raw.len() < expected_bytes {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "Q8_0 row is truncated: expected {expected_bytes} bytes, got {}",
+            raw.len()
+        )));
+    }
+
+    let mut out = Vec::with_capacity(active_hidden_size);
+    for block_idx in 0..blocks_per_row {
+        let base = block_idx * GGML_Q8_0_BLOCK_BYTES;
+        let scale = f16_to_f32(u16::from_le_bytes([raw[base], raw[base + 1]]));
+        for q in &raw[base + 2..base + GGML_Q8_0_BLOCK_BYTES] {
+            if out.len() == active_hidden_size {
+                return Ok(out);
+            }
+            out.push((*q as i8 as f32) * scale);
+        }
+    }
+
+    Ok(out)
 }
 
 const GGUF_VALUE_TYPE_UINT8: u32 = 0;
@@ -54,6 +93,7 @@ pub struct OLMoE {
     top_k: usize,
     loaded: bool,
     metadata: OlmoeMetadata,
+    routing_tensor_name: String,
     execution_mode: OlmoeExecutionMode,
     expert_membranes: Vec<f32>,
     hidden_membranes: Vec<f32>,
@@ -64,10 +104,25 @@ pub struct OLMoE {
 
 #[derive(Debug, Clone, Default)]
 struct OlmoeMetadata {
+    pub architecture: String,
     pub hidden_size: usize,
+    pub source_hidden_size: usize,
     pub num_layers: usize,
     pub num_experts: usize,
+    pub expert_used_count: Option<usize>,
     pub quantization: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct OlmoeCheckpointMetadata {
+    pub architecture: String,
+    pub hidden_size: usize,
+    pub source_hidden_size: usize,
+    pub num_layers: usize,
+    pub num_experts: usize,
+    pub expert_used_count: Option<usize>,
+    pub quantization: String,
+    pub routing_tensor_name: String,
 }
 
 #[derive(Debug, Clone)]
@@ -109,6 +164,7 @@ struct RegisteredCudaRegion {
 struct ParsedCheckpointLayout {
     metadata: OlmoeMetadata,
     tensors: HashMap<String, GgufTensorInfo>,
+    routing_tensor_name: String,
 }
 
 struct GgufCursor<'a> {
@@ -141,11 +197,15 @@ impl OLMoE {
                 top_k,
                 loaded: false,
                 metadata: OlmoeMetadata {
+                    architecture: "stub".into(),
                     hidden_size: OLMOE_HIDDEN,
+                    source_hidden_size: OLMOE_HIDDEN,
                     num_layers: OLMOE_NUM_LAYERS,
                     num_experts: OLMOE_NUM_EXPERTS,
+                    expert_used_count: None,
                     quantization: "stub".into(),
                 },
+                routing_tensor_name: ROUTING_TENSOR_CANDIDATES[0].into(),
                 execution_mode,
                 expert_membranes: vec![0.0; num_experts],
                 hidden_membranes: vec![0.0; EMBEDDING_DIM],
@@ -155,13 +215,14 @@ impl OLMoE {
             });
         }
 
-        let (metadata, checkpoint) = Self::probe_and_map(model_path)?;
+        let (metadata, routing_tensor_name, checkpoint) = Self::probe_and_map(model_path)?;
         if num_experts > metadata.num_experts {
             return Err(HybridError::InvalidConfig(format!(
                 "num_experts ({num_experts}) exceeds checkpoint expert_count ({})",
                 metadata.num_experts
             )));
         }
+        let hidden_size = metadata.hidden_size;
 
         Ok(Self {
             model_path: model_path.to_owned(),
@@ -169,19 +230,47 @@ impl OLMoE {
             top_k,
             loaded: true,
             metadata,
+            routing_tensor_name,
             execution_mode,
             expert_membranes: vec![0.0; num_experts],
-            hidden_membranes: vec![0.0; EMBEDDING_DIM],
+            hidden_membranes: vec![0.0; hidden_size],
             threshold: 0.75,
             decay: 0.91,
             checkpoint: Some(checkpoint),
         })
     }
 
+    pub fn probe_checkpoint(model_path: &str) -> Result<OlmoeCheckpointMetadata> {
+        let file = OpenOptions::new()
+            .read(true)
+            .open(model_path)
+            .map_err(|e| HybridError::ModelLoad {
+                path: model_path.to_owned(),
+                reason: e.to_string(),
+            })?;
+        let mmap = unsafe { MmapOptions::new().map_copy(&file) }.map_err(|e| {
+            HybridError::ModelLoad {
+                path: model_path.to_owned(),
+                reason: format!("copy-on-write mmap failed: {e}"),
+            }
+        })?;
+        let parsed = parse_checkpoint_layout(&mmap, model_path)?;
+        Ok(OlmoeCheckpointMetadata {
+            architecture: parsed.metadata.architecture,
+            hidden_size: parsed.metadata.hidden_size,
+            source_hidden_size: parsed.metadata.source_hidden_size,
+            num_layers: parsed.metadata.num_layers,
+            num_experts: parsed.metadata.num_experts,
+            expert_used_count: parsed.metadata.expert_used_count,
+            quantization: parsed.metadata.quantization,
+            routing_tensor_name: parsed.routing_tensor_name,
+        })
+    }
+
     pub fn forward(&mut self, embedding: &[f32]) -> Result<OlmoeOutput> {
-        if embedding.len() != EMBEDDING_DIM {
+        if embedding.len() != self.metadata.hidden_size {
             return Err(HybridError::InputLengthMismatch {
-                expected: EMBEDDING_DIM,
+                expected: self.metadata.hidden_size,
                 got: embedding.len(),
             });
         }
@@ -195,6 +284,8 @@ impl OLMoE {
 
     pub fn extract_token_embedding(&mut self, token_id: usize) -> Result<Vec<f32>> {
         let path = self.model_path.clone();
+        let hidden_size = self.metadata.hidden_size;
+        let source_hidden_size = self.metadata.source_hidden_size;
         let checkpoint = self
             .checkpoint
             .as_mut()
@@ -210,17 +301,19 @@ impl OLMoE {
         match info.ggml_type {
             GGML_TYPE_F32 => {
                 let weights = checkpoint.f32_tensor("token_embd.weight", &path)?;
-                if d0 == EMBEDDING_DIM {
+                if d0 == source_hidden_size {
                     if token_id >= d1 {
                         return Err(HybridError::InputLengthMismatch { expected: d1, got: token_id });
                     }
-                    let start = token_id * EMBEDDING_DIM;
-                    Ok(weights[start..start + EMBEDDING_DIM].to_vec())
-                } else if d1 == EMBEDDING_DIM {
+                    let start = token_id * d0;
+                    Ok(weights[start..start + hidden_size].to_vec())
+                } else if d1 == source_hidden_size {
                     if token_id >= d0 {
                         return Err(HybridError::InputLengthMismatch { expected: d0, got: token_id });
                     }
-                    Ok((0..EMBEDDING_DIM).map(|dim| weights[dim * d0 + token_id]).collect())
+                    Ok((0..hidden_size)
+                        .map(|dim| weights[dim * d0 + token_id])
+                        .collect())
                 } else {
                     Err(HybridError::UnsupportedFormat(format!(
                         "tensor 'token_embd.weight' has unexpected dimensions {:?}", info.dims
@@ -241,22 +334,58 @@ impl OLMoE {
                     .chunks_exact(2)
                     .map(|b| u16::from_le_bytes([b[0], b[1]]))
                     .collect();
-                if d0 == EMBEDDING_DIM {
+                if d0 == source_hidden_size {
                     if token_id >= d1 {
                         return Err(HybridError::InputLengthMismatch { expected: d1, got: token_id });
                     }
-                    let start = token_id * EMBEDDING_DIM;
-                    Ok(u16s[start..start + EMBEDDING_DIM].iter().map(|&b| f16_to_f32(b)).collect())
-                } else if d1 == EMBEDDING_DIM {
+                    let start = token_id * d0;
+                    Ok(u16s[start..start + hidden_size]
+                        .iter()
+                        .map(|&b| f16_to_f32(b))
+                        .collect())
+                } else if d1 == source_hidden_size {
                     if token_id >= d0 {
                         return Err(HybridError::InputLengthMismatch { expected: d0, got: token_id });
                     }
-                    Ok((0..EMBEDDING_DIM).map(|dim| f16_to_f32(u16s[dim * d0 + token_id])).collect())
+                    Ok((0..hidden_size)
+                        .map(|dim| f16_to_f32(u16s[dim * d0 + token_id]))
+                        .collect())
                 } else {
                     Err(HybridError::UnsupportedFormat(format!(
                         "tensor 'token_embd.weight' has unexpected dimensions {:?}", info.dims
                     )))
                 }
+            }
+            GGML_TYPE_Q8_0 => {
+                if d0 != source_hidden_size {
+                    return Err(HybridError::UnsupportedFormat(format!(
+                        "Q8_0 token embeddings must be [hidden_size, vocab], got {:?}",
+                        info.dims
+                    )));
+                }
+                if token_id >= d1 {
+                    return Err(HybridError::InputLengthMismatch {
+                        expected: d1,
+                        got: token_id,
+                    });
+                }
+
+                let blocks_per_row = source_hidden_size / GGML_Q8_0_BLOCK_SIZE;
+                let row_bytes = blocks_per_row * GGML_Q8_0_BLOCK_BYTES;
+                let byte_start = info.absolute_offset + token_id * row_bytes;
+                let byte_end = byte_start + row_bytes;
+                if byte_end > checkpoint.mmap.len() {
+                    return Err(HybridError::ModelLoad {
+                        path: path.clone(),
+                        reason: "token_embd.weight Q8_0 tensor extends beyond mapped file".into(),
+                    });
+                }
+
+                decode_q8_0_row(
+                    &checkpoint.mmap[byte_start..byte_end],
+                    source_hidden_size,
+                    hidden_size,
+                )
             }
             other => Err(HybridError::UnsupportedFormat(format!(
                 "tensor 'token_embd.weight' has unsupported ggml_type={other}"
@@ -276,7 +405,7 @@ impl OLMoE {
         checkpoint.registered_f16_tensor(tensor_name, &path)
     }
 
-    fn probe_and_map(path: &str) -> Result<(OlmoeMetadata, MappedOlmoeCheckpoint)> {
+    fn probe_and_map(path: &str) -> Result<(OlmoeMetadata, String, MappedOlmoeCheckpoint)> {
         let file =
             OpenOptions::new()
                 .read(true)
@@ -295,27 +424,24 @@ impl OLMoE {
             })?;
 
         let parsed = parse_checkpoint_layout(&mmap, path)?;
-        let routing =
-            parsed
-                .tensors
-                .get(ROUTING_TENSOR_NAME)
-                .ok_or_else(|| HybridError::MissingTensor {
-                    name: ROUTING_TENSOR_NAME.into(),
-                    path: path.to_owned(),
-                })?;
-        validate_routing_tensor(path, routing)?;
-
-        let synapse = parsed
+        let routing = parsed
             .tensors
-            .get(DEFAULT_GPU_SYNAPSE_TENSOR_NAME)
+            .get(parsed.routing_tensor_name.as_str())
             .ok_or_else(|| HybridError::MissingTensor {
-                name: DEFAULT_GPU_SYNAPSE_TENSOR_NAME.into(),
+                name: parsed.routing_tensor_name.clone(),
                 path: path.to_owned(),
             })?;
-        validate_gpu_synapse_tensor(path, DEFAULT_GPU_SYNAPSE_TENSOR_NAME, synapse)?;
+        validate_routing_tensor(
+            path,
+            parsed.routing_tensor_name.as_str(),
+            routing,
+            parsed.metadata.source_hidden_size,
+            parsed.metadata.num_experts,
+        )?;
 
         Ok((
             parsed.metadata,
+            parsed.routing_tensor_name,
             MappedOlmoeCheckpoint {
                 mmap,
                 tensors: parsed.tensors,
@@ -373,7 +499,7 @@ impl OLMoE {
             .map(|&expert_id| expert_spikes[expert_id] * expert_weights[expert_id])
             .sum();
 
-        let mut hidden = vec![0.0f32; EMBEDDING_DIM];
+        let mut hidden = vec![0.0f32; self.metadata.hidden_size];
         for (j, h) in hidden.iter_mut().enumerate() {
             let input = embedding[j] * active_mass;
             self.hidden_membranes[j] = self.hidden_membranes[j] * self.decay + input;
@@ -400,13 +526,19 @@ impl OLMoE {
 
     fn compute_gate_scores(&self, embedding: &[f32]) -> Result<Vec<f32>> {
         if let Some(checkpoint) = &self.checkpoint {
-            let info = checkpoint.tensor_info(ROUTING_TENSOR_NAME, &self.model_path)?;
-            let weights = checkpoint.f32_tensor(ROUTING_TENSOR_NAME, &self.model_path)?;
+            let info = checkpoint.tensor_info(&self.routing_tensor_name, &self.model_path)?;
+            let weights = checkpoint.f32_tensor(&self.routing_tensor_name, &self.model_path)?;
             let mut gate_scores = Vec::with_capacity(self.num_experts);
             for expert_id in 0..self.num_experts {
                 let mut score = 0.0f32;
                 for (dim, &value) in embedding.iter().enumerate() {
-                    let index = routing_weight_index(info, expert_id, dim, self.num_experts)?;
+                    let index = routing_weight_index(
+                        info,
+                        expert_id,
+                        dim,
+                        self.metadata.source_hidden_size,
+                        self.num_experts,
+                    )?;
                     score += weights[index] * value;
                 }
                 gate_scores.push(score);
@@ -415,11 +547,11 @@ impl OLMoE {
         }
 
         // Deterministic synthetic fallback for DenseSim/SpikingSim when no checkpoint is present.
-        let chunk = (EMBEDDING_DIM / self.num_experts.max(1)).max(1);
+        let chunk = (embedding.len() / self.num_experts.max(1)).max(1);
         let mut gate_scores = Vec::with_capacity(self.num_experts);
         for expert_id in 0..self.num_experts {
-            let start = (expert_id * chunk) % EMBEDDING_DIM;
-            let end = (start + chunk).min(EMBEDDING_DIM);
+            let start = (expert_id * chunk) % embedding.len().max(1);
+            let end = (start + chunk).min(embedding.len());
             gate_scores.push(embedding[start..end].iter().sum());
         }
         Ok(gate_scores)
@@ -429,7 +561,7 @@ impl OLMoE {
         let n = self.num_experts;
         let expert_weights = vec![1.0 / n as f32; n];
         let selected_experts = (0..self.top_k).collect();
-        let hidden = vec![0.0f32; EMBEDDING_DIM];
+        let hidden = vec![0.0f32; self.metadata.hidden_size];
         OlmoeOutput {
             expert_weights,
             selected_experts,
@@ -454,8 +586,16 @@ impl OLMoE {
         &self.metadata.quantization
     }
 
+    pub fn architecture(&self) -> &str {
+        &self.metadata.architecture
+    }
+
     pub fn hidden_size(&self) -> usize {
         self.metadata.hidden_size
+    }
+
+    pub fn source_hidden_size(&self) -> usize {
+        self.metadata.source_hidden_size
     }
 
     pub fn num_layers(&self) -> usize {
@@ -466,8 +606,16 @@ impl OLMoE {
         self.metadata.num_experts
     }
 
+    pub fn expert_used_count(&self) -> Option<usize> {
+        self.metadata.expert_used_count
+    }
+
     pub fn num_experts(&self) -> usize {
         self.num_experts
+    }
+
+    pub fn routing_tensor_name(&self) -> &str {
+        &self.routing_tensor_name
     }
 
     pub fn execution_mode(&self) -> OlmoeExecutionMode {
@@ -626,7 +774,8 @@ fn parse_checkpoint_layout(bytes: &[u8], path: &str) -> Result<ParsedCheckpointL
 
     let mut alignment = 32usize;
     let mut file_type = None;
-    let mut expert_count = OLMOE_NUM_EXPERTS;
+    let mut architecture = "olmoe".to_owned();
+    let mut numeric_metadata = HashMap::new();
 
     for _ in 0..kv_count {
         let key = cursor.read_string(path)?;
@@ -634,8 +783,12 @@ fn parse_checkpoint_layout(bytes: &[u8], path: &str) -> Result<ParsedCheckpointL
         match key.as_str() {
             "general.alignment" => alignment = cursor.read_numeric_as_usize(value_type, path)?,
             "general.file_type" => file_type = Some(cursor.read_numeric_as_u32(value_type, path)?),
-            "olmoe.expert_count" => {
-                expert_count = cursor.read_numeric_as_usize(value_type, path)?
+            "general.architecture" => {
+                architecture = cursor.read_string(path)?;
+            }
+            _ if is_numeric_gguf_value(value_type) => {
+                let value = cursor.read_numeric_as_usize(value_type, path)?;
+                numeric_metadata.insert(key, value);
             }
             _ => cursor.skip_value(value_type, path)?,
         }
@@ -675,51 +828,72 @@ fn parse_checkpoint_layout(bytes: &[u8], path: &str) -> Result<ParsedCheckpointL
         tensor.absolute_offset = tensor_data_offset + tensor.relative_offset;
     }
 
+    let source_hidden_size = numeric_metadata
+        .get(format!("{architecture}.embedding_length").as_str())
+        .copied()
+        .unwrap_or(OLMOE_HIDDEN);
+    if source_hidden_size < EMBEDDING_DIM {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "checkpoint '{path}' hidden size {source_hidden_size} is smaller than required SNN width {EMBEDDING_DIM}"
+        )));
+    }
+    let num_layers = numeric_metadata
+        .get(format!("{architecture}.block_count").as_str())
+        .copied()
+        .unwrap_or(OLMOE_NUM_LAYERS);
+    let num_experts = numeric_metadata
+        .get(format!("{architecture}.expert_count").as_str())
+        .copied()
+        .or_else(|| numeric_metadata.get("olmoe.expert_count").copied())
+        .unwrap_or(OLMOE_NUM_EXPERTS);
+    let expert_used_count = numeric_metadata
+        .get(format!("{architecture}.expert_used_count").as_str())
+        .copied();
+    let routing_tensor_name = resolve_routing_tensor_name(
+        path,
+        &tensors,
+        source_hidden_size,
+        num_experts,
+    )?;
+
     Ok(ParsedCheckpointLayout {
         metadata: OlmoeMetadata {
-            hidden_size: OLMOE_HIDDEN,
-            num_layers: OLMOE_NUM_LAYERS,
-            num_experts: expert_count,
+            architecture,
+            hidden_size: EMBEDDING_DIM,
+            source_hidden_size,
+            num_layers,
+            num_experts,
+            expert_used_count,
             quantization: quantization_label(file_type),
         },
         tensors,
+        routing_tensor_name,
     })
 }
 
-fn validate_routing_tensor(path: &str, tensor: &GgufTensorInfo) -> Result<()> {
+fn validate_routing_tensor(
+    path: &str,
+    tensor_name: &str,
+    tensor: &GgufTensorInfo,
+    hidden_size: usize,
+    num_experts: usize,
+) -> Result<()> {
     if tensor.ggml_type != GGML_TYPE_F32 {
         return Err(HybridError::UnsupportedFormat(format!(
-            "tensor '{ROUTING_TENSOR_NAME}' must be F32 in '{path}'"
+            "tensor '{tensor_name}' must be F32 in '{path}'"
         )));
     }
     if tensor.dims.len() != 2 {
         return Err(HybridError::UnsupportedFormat(format!(
-            "tensor '{ROUTING_TENSOR_NAME}' must be rank-2, got {:?}",
+            "tensor '{tensor_name}' must be rank-2, got {:?}",
             tensor.dims
         )));
     }
-    if tensor.n_elements != OLMOE_HIDDEN * OLMOE_NUM_EXPERTS {
+    let matches = (tensor.dims[0] == hidden_size && tensor.dims[1] == num_experts)
+        || (tensor.dims[0] == num_experts && tensor.dims[1] == hidden_size);
+    if !matches {
         return Err(HybridError::UnsupportedFormat(format!(
-            "tensor '{ROUTING_TENSOR_NAME}' has unexpected size {:?}",
-            tensor.dims
-        )));
-    }
-    Ok(())
-}
-
-fn validate_gpu_synapse_tensor(
-    path: &str,
-    tensor_name: &str,
-    tensor: &GgufTensorInfo,
-) -> Result<()> {
-    if tensor.ggml_type != GGML_TYPE_F16 {
-        return Err(HybridError::UnsupportedFormat(format!(
-            "tensor '{tensor_name}' must be F16 in '{path}'"
-        )));
-    }
-    if tensor.dims != [OLMOE_HIDDEN, OLMOE_HIDDEN] {
-        return Err(HybridError::UnsupportedFormat(format!(
-            "tensor '{tensor_name}' must be [2048, 2048], got {:?}",
+            "tensor '{tensor_name}' must expose expert axis {num_experts} and hidden axis {hidden_size}, got {:?}",
             tensor.dims
         )));
     }
@@ -730,15 +904,16 @@ fn routing_weight_index(
     tensor: &GgufTensorInfo,
     expert_id: usize,
     dim: usize,
+    hidden_size: usize,
     num_experts: usize,
 ) -> Result<usize> {
     let d0 = tensor.dims[0];
     let d1 = tensor.dims[1];
 
-    if d0 == EMBEDDING_DIM && d1 >= num_experts {
+    if d0 == hidden_size && d1 >= num_experts {
         return Ok(dim * d1 + expert_id);
     }
-    if d0 >= num_experts && d1 == EMBEDDING_DIM {
+    if d0 >= num_experts && d1 == hidden_size {
         return Ok(expert_id * d1 + dim);
     }
 
@@ -776,6 +951,45 @@ fn top_k_indices(weights: &[f32], top_k: usize) -> Vec<usize> {
         .take(top_k)
         .map(|(idx, _)| idx)
         .collect()
+}
+
+fn is_numeric_gguf_value(value_type: u32) -> bool {
+    matches!(
+        value_type,
+        GGUF_VALUE_TYPE_UINT8
+            | GGUF_VALUE_TYPE_INT8
+            | GGUF_VALUE_TYPE_UINT16
+            | GGUF_VALUE_TYPE_INT16
+            | GGUF_VALUE_TYPE_UINT32
+            | GGUF_VALUE_TYPE_INT32
+            | GGUF_VALUE_TYPE_UINT64
+            | GGUF_VALUE_TYPE_INT64
+    )
+}
+
+fn resolve_routing_tensor_name(
+    path: &str,
+    tensors: &HashMap<String, GgufTensorInfo>,
+    hidden_size: usize,
+    num_experts: usize,
+) -> Result<String> {
+    for candidate in ROUTING_TENSOR_CANDIDATES {
+        let Some(tensor) = tensors.get(candidate) else {
+            continue;
+        };
+        if validate_routing_tensor(path, candidate, tensor, hidden_size, num_experts).is_ok() {
+            return Ok(candidate.to_owned());
+        }
+    }
+
+    let available: Vec<String> = ROUTING_TENSOR_CANDIDATES
+        .iter()
+        .filter_map(|name| tensors.get(*name).map(|tensor| format!("{name}:{:?}", tensor.dims)))
+        .collect();
+
+    Err(HybridError::UnsupportedFormat(format!(
+        "no compatible first-block routing tensor found in '{path}' for hidden_size={hidden_size} expert_count={num_experts}; candidates={available:?}"
+    )))
 }
 
 fn quantization_label(file_type: Option<u32>) -> String {
@@ -1018,13 +1232,13 @@ mod tests {
         build_test_gguf(
             vec![
                 (
-                    ROUTING_TENSOR_NAME,
+                    ROUTING_TENSOR_CANDIDATES[0],
                     vec![EMBEDDING_DIM, OLMOE_NUM_EXPERTS],
                     GGML_TYPE_F32,
                     gate_payload,
                 ),
                 (
-                    DEFAULT_GPU_SYNAPSE_TENSOR_NAME,
+                    "blk.0.attn_q.weight",
                     vec![OLMOE_HIDDEN, OLMOE_HIDDEN],
                     GGML_TYPE_F16,
                     attn_q_payload,
@@ -1139,12 +1353,24 @@ mod tests {
     #[test]
     fn test_parse_checkpoint_layout_preserves_tensor_offsets() {
         let bytes = build_test_gguf(
-            vec![("demo.weight", vec![2, 2], GGML_TYPE_F32, vec![0u8; 16])],
+            vec![
+                (
+                    ROUTING_TENSOR_CANDIDATES[0],
+                    vec![EMBEDDING_DIM, OLMOE_NUM_EXPERTS],
+                    GGML_TYPE_F32,
+                    vec![0u8; EMBEDDING_DIM * OLMOE_NUM_EXPERTS * 4],
+                ),
+                ("demo.weight", vec![2, 2], GGML_TYPE_F32, vec![0u8; 16]),
+            ],
             64,
         );
         let parsed = parse_checkpoint_layout(&bytes, "test.gguf").unwrap();
+        let routing = parsed
+            .tensors
+            .get(ROUTING_TENSOR_CANDIDATES[0])
+            .unwrap();
         let tensor = parsed.tensors.get("demo.weight").unwrap();
-        assert_eq!(tensor.relative_offset, 0);
+        assert_eq!(tensor.relative_offset, routing.n_elements * std::mem::size_of::<f32>());
         assert_eq!(tensor.absolute_offset % 64, 0);
         assert_eq!(tensor.n_elements, 4);
     }
@@ -1153,7 +1379,7 @@ mod tests {
     fn test_probe_and_map_rejects_missing_routing_tensor() {
         let bytes = build_test_gguf(
             vec![(
-                DEFAULT_GPU_SYNAPSE_TENSOR_NAME,
+                "blk.0.attn_q.weight",
                 vec![OLMOE_HIDDEN, OLMOE_HIDDEN],
                 GGML_TYPE_F16,
                 vec![0u8; OLMOE_HIDDEN * OLMOE_HIDDEN * 2],
@@ -1162,23 +1388,23 @@ mod tests {
         );
         let path = write_temp_file(&bytes, "missing-routing");
         let err = OLMoE::probe_and_map(path.to_str().unwrap()).unwrap_err();
-        assert!(matches!(err, HybridError::MissingTensor { .. }));
+        assert!(matches!(err, HybridError::UnsupportedFormat(_)));
         let _ = std::fs::remove_file(path);
     }
 
     #[test]
-    fn test_probe_and_map_rejects_wrong_synapse_type() {
+    fn test_probe_and_map_allows_non_f16_synapse_tensor() {
         let gate_payload = vec![0u8; EMBEDDING_DIM * OLMOE_NUM_EXPERTS * 4];
         let bytes = build_test_gguf(
             vec![
                 (
-                    ROUTING_TENSOR_NAME,
+                    ROUTING_TENSOR_CANDIDATES[0],
                     vec![EMBEDDING_DIM, OLMOE_NUM_EXPERTS],
                     GGML_TYPE_F32,
                     gate_payload,
                 ),
                 (
-                    DEFAULT_GPU_SYNAPSE_TENSOR_NAME,
+                    "blk.0.attn_q.weight",
                     vec![OLMOE_HIDDEN, OLMOE_HIDDEN],
                     GGML_TYPE_F32,
                     vec![0u8; OLMOE_HIDDEN * OLMOE_HIDDEN * 4],
@@ -1187,7 +1413,10 @@ mod tests {
             32,
         );
         let path = write_temp_file(&bytes, "wrong-type");
-        let err = OLMoE::probe_and_map(path.to_str().unwrap()).unwrap_err();
+        let (_, _, mut checkpoint) = OLMoE::probe_and_map(path.to_str().unwrap()).unwrap();
+        let err = checkpoint
+            .registered_f16_tensor("blk.0.attn_q.weight", path.to_str().unwrap())
+            .unwrap_err();
         assert!(matches!(err, HybridError::UnsupportedFormat(_)));
         let _ = std::fs::remove_file(path);
     }
@@ -1251,13 +1480,16 @@ mod tests {
             return;
         };
 
-        let (metadata, checkpoint) = OLMoE::probe_and_map(&path).unwrap();
+        let (metadata, routing_tensor_name, checkpoint) = OLMoE::probe_and_map(&path).unwrap();
         assert_eq!(metadata.hidden_size, 2048);
         assert_eq!(metadata.num_experts, 64);
-        let routing = checkpoint.tensor_info(ROUTING_TENSOR_NAME, &path).unwrap();
+        assert_eq!(routing_tensor_name, ROUTING_TENSOR_CANDIDATES[0]);
+        let routing = checkpoint
+            .tensor_info(ROUTING_TENSOR_CANDIDATES[0], &path)
+            .unwrap();
         assert_eq!(routing.dims, vec![2048, 64]);
         let synapse = checkpoint
-            .tensor_info(DEFAULT_GPU_SYNAPSE_TENSOR_NAME, &path)
+            .tensor_info("blk.0.attn_q.weight", &path)
             .unwrap();
         assert_eq!(synapse.dims, vec![2048, 2048]);
     }
@@ -1279,7 +1511,7 @@ mod tests {
         let mut model = OLMoE::load_with_mode(&path, 8, 1, OlmoeExecutionMode::DenseSim).unwrap();
         accelerator.ensure_temporal_state(OLMOE_HIDDEN).unwrap();
         let weights = model
-            .registered_gpu_synapse_weights(DEFAULT_GPU_SYNAPSE_TENSOR_NAME)
+            .registered_gpu_synapse_weights("blk.0.attn_q.weight")
             .unwrap();
         accelerator
             .load_synapse_weights_f16_registered("env::blk.0.attn_q.weight", weights)


### PR DESCRIPTION
## **User description**
## What changed

This PR broadens the first-block GGUF bridge beyond the original OLMoE-only assumptions and turns `examples/saaq_latent_calibration.rs` into a labeled research run generator.

Key changes:
- add checkpoint probing for architecture, hidden size, expert count, and compatible routing tensor selection
- accept compatible GGUF first-block routing tensors such as `blk.0.ffn_gate_inp.weight`
- fall back to synthetic recurrent synapse weights when a checkpoint does not expose a square F16 `attn_q` tensor
- add Q8_0 token embedding decode for quantized `token_embd.weight`
- export labeled calibration artifacts: `tick_telemetry.txt`, `latent_telemetry.csv`, and `run_manifest.json`
- support `MOE_GGUF_PATH` as the preferred env var, while keeping `OLMOE_PATH` as a fallback alias
- update the other examples and README to reflect the generic GGUF path

## Why it changed

The existing bridge was hardcoded to OLMoE-specific metadata and tensor names. That blocked local GGUF experiments with newer MoE checkpoints, and the calibration output was not organized well enough for research reuse.

This PR makes the loader probe the checkpoint instead of assuming OLMoE layout, and it gives the calibration path a stable run-folder output structure for downstream Julia plotting and symbolic regression work.

## Impact

- OLMoE remains supported.
- Wider GGUF checkpoints can now be probed and partially adapted into the current 2048-neuron SNN path.
- Gemma-4 GGUF loading now progresses through metadata probe, routing tensor selection, and quantized token embedding decode.
- Research outputs are easier to compare and archive across runs.

## Validation

- `cargo test`
- `MOE_GGUF_PATH=/home/raulmc/Downloads/SNN_Quantization/models/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-UD-IQ4_NL.gguf RUN_OUTPUT_ROOT=/tmp/corinth_canal_gemma_smoke TICKS=1 cargo run --example saaq_latent_calibration`

Runtime note:
- the Gemma smoke run now reaches the GPU execution stage and then fails with `NoGpu` on this machine during the temporal step. The GGUF compatibility layer itself is loading and decoding successfully before that point.

## Review focus

Please focus review on:
- checkpoint metadata probing and routing tensor selection
- the 2048-width adaptation path for wider checkpoints
- Q8_0 token embedding decode
- the labeled run output layout in `saaq_latent_calibration`


___

## **CodeAnt-AI Description**
**Probe GGUF checkpoints dynamically and save labeled calibration runs**

### What Changed
- The calibration example now detects checkpoint metadata at startup, accepts `MOE_GGUF_PATH` with `OLMOE_PATH` as a fallback, and supports a wider range of GGUF checkpoints with matching routing tensors and quantized token embeddings
- Calibration runs now write a named output folder with `tick_telemetry.txt`, `latent_telemetry.csv`, and `run_manifest.json`, plus the expected plot path for later analysis
- The GPU temporal path no longer fails when a checkpoint does not expose a square F16 recurrent synapse tensor; it now falls back to the synthetic synapse path while keeping the real routing bridge
- Example commands and messages now point to the new GGUF path variable across the repo

### Impact
`✅ Wider GGUF checkpoint support`
`✅ Fewer calibration run failures`
`✅ Easier run comparison and archiving`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=L6ayNDwIEI1n0denHu7W2ijXaTZKARVjgNv3i1B980c&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
