### PR TITLE
feat: dual-SAAQ emission + telemetry source handling for SR.jl corpus runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,83 @@ tick=2 best_walker=45 elapsed_us=842
 
 This path exercises the pure Spikenaut physics engine (GIF membrane + adaptive thresholds + two-pass SAT reduction) driven by realistic, pooled semantic pressure.
 
+### Validation Sweeps (dual-SAAQ, CSV-replay, repeat-aware)
+
+The `saaq_latent_calibration` runner is a sweep orchestrator over every discovered GGUF model. Per-run artifacts land under a fully-labeled directory tree:
+
+```text
+<VALIDATION_OUTPUT_ROOT>/<model_slug>/<telemetry_source>/<heartbeat_slug>/<run_id>/
+    tick_telemetry.txt
+    latent_telemetry.csv
+    run_manifest.json
+```
+
+where `<run_id>` = `<YYYYMMDDTHHMMSS>_<prompt_slug>_r<repeat_idx>` (UTC, sortable).
+
+#### Environment knobs
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `TELEMETRY_SOURCE` | `synthetic` | `synthetic` runs the in-process sinusoid; `csv` replays a canonical telemetry CSV. Must be set explicitly to `csv` for real-corpus runs — defaults are dependency-light on purpose. |
+| `TELEMETRY_CSV_PATH` | `/home/raulmc/Julia/Surrogate_Viz.jl/telemetry.csv` | Canonical-format CSV (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`). Missing/malformed → fallback to synthetic, stamped `synthetic_fallback` in the manifest. |
+| `TICKS` | `512` | Per-run tick count. Special case: when `TICKS=0` *and* `TELEMETRY_SOURCE=csv`, uses the exact CSV row count so a SymbolicRegression.jl corpus run covers exactly one loop with zero wraparound contamination. |
+| `REPEAT_COUNT` | `1` | Number of repeats per (model, telemetry, heartbeat) tuple. Deterministic inputs mean repeats should bit-match — divergence indicates scheduler noise. |
+| `VALIDATION_OUTPUT_ROOT` | `/home/raulmc/Julia/Surrogate_Viz.jl/outputs/saaq15` | Top of the per-run output tree. |
+| `HEARTBEAT_MATRIX` | `off,on` | Kept as-is for this round; amplitude/period sweep is future work. |
+| `SAAQ_RULE` | `saaq_v1_5` | Selects which rule fills the legacy `saaq_delta_q_{prev,target}` columns. Both rules are always emitted in the dual-SAAQ columns regardless. |
+
+#### Wraparound hygiene
+
+For `TELEMETRY_SOURCE=csv`, if `TICKS > rows.len()` the runner emits a warning:
+
+```text
+wraparound: ticks={N} > rows={M}; regression corpus may be contaminated by looped endings. Prefer TICKS=0 or TICKS<={M}.
+```
+
+The manifest records `wraparound_enabled`, `wraparound_loops`, and `ticks_effective` so any downstream filter can reject contaminated traces with one predicate. **For SymbolicRegression.jl corpus generation, always use `TICKS=0` (or `TICKS ≤ CSV row count`).** Wraparound is intended for smoke tests only.
+
+#### Dual-SAAQ CSV schema
+
+`latent_telemetry.csv` preserves the original 12 columns for backward compatibility with existing SR.jl scripts, and appends 4 new columns so both SAAQ rules can be fitted without rerunning:
+
+```text
+timestamp_ms, avg_pop_firing_rate_hz, membrane_dv_dt, routing_entropy,
+saaq_delta_q_prev, saaq_delta_q_target,           # primary rule (selected via SAAQ_RULE)
+heartbeat_signal, heartbeat_enabled,
+gpu_temp_c, gpu_power_w, cpu_tctl_c, cpu_package_power_w,
+saaq_delta_q_legacy_prev, saaq_delta_q_legacy_target,   # SAAQ 1.0 trajectory
+saaq_delta_q_v15_prev, saaq_delta_q_v15_target          # SAAQ 1.5 trajectory
+```
+
+The feature columns fed to SR.jl (`avg_pop_firing_rate_hz`, `membrane_dv_dt`, `routing_entropy`) are computed from activity/routing only and are therefore identical across rules — this makes dual-emission paired data for free. See `SnnDualLatentCalibrator` in `src/latent.rs`.
+
+#### Recipes
+
+Synthetic smoke (no CSV dependency, fast wiring check):
+
+```bash
+TICKS=64 HEARTBEAT_MATRIX=off \
+  cargo run --release --example saaq_latent_calibration
+```
+
+RE4 corpus run (exact CSV length, zero wraparound):
+
+```bash
+TELEMETRY_SOURCE=csv TICKS=0 REPEAT_COUNT=1 HEARTBEAT_MATRIX=off \
+  cargo run --release --example saaq_latent_calibration
+```
+
+Repeatability check (3 runs per model per heartbeat, deterministic inputs):
+
+```bash
+TELEMETRY_SOURCE=csv TICKS=0 REPEAT_COUNT=3 \
+  cargo run --release --example saaq_latent_calibration
+```
+
+#### CWD routing-CSV caveat
+
+`snn_gpu_routing_telemetry.csv` is hardcoded to the current working directory by `forward_gpu_temporal` / `compute_routing_telemetry` (see `src/model/core.rs`). `saaq_latent_calibration` drives the GPU via `tick_gpu_temporal`, which does **not** write that file, so it is safe today. If a future change starts invoking `forward_gpu_temporal` from the validation runner, every model's writes will silently merge into the same CWD-scoped file — move the sink into the per-run directory before doing that.
+
 ## GPU Routing Telemetry
 
 For high-performance expert routing analysis, the crate utilizes the NVIDIA Blackwell (RTX 5080) GPU to perform two-pass SAT reductions directly in VRAM. This telemetry path captures the final winning scores and walkers for every token processed.

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -1,19 +1,20 @@
 mod support;
 
 use corinth_canal::{
-    FunnelActivity, HeartbeatInjector, SaaqUpdateRule, SnnLatentCalibrator, SnnLatentCsvExporter,
-    gpu::GpuAccelerator, model::Model,
+    FunnelActivity, HeartbeatInjector, SaaqUpdateRule, SnnDualLatentCalibrator,
+    SnnLatentCsvExporter, gpu::GpuAccelerator, model::Model,
 };
 use serde::Serialize;
 use std::fs::{self, File};
 use std::io::{BufWriter, Error, Write};
 use std::path::PathBuf;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 use support::{
-    ValidationModelSpec, default_spiking_model_config, discover_validation_models, heartbeat_gain,
-    heartbeat_modes_for_matrix, model_family_override_from_env,
-    prompt_embedding_for_validation, prompt_profile_slug, prompt_text_for_profile,
-    saaq_update_rule_from_env, synthetic_base_snapshot, ticks_from_env,
+    ResolvedTelemetry, TelemetrySource, ValidationModelSpec, default_spiking_model_config,
+    discover_validation_models, heartbeat_gain, heartbeat_modes_for_matrix,
+    model_family_override_from_env, prompt_embedding_for_validation, prompt_profile_slug,
+    prompt_text_for_profile, repeat_count_from_env, resolve_telemetry_source,
+    saaq_update_rule_from_env, telemetry_snapshot_for_tick, ticks_from_env,
 };
 
 #[derive(Debug, Serialize)]
@@ -30,6 +31,8 @@ struct ValidationManifest {
     prompt_text: String,
     ticks: usize,
     saaq_rule: &'static str,
+    saaq_primary_rule: &'static str,
+    saaq_dual_emit: bool,
     validation_status: &'static str,
     error: Option<String>,
     heartbeat_enabled: bool,
@@ -37,13 +40,67 @@ struct ValidationManifest {
     heartbeat_period_ticks: usize,
     heartbeat_duty_cycle: f32,
     heartbeat_phase_offset_ticks: usize,
+    telemetry_source: String,
+    telemetry_csv_path: Option<String>,
+    telemetry_row_count: Option<usize>,
+    wraparound_enabled: bool,
+    wraparound_loops: u64,
+    ticks_effective: usize,
+    run_id: String,
+    run_dir: String,
+    output_root: String,
+    repeat_idx: usize,
+    repeat_count: usize,
+    cwd_routing_csv_contaminated: bool,
     generated_files: Vec<String>,
+}
+
+struct RunContext<'a> {
+    spec: &'a ValidationModelSpec,
+    prompt_profile: &'a str,
+    prompt_text: &'a str,
+    ticks: usize,
+    heartbeat_enabled: bool,
+    repeat_idx: usize,
+    repeat_count: usize,
+    resolved: &'a ResolvedTelemetry,
+    run_id: String,
+    output_root: PathBuf,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let prompt_profile = prompt_profile_slug();
     let prompt_text = prompt_text_for_profile(&prompt_profile);
     let ticks = ticks_from_env(512);
+    let repeat_count = repeat_count_from_env();
+    let resolved = resolve_telemetry_source();
+    let output_root = output_root_from_env();
+
+    // Effective tick count: when TICKS=0 and CSV replay is live, use the full
+    // CSV length so SR.jl corpus runs cover exactly one loop with zero
+    // wraparound contamination (per plan: wraparound is for smoke only).
+    let effective_ticks = match (ticks, resolved.source, resolved.row_count()) {
+        (0, TelemetrySource::Csv, Some(rows)) if rows > 0 => rows,
+        (0, _, _) => 1, // degenerate guard; never emit a zero-tick run
+        (other, _, _) => other,
+    };
+
+    if let Some(rows) = resolved.row_count() {
+        if effective_ticks > rows {
+            eprintln!(
+                "wraparound: ticks={effective_ticks} > rows={rows}; regression corpus may be contaminated by looped endings. Prefer TICKS=0 or TICKS<={rows}.",
+            );
+        }
+    }
+
+    println!(
+        "saaq_latent_calibration: telemetry_source={} ticks={} repeat_count={} output_root={}",
+        resolved.source_label,
+        effective_ticks,
+        repeat_count,
+        output_root.display(),
+    );
+
     let models = discover_validation_models();
     if models.is_empty() {
         return Err(Error::other(
@@ -53,24 +110,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     for spec in models {
-        for heartbeat_enabled in heartbeat_modes_for_matrix() {
-            run_validation(&spec, &prompt_profile, prompt_text, ticks, heartbeat_enabled)?;
+        for repeat_idx in 0..repeat_count {
+            for heartbeat_enabled in heartbeat_modes_for_matrix() {
+                let run_id = build_run_id(&prompt_profile, repeat_idx);
+                let ctx = RunContext {
+                    spec: &spec,
+                    prompt_profile: &prompt_profile,
+                    prompt_text,
+                    ticks: effective_ticks,
+                    heartbeat_enabled,
+                    repeat_idx,
+                    repeat_count,
+                    resolved: &resolved,
+                    run_id,
+                    output_root: output_root.clone(),
+                };
+                run_validation(&ctx)?;
+            }
         }
     }
 
     Ok(())
 }
 
-fn run_validation(
-    spec: &ValidationModelSpec,
-    prompt_profile: &str,
-    prompt_text: &str,
-    ticks: usize,
-    heartbeat_enabled: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = default_spiking_model_config(spec.path.clone(), 1);
-    config.model_family = model_family_override_from_env().or(spec.family);
-    config.heartbeat.enabled = heartbeat_enabled;
+fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = default_spiking_model_config(ctx.spec.path.clone(), 1);
+    config.model_family = model_family_override_from_env().or(ctx.spec.family);
+    config.heartbeat.enabled = ctx.heartbeat_enabled;
     let saaq_rule = saaq_update_rule_from_env();
 
     let mut accelerator = GpuAccelerator::new();
@@ -79,12 +145,12 @@ fn run_validation(
     if !model.router_loaded() {
         return Err(Error::other(format!(
             "router did not load for checkpoint '{}'",
-            spec.path
+            ctx.spec.path
         ))
         .into());
     }
 
-    let run_dir = build_run_dir(spec, prompt_profile, heartbeat_enabled)?;
+    let run_dir = build_run_dir(ctx)?;
     fs::create_dir_all(&run_dir)?;
     let tick_path = run_dir.join("tick_telemetry.txt");
     let latent_path = run_dir.join("latent_telemetry.csv");
@@ -100,19 +166,16 @@ fn run_validation(
     ];
     let target_neurons = model.projector_mut().input_neurons();
     let (prompt_embedding, prompt_embedding_source) =
-        match prompt_embedding_for_validation(&spec.path, prompt_text, target_neurons) {
+        match prompt_embedding_for_validation(&ctx.spec.path, ctx.prompt_text, target_neurons) {
             Ok(result) => result,
             Err(error) => {
                 write_manifest(
                     &manifest_path,
                     build_manifest(
-                        spec,
-                        prompt_profile,
-                        prompt_text,
-                        ticks,
+                        ctx,
                         &config,
                         &model,
-                        heartbeat_enabled,
+                        &run_dir,
                         "unavailable",
                         saaq_rule,
                         "prompt_embedding_failed",
@@ -127,13 +190,10 @@ fn run_validation(
     write_manifest(
         &manifest_path,
         build_manifest(
-            spec,
-            prompt_profile,
-            prompt_text,
-            ticks,
+            ctx,
             &config,
             &model,
-            heartbeat_enabled,
+            &run_dir,
             &prompt_embedding_source,
             saaq_rule,
             "preflight",
@@ -146,13 +206,10 @@ fn run_validation(
         write_manifest(
             &manifest_path,
             build_manifest(
-                spec,
-                prompt_profile,
-                prompt_text,
-                ticks,
+                ctx,
                 &config,
                 &model,
-                heartbeat_enabled,
+                &run_dir,
                 &prompt_embedding_source,
                 saaq_rule,
                 "gpu_setup_failed",
@@ -165,24 +222,26 @@ fn run_validation(
 
     let mut tick_writer = BufWriter::new(File::create(&tick_path)?);
     let mut latent_exporter = SnnLatentCsvExporter::create(&latent_path)?;
-    let mut calibrator = SnnLatentCalibrator::with_update_rule(saaq_rule);
+    let mut calibrator = SnnDualLatentCalibrator::new(saaq_rule);
     let heartbeat = HeartbeatInjector::new(config.heartbeat.clone());
 
     println!(
-        "validation_start model_slug={} family={:?} architecture={} heartbeat_enabled={} ticks={} routing_tensor={} synapse_source={}",
-        spec.slug,
+        "validation_start model_slug={} family={:?} architecture={} heartbeat_enabled={} ticks={} repeat={}/{} routing_tensor={} synapse_source={} telemetry_source={}",
+        ctx.spec.slug,
         model.router_family(),
         model.router_architecture(),
-        heartbeat_enabled,
-        ticks,
+        ctx.heartbeat_enabled,
+        ctx.ticks,
+        ctx.repeat_idx + 1,
+        ctx.repeat_count,
         model.routing_tensor_name(),
         model.synapse_source(),
+        ctx.resolved.source_label,
     );
 
     let run_result = (|| -> Result<(), Box<dyn std::error::Error>> {
-        for tick in 0..ticks {
-            let mut snap = synthetic_base_snapshot(tick);
-            snap.timestamp_ms = (tick as u64) + 1;
+        for tick in 0..ctx.ticks {
+            let snap = telemetry_snapshot_for_tick(tick, ctx.resolved);
             let snap = heartbeat.apply(&snap, tick);
             let gain = heartbeat_gain(snap.heartbeat_signal);
             let input_spikes: Vec<f32> =
@@ -244,13 +303,10 @@ fn run_validation(
         write_manifest(
             &manifest_path,
             build_manifest(
-                spec,
-                prompt_profile,
-                prompt_text,
-                ticks,
+                ctx,
                 &config,
                 &model,
-                heartbeat_enabled,
+                &run_dir,
                 &prompt_embedding_source,
                 saaq_rule,
                 "tick_failed",
@@ -261,34 +317,25 @@ fn run_validation(
         return Err(error);
     }
 
-    let manifest = ValidationManifest {
-        model_slug: spec.slug.clone(),
-        model_family: format!("{:?}", model.router_family()),
-        architecture: model.router_architecture().to_owned(),
-        checkpoint_path: spec.path.clone(),
-        routing_tensor_name: model.routing_tensor_name().to_owned(),
-        synapse_source: model.synapse_source().to_owned(),
-        checkpoint_format: "gguf",
-        prompt_embedding_source,
-        prompt_profile: prompt_profile.to_owned(),
-        prompt_text: prompt_text.to_owned(),
-        ticks,
-        saaq_rule: saaq_rule_label(saaq_rule),
-        validation_status: "completed",
-        error: None,
-        heartbeat_enabled,
-        heartbeat_amplitude: config.heartbeat.amplitude,
-        heartbeat_period_ticks: config.heartbeat.period_ticks,
-        heartbeat_duty_cycle: config.heartbeat.duty_cycle,
-        heartbeat_phase_offset_ticks: config.heartbeat.phase_offset_ticks,
+    let manifest = build_manifest(
+        ctx,
+        &config,
+        &model,
+        &run_dir,
+        &prompt_embedding_source,
+        saaq_rule,
+        "completed",
+        None,
         generated_files,
-    };
+    );
     write_manifest(&manifest_path, manifest)?;
 
     println!(
-        "validation_complete model_slug={} heartbeat_enabled={} run_dir={}",
-        spec.slug,
-        heartbeat_enabled,
+        "validation_complete model_slug={} heartbeat_enabled={} repeat={}/{} run_dir={}",
+        ctx.spec.slug,
+        ctx.heartbeat_enabled,
+        ctx.repeat_idx + 1,
+        ctx.repeat_count,
         run_dir.display()
     );
 
@@ -299,39 +346,70 @@ fn run_validation(
 }
 
 fn build_manifest(
-    spec: &ValidationModelSpec,
-    prompt_profile: &str,
-    prompt_text: &str,
-    ticks: usize,
+    ctx: &RunContext<'_>,
     config: &corinth_canal::model::ModelConfig,
     model: &Model,
-    heartbeat_enabled: bool,
+    run_dir: &std::path::Path,
     prompt_embedding_source: &str,
     saaq_rule: SaaqUpdateRule,
     validation_status: &'static str,
     error: Option<String>,
     generated_files: Vec<String>,
 ) -> ValidationManifest {
+    let telemetry_row_count = ctx.resolved.row_count();
+    let wraparound_enabled = telemetry_row_count
+        .map(|rows| rows > 0 && ctx.ticks > rows)
+        .unwrap_or(false);
+    // Count only *extra* passes beyond the first. `ticks == rows` is exactly
+    // one pass with zero wraparound (SR.jl corpus sweet spot); `ticks =
+    // 2*rows` is one wraparound; and so on. This makes the field a clean
+    // predicate for "did this run teach the regressor on looped data?".
+    let wraparound_loops = telemetry_row_count
+        .filter(|rows| *rows > 0 && ctx.ticks > *rows)
+        .map(|rows| ((ctx.ticks - rows) as u64) / (rows as u64) + 1)
+        .unwrap_or(0);
+
     ValidationManifest {
-        model_slug: spec.slug.clone(),
+        model_slug: ctx.spec.slug.clone(),
         model_family: format!("{:?}", model.router_family()),
         architecture: model.router_architecture().to_owned(),
-        checkpoint_path: spec.path.clone(),
+        checkpoint_path: ctx.spec.path.clone(),
         routing_tensor_name: model.routing_tensor_name().to_owned(),
         synapse_source: model.synapse_source().to_owned(),
         checkpoint_format: "gguf",
         prompt_embedding_source: prompt_embedding_source.to_owned(),
-        prompt_profile: prompt_profile.to_owned(),
-        prompt_text: prompt_text.to_owned(),
-        ticks,
+        prompt_profile: ctx.prompt_profile.to_owned(),
+        prompt_text: ctx.prompt_text.to_owned(),
+        ticks: ctx.ticks,
         saaq_rule: saaq_rule_label(saaq_rule),
+        saaq_primary_rule: saaq_rule_label(saaq_rule),
+        saaq_dual_emit: true,
         validation_status,
         error,
-        heartbeat_enabled,
+        heartbeat_enabled: ctx.heartbeat_enabled,
         heartbeat_amplitude: config.heartbeat.amplitude,
         heartbeat_period_ticks: config.heartbeat.period_ticks,
         heartbeat_duty_cycle: config.heartbeat.duty_cycle,
         heartbeat_phase_offset_ticks: config.heartbeat.phase_offset_ticks,
+        telemetry_source: ctx.resolved.source_label.clone(),
+        telemetry_csv_path: ctx
+            .resolved
+            .csv_path
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned()),
+        telemetry_row_count,
+        wraparound_enabled,
+        wraparound_loops,
+        ticks_effective: ctx.ticks,
+        run_id: ctx.run_id.clone(),
+        run_dir: run_dir.to_string_lossy().into_owned(),
+        output_root: ctx.output_root.to_string_lossy().into_owned(),
+        repeat_idx: ctx.repeat_idx,
+        repeat_count: ctx.repeat_count,
+        // `snn_gpu_routing_telemetry.csv` is written to CWD by
+        // `forward_gpu_temporal` / `compute_routing_telemetry` only; this
+        // runner uses `tick_gpu_temporal`, which does not touch that file.
+        cwd_routing_csv_contaminated: false,
         generated_files,
     }
 }
@@ -351,22 +429,79 @@ fn saaq_rule_label(rule: SaaqUpdateRule) -> &'static str {
     }
 }
 
-fn build_run_dir(
-    spec: &ValidationModelSpec,
-    prompt_profile: &str,
-    heartbeat_enabled: bool,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let root = std::env::var("VALIDATION_OUTPUT_ROOT")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("outputs").join("validation"));
-    let epoch = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-    let heartbeat_slug = if heartbeat_enabled {
+fn output_root_from_env() -> PathBuf {
+    if let Ok(value) = std::env::var("VALIDATION_OUTPUT_ROOT") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    PathBuf::from("/home/raulmc/Julia/Surrogate_Viz.jl/outputs/saaq15")
+}
+
+fn build_run_id(prompt_profile: &str, repeat_idx: usize) -> String {
+    format!(
+        "{}_{}_r{}",
+        format_local_timestamp_compact(),
+        prompt_profile,
+        repeat_idx
+    )
+}
+
+fn build_run_dir(ctx: &RunContext<'_>) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let heartbeat_slug = if ctx.heartbeat_enabled {
         "heartbeat_on"
     } else {
         "heartbeat_off"
     };
-    Ok(root.join(format!(
-        "{epoch}_{}_{}_{}",
-        spec.slug, prompt_profile, heartbeat_slug
-    )))
+    Ok(ctx
+        .output_root
+        .join(&ctx.spec.slug)
+        .join(&ctx.resolved.source_label)
+        .join(heartbeat_slug)
+        .join(&ctx.run_id))
+}
+
+/// Return a local-time-ish compact timestamp `YYYYMMDDTHHMMSS` suitable for
+/// sortable directory naming. We derive it from seconds since UNIX_EPOCH with
+/// the local TZ offset pulled from `std::time` via a manual conversion — no
+/// external crate needed and no chrono dependency.
+fn format_local_timestamp_compact() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    // Pure-Rust gregorian breakdown (UTC). Using UTC keeps timestamps unique
+    // and sortable without depending on the machine's TZ configuration; the
+    // full ISO-ish form is still human-readable in the path.
+    let (year, month, day, hour, minute, second) = civil_from_unix_secs(secs as i64);
+    format!(
+        "{year:04}{month:02}{day:02}T{hour:02}{minute:02}{second:02}"
+    )
+}
+
+/// Civil (Y, M, D, h, m, s) in UTC from a unix timestamp.
+/// Based on Howard Hinnant's public-domain date algorithm.
+fn civil_from_unix_secs(secs: i64) -> (i32, u32, u32, u32, u32, u32) {
+    let days = secs.div_euclid(86_400);
+    let rem = secs.rem_euclid(86_400) as u32;
+    let hour = rem / 3_600;
+    let minute = (rem % 3_600) / 60;
+    let second = rem % 60;
+
+    // Hinnant's civil_from_days
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if m <= 2 { y + 1 } else { y };
+    (year as i32, m as u32, d as u32, hour, minute, second)
 }

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -257,6 +257,246 @@ pub fn ticks_from_env(default_ticks: usize) -> usize {
     env_usize("TICKS", default_ticks)
 }
 
+pub fn repeat_count_from_env() -> usize {
+    env_usize("REPEAT_COUNT", 1).max(1)
+}
+
+/// Source of per-tick telemetry snapshots feeding the validation runner.
+///
+/// Default is [`TelemetrySource::Synthetic`] so a fresh clone never silently
+/// depends on a machine-specific CSV path. CSV replay is opt-in via
+/// `TELEMETRY_SOURCE=csv` for RE4/Cyberpunk corpus generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetrySource {
+    Synthetic,
+    Csv,
+}
+
+/// Telemetry state resolved once per process and reused by every tick.
+///
+/// `source_label` is what lands in the directory path and manifest: one of
+/// `synthetic`, `synthetic_fallback`, or `csv_<stem>` (e.g. `csv_re4` for
+/// `telemetry.csv`). `rows` is only populated on a successful CSV load.
+#[derive(Debug, Clone)]
+pub struct ResolvedTelemetry {
+    pub source: TelemetrySource,
+    pub source_label: String,
+    pub csv_path: Option<PathBuf>,
+    pub rows: Option<Vec<corinth_canal::TelemetrySnapshot>>,
+}
+
+impl ResolvedTelemetry {
+    pub fn row_count(&self) -> Option<usize> {
+        self.rows.as_ref().map(|rows| rows.len())
+    }
+}
+
+pub fn telemetry_source_from_env() -> TelemetrySource {
+    match std::env::var("TELEMETRY_SOURCE")
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .trim()
+    {
+        "csv" => TelemetrySource::Csv,
+        // Empty string and any unrecognised value fall back to Synthetic so
+        // contributors never get surprised by a missing CSV path.
+        _ => TelemetrySource::Synthetic,
+    }
+}
+
+pub fn telemetry_csv_path_from_env() -> PathBuf {
+    if let Ok(value) = std::env::var("TELEMETRY_CSV_PATH") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    PathBuf::from("/home/raulmc/Julia/Surrogate_Viz.jl/telemetry.csv")
+}
+
+const TELEMETRY_CSV_HEADER: &str =
+    "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
+
+/// Parse a canonical telemetry CSV exported by `gaming-telemetry` into a
+/// vector of [`corinth_canal::TelemetrySnapshot`] ready for replay.
+///
+/// Fails fast on header mismatch; silently skips malformed data rows (counted
+/// in the returned log line via stderr) so a few dropped samples don't abort
+/// a 2000-row sweep.
+pub fn load_csv_telemetry_rows(
+    path: &Path,
+) -> Result<Vec<corinth_canal::TelemetrySnapshot>, Box<dyn std::error::Error>> {
+    let contents = std::fs::read_to_string(path).map_err(|error| {
+        Error::other(format!(
+            "telemetry CSV '{}' could not be read: {error}",
+            path.display()
+        ))
+    })?;
+
+    let mut lines = contents.lines();
+    let header = lines
+        .next()
+        .ok_or_else(|| Error::other(format!("telemetry CSV '{}' is empty", path.display())))?
+        .trim();
+    if header != TELEMETRY_CSV_HEADER {
+        return Err(Error::other(format!(
+            "telemetry CSV '{}' header mismatch: expected '{TELEMETRY_CSV_HEADER}', got '{header}'",
+            path.display()
+        ))
+        .into());
+    }
+
+    let mut rows = Vec::new();
+    let mut skipped = 0usize;
+    for (idx, raw_line) in lines.enumerate() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = line.split(',').collect();
+        if fields.len() != 5 {
+            skipped += 1;
+            continue;
+        }
+        let parsed = (
+            fields[0].parse::<u64>().ok(),
+            parse_finite_f32(fields[1]),
+            parse_finite_f32(fields[2]),
+            parse_finite_f32(fields[3]),
+            parse_finite_f32(fields[4]),
+        );
+        let (
+            Some(timestamp_ms),
+            Some(gpu_temp_c),
+            Some(gpu_power_w),
+            Some(cpu_tctl_c),
+            Some(cpu_package_power_w),
+        ) = parsed
+        else {
+            skipped += 1;
+            let _ = idx;
+            continue;
+        };
+        rows.push(corinth_canal::TelemetrySnapshot {
+            timestamp_ms,
+            gpu_temp_c,
+            gpu_power_w,
+            cpu_tctl_c,
+            cpu_package_power_w,
+            heartbeat_signal: 0.0,
+            heartbeat_enabled: false,
+        });
+    }
+
+    if skipped > 0 {
+        eprintln!(
+            "load_csv_telemetry_rows: skipped {skipped} malformed row(s) in '{}'",
+            path.display()
+        );
+    }
+
+    Ok(rows)
+}
+
+/// Resolve the process-wide telemetry source once.
+///
+/// For `Csv`, loads and validates the CSV file up front; if the file is
+/// missing, malformed, or empty, emits a single warning to stderr and
+/// degrades to `Synthetic`, stamping `source_label = "synthetic_fallback"`
+/// so the manifest faithfully records what actually happened.
+pub fn resolve_telemetry_source() -> ResolvedTelemetry {
+    match telemetry_source_from_env() {
+        TelemetrySource::Synthetic => ResolvedTelemetry {
+            source: TelemetrySource::Synthetic,
+            source_label: "synthetic".to_string(),
+            csv_path: None,
+            rows: None,
+        },
+        TelemetrySource::Csv => {
+            let csv_path = telemetry_csv_path_from_env();
+            match load_csv_telemetry_rows(&csv_path) {
+                Ok(rows) if !rows.is_empty() => {
+                    let label = csv_source_label(&csv_path);
+                    ResolvedTelemetry {
+                        source: TelemetrySource::Csv,
+                        source_label: label,
+                        csv_path: Some(csv_path),
+                        rows: Some(rows),
+                    }
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "resolve_telemetry_source: CSV '{}' is empty; falling back to synthetic",
+                        csv_path.display()
+                    );
+                    ResolvedTelemetry {
+                        source: TelemetrySource::Synthetic,
+                        source_label: "synthetic_fallback".to_string(),
+                        csv_path: Some(csv_path),
+                        rows: None,
+                    }
+                }
+                Err(error) => {
+                    eprintln!(
+                        "resolve_telemetry_source: CSV '{}' failed to load: {error}; falling back to synthetic",
+                        csv_path.display()
+                    );
+                    ResolvedTelemetry {
+                        source: TelemetrySource::Synthetic,
+                        source_label: "synthetic_fallback".to_string(),
+                        csv_path: Some(csv_path),
+                        rows: None,
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Convert a CSV path into a directory-safe source slug. The stem
+/// `telemetry` is treated as the canonical RE4 corpus and renders as
+/// `csv_re4`; any other stem becomes `csv_<stem>`.
+fn csv_source_label(path: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown")
+        .to_ascii_lowercase();
+    if stem == "telemetry" {
+        "csv_re4".to_string()
+    } else {
+        let sanitized = stem.replace([' ', '.'], "_");
+        format!("csv_{sanitized}")
+    }
+}
+
+/// Produce the telemetry snapshot for a given tick. For CSV replay this
+/// wraps around when `tick >= rows.len()`; the caller is responsible for
+/// warning when `TICKS > row_count` (see `saaq_latent_calibration`).
+///
+/// `timestamp_ms` is always rewritten to `tick + 1` so the resulting latent
+/// CSV joins 1-to-1 against `tick_telemetry.txt` on tick index regardless
+/// of the underlying CSV's absolute timestamps.
+pub fn telemetry_snapshot_for_tick(
+    tick: usize,
+    resolved: &ResolvedTelemetry,
+) -> corinth_canal::TelemetrySnapshot {
+    let mut snap = match (resolved.source, resolved.rows.as_ref()) {
+        (TelemetrySource::Csv, Some(rows)) if !rows.is_empty() => {
+            let idx = tick % rows.len();
+            rows[idx].clone()
+        }
+        _ => synthetic_base_snapshot(tick),
+    };
+    snap.timestamp_ms = (tick as u64) + 1;
+    snap
+}
+
+fn parse_finite_f32(value: &str) -> Option<f32> {
+    let parsed = value.parse::<f32>().ok()?;
+    if parsed.is_finite() { Some(parsed) } else { None }
+}
+
 pub fn synthetic_base_snapshot(tick: usize) -> corinth_canal::TelemetrySnapshot {
     let phase = tick as f32 * 0.041;
     corinth_canal::TelemetrySnapshot {
@@ -423,4 +663,127 @@ fn env_flag(key: &str, default_value: bool) -> bool {
         .ok()
         .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
         .unwrap_or(default_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp_csv(name: &str, contents: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "corinth_canal_support_{}_{}.csv",
+            name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn load_csv_accepts_canonical_header_and_parses_rows() {
+        let csv = "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w\n\
+                   1000,60.5,250.0,70.0,120.0\n\
+                   2000,61.0,252.5,70.5,121.5\n";
+        let path = write_temp_csv("canonical", csv);
+        let rows = load_csv_telemetry_rows(&path).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].timestamp_ms, 1000);
+        assert!((rows[0].gpu_temp_c - 60.5).abs() < 1e-6);
+        assert_eq!(rows[1].timestamp_ms, 2000);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn load_csv_rejects_bad_header() {
+        let csv = "t,gpu,gpuw,cpu,cpuw\n1000,60,250,70,120\n";
+        let path = write_temp_csv("bad_header", csv);
+        let err = load_csv_telemetry_rows(&path).unwrap_err();
+        assert!(err.to_string().contains("header mismatch"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn load_csv_skips_malformed_rows() {
+        let csv = "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w\n\
+                   1000,60.5,250.0,70.0,120.0\n\
+                   malformed,row\n\
+                   2000,NaN,250.0,70.0,120.0\n\
+                   3000,61.0,252.5,70.5,121.5\n";
+        let path = write_temp_csv("skip_bad", csv);
+        let rows = load_csv_telemetry_rows(&path).unwrap();
+        assert_eq!(rows.len(), 2, "expected only the two fully-valid rows");
+        assert_eq!(rows[0].timestamp_ms, 1000);
+        assert_eq!(rows[1].timestamp_ms, 3000);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn telemetry_snapshot_for_tick_wraps_around_csv_rows() {
+        let rows = vec![
+            corinth_canal::TelemetrySnapshot {
+                timestamp_ms: 111,
+                gpu_temp_c: 10.0,
+                gpu_power_w: 100.0,
+                cpu_tctl_c: 20.0,
+                cpu_package_power_w: 200.0,
+                heartbeat_signal: 0.0,
+                heartbeat_enabled: false,
+            },
+            corinth_canal::TelemetrySnapshot {
+                timestamp_ms: 222,
+                gpu_temp_c: 30.0,
+                gpu_power_w: 300.0,
+                cpu_tctl_c: 40.0,
+                cpu_package_power_w: 400.0,
+                heartbeat_signal: 0.0,
+                heartbeat_enabled: false,
+            },
+        ];
+        let resolved = ResolvedTelemetry {
+            source: TelemetrySource::Csv,
+            source_label: "csv_re4".to_string(),
+            csv_path: Some(PathBuf::from("/tmp/telemetry.csv")),
+            rows: Some(rows),
+        };
+
+        // tick=0 uses row[0], tick=3 wraps back to row[1] (3 % 2 == 1).
+        let snap0 = telemetry_snapshot_for_tick(0, &resolved);
+        let snap3 = telemetry_snapshot_for_tick(3, &resolved);
+
+        assert!((snap0.gpu_temp_c - 10.0).abs() < 1e-6);
+        assert!((snap3.gpu_temp_c - 30.0).abs() < 1e-6);
+        // timestamps are rewritten to (tick + 1) for 1-to-1 join with tick txt.
+        assert_eq!(snap0.timestamp_ms, 1);
+        assert_eq!(snap3.timestamp_ms, 4);
+    }
+
+    #[test]
+    fn telemetry_snapshot_for_tick_uses_synthetic_on_fallback() {
+        let resolved = ResolvedTelemetry {
+            source: TelemetrySource::Synthetic,
+            source_label: "synthetic_fallback".to_string(),
+            csv_path: Some(PathBuf::from("/nonexistent/telemetry.csv")),
+            rows: None,
+        };
+        let snap = telemetry_snapshot_for_tick(5, &resolved);
+        // Synthetic path writes its own timestamp then we overwrite to tick+1.
+        assert_eq!(snap.timestamp_ms, 6);
+        // And the synthetic sinusoid produces non-zero, finite values.
+        assert!(snap.gpu_temp_c.is_finite() && snap.gpu_temp_c > 0.0);
+    }
+
+    #[test]
+    fn csv_source_label_maps_telemetry_stem_to_csv_re4() {
+        assert_eq!(
+            csv_source_label(Path::new("/home/raulmc/Julia/Surrogate_Viz.jl/telemetry.csv")),
+            "csv_re4"
+        );
+        assert_eq!(
+            csv_source_label(Path::new("/tmp/cyberpunk2077_combat.csv")),
+            "csv_cyberpunk2077_combat"
+        );
+    }
 }

--- a/src/latent.rs
+++ b/src/latent.rs
@@ -21,7 +21,11 @@ pub struct SnnLatentSnapshot {
     pub avg_pop_firing_rate_hz: f32,
     pub membrane_dv_dt: f32,
     pub routing_entropy: f32,
+    /// Legacy SAAQ column carrying whichever rule is designated primary.
+    /// Preserved so existing SR.jl scripts that reference this name keep
+    /// working after dual-rule emission was added.
     pub saaq_delta_q_prev: f32,
+    /// Legacy SAAQ column carrying whichever rule is designated primary.
     pub saaq_delta_q_target: f32,
     pub heartbeat_signal: f32,
     pub heartbeat_enabled: bool,
@@ -29,6 +33,14 @@ pub struct SnnLatentSnapshot {
     pub gpu_power_w: f32,
     pub cpu_tctl_c: f32,
     pub cpu_package_power_w: f32,
+    /// SAAQ 1.0 (`LegacyV1_0`) previous target at this tick. Emitted by
+    /// [`SnnDualLatentCalibrator`] so SR.jl can fit candidate laws against
+    /// either rule without rerunning the whole sweep.
+    pub saaq_delta_q_legacy_prev: f32,
+    pub saaq_delta_q_legacy_target: f32,
+    /// SAAQ 1.5 (`SaaqV1_5SqrtRate`) previous target at this tick.
+    pub saaq_delta_q_v15_prev: f32,
+    pub saaq_delta_q_v15_target: f32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -100,6 +112,10 @@ impl SnnLatentCalibrator {
         self.prev_mean_membrane = Some(mean_membrane);
         self.prev_delta_q = saaq_delta_q_target;
 
+        // Solo calibrators only populate the legacy `saaq_delta_q_*` columns.
+        // The dual-rule fields are left at their defaults (0.0) and filled in
+        // by `SnnDualLatentCalibrator::observe` when both rules are run
+        // together.
         Ok(SnnLatentSnapshot {
             timestamp_ms: snap.timestamp_ms,
             avg_pop_firing_rate_hz,
@@ -113,6 +129,7 @@ impl SnnLatentCalibrator {
             gpu_power_w: snap.gpu_power_w,
             cpu_tctl_c: snap.cpu_tctl_c,
             cpu_package_power_w: snap.cpu_package_power_w,
+            ..Default::default()
         })
     }
 
@@ -136,7 +153,7 @@ impl SnnLatentCsvExporter {
         let mut writer = BufWriter::new(File::create(path)?);
         writeln!(
             writer,
-            "timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target,heartbeat_signal,heartbeat_enabled,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w"
+            "timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target,heartbeat_signal,heartbeat_enabled,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w,saaq_delta_q_legacy_prev,saaq_delta_q_legacy_target,saaq_delta_q_v15_prev,saaq_delta_q_v15_target"
         )?;
         Ok(Self { writer })
     }
@@ -144,7 +161,7 @@ impl SnnLatentCsvExporter {
     pub fn write_row(&mut self, snapshot: &SnnLatentSnapshot) -> Result<()> {
         writeln!(
             self.writer,
-            "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{},{:.6},{:.6},{:.6},{:.6}",
+            "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6}",
             snapshot.timestamp_ms,
             snapshot.avg_pop_firing_rate_hz,
             snapshot.membrane_dv_dt,
@@ -157,6 +174,10 @@ impl SnnLatentCsvExporter {
             snapshot.gpu_power_w,
             snapshot.cpu_tctl_c,
             snapshot.cpu_package_power_w,
+            snapshot.saaq_delta_q_legacy_prev,
+            snapshot.saaq_delta_q_legacy_target,
+            snapshot.saaq_delta_q_v15_prev,
+            snapshot.saaq_delta_q_v15_target,
         )?;
         Ok(())
     }
@@ -164,6 +185,89 @@ impl SnnLatentCsvExporter {
     pub fn flush(&mut self) -> Result<()> {
         self.writer.flush()?;
         Ok(())
+    }
+}
+
+/// Dual-rule latent calibrator that runs `LegacyV1_0` (SAAQ 1.0) and
+/// `SaaqV1_5SqrtRate` (SAAQ 1.5) in parallel over the same `(snap, activity,
+/// output)` stream.
+///
+/// Emits a single [`SnnLatentSnapshot`] per observation with *both* SAAQ
+/// trajectories populated. The `primary_rule` selects which of the two rules
+/// fills the legacy `saaq_delta_q_{prev,target}` columns so existing
+/// SymbolicRegression.jl scripts (which read those names) remain valid.
+///
+/// Why dual-emit matters: the feature columns fed to SR.jl
+/// (`avg_pop_firing_rate_hz`, `membrane_dv_dt`, `routing_entropy`) are
+/// computed from activity/routing only and do **not** depend on which SAAQ
+/// rule is being evolved. Running two solo calibrators against identical
+/// inputs therefore produces paired `(X, y_legacy)` and `(X, y_v15)` data
+/// with no run-to-run noise, at the cost of a few extra arithmetic ops.
+#[derive(Debug, Clone)]
+pub struct SnnDualLatentCalibrator {
+    legacy: SnnLatentCalibrator,
+    v15: SnnLatentCalibrator,
+    primary_rule: SaaqUpdateRule,
+}
+
+impl SnnDualLatentCalibrator {
+    pub fn new(primary_rule: SaaqUpdateRule) -> Self {
+        Self {
+            legacy: SnnLatentCalibrator::with_update_rule(SaaqUpdateRule::LegacyV1_0),
+            v15: SnnLatentCalibrator::with_update_rule(SaaqUpdateRule::SaaqV1_5SqrtRate),
+            primary_rule,
+        }
+    }
+
+    pub fn primary_rule(&self) -> SaaqUpdateRule {
+        self.primary_rule
+    }
+
+    /// Observe one tick against both rules and return a merged snapshot.
+    ///
+    /// The returned snapshot has:
+    /// - `saaq_delta_q_{legacy,v15}_{prev,target}` populated from each rule,
+    /// - `saaq_delta_q_{prev,target}` populated from the [`primary_rule`],
+    /// - all other fields taken from the legacy calibrator (identical across
+    ///   rules by construction, since they are computed from activity alone).
+    pub fn observe(
+        &mut self,
+        snap: &TelemetrySnapshot,
+        activity: &FunnelActivity,
+        output: &ModelOutput,
+    ) -> Result<SnnLatentSnapshot> {
+        let legacy_snapshot = self.legacy.observe(snap, activity, output)?;
+        let v15_snapshot = self.v15.observe(snap, activity, output)?;
+
+        let (primary_prev, primary_target) = match self.primary_rule {
+            SaaqUpdateRule::LegacyV1_0 => (
+                legacy_snapshot.saaq_delta_q_prev,
+                legacy_snapshot.saaq_delta_q_target,
+            ),
+            SaaqUpdateRule::SaaqV1_5SqrtRate => (
+                v15_snapshot.saaq_delta_q_prev,
+                v15_snapshot.saaq_delta_q_target,
+            ),
+        };
+
+        Ok(SnnLatentSnapshot {
+            timestamp_ms: legacy_snapshot.timestamp_ms,
+            avg_pop_firing_rate_hz: legacy_snapshot.avg_pop_firing_rate_hz,
+            membrane_dv_dt: legacy_snapshot.membrane_dv_dt,
+            routing_entropy: legacy_snapshot.routing_entropy,
+            saaq_delta_q_prev: primary_prev,
+            saaq_delta_q_target: primary_target,
+            heartbeat_signal: legacy_snapshot.heartbeat_signal,
+            heartbeat_enabled: legacy_snapshot.heartbeat_enabled,
+            gpu_temp_c: legacy_snapshot.gpu_temp_c,
+            gpu_power_w: legacy_snapshot.gpu_power_w,
+            cpu_tctl_c: legacy_snapshot.cpu_tctl_c,
+            cpu_package_power_w: legacy_snapshot.cpu_package_power_w,
+            saaq_delta_q_legacy_prev: legacy_snapshot.saaq_delta_q_prev,
+            saaq_delta_q_legacy_target: legacy_snapshot.saaq_delta_q_target,
+            saaq_delta_q_v15_prev: v15_snapshot.saaq_delta_q_prev,
+            saaq_delta_q_v15_target: v15_snapshot.saaq_delta_q_target,
+        })
     }
 }
 
@@ -279,6 +383,7 @@ mod tests {
                 gpu_power_w: 250.0,
                 cpu_tctl_c: 70.0,
                 cpu_package_power_w: 120.0,
+                ..Default::default()
             })
             .unwrap();
         exporter.flush().unwrap();
@@ -287,7 +392,7 @@ mod tests {
         let mut lines = contents.lines();
         assert_eq!(
             lines.next().unwrap(),
-            "timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target,heartbeat_signal,heartbeat_enabled,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w"
+            "timestamp_ms,avg_pop_firing_rate_hz,membrane_dv_dt,routing_entropy,saaq_delta_q_prev,saaq_delta_q_target,heartbeat_signal,heartbeat_enabled,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w,saaq_delta_q_legacy_prev,saaq_delta_q_legacy_target,saaq_delta_q_v15_prev,saaq_delta_q_v15_target"
         );
         assert!(lines.next().is_some());
         assert!(lines.next().is_none());
@@ -333,5 +438,94 @@ mod tests {
         assert_eq!(calibrator.update_rule(), SaaqUpdateRule::LegacyV1_0);
         calibrator.set_update_rule(SaaqUpdateRule::SaaqV1_5SqrtRate);
         assert_eq!(calibrator.update_rule(), SaaqUpdateRule::SaaqV1_5SqrtRate);
+    }
+
+    #[test]
+    fn dual_calibrator_matches_solo_calibrators_bit_for_bit() {
+        let mut legacy_solo = SnnLatentCalibrator::with_update_rule(SaaqUpdateRule::LegacyV1_0);
+        let mut v15_solo = SnnLatentCalibrator::with_update_rule(SaaqUpdateRule::SaaqV1_5SqrtRate);
+        let mut dual = SnnDualLatentCalibrator::new(SaaqUpdateRule::SaaqV1_5SqrtRate);
+
+        let output = sample_output(vec![0.6, 0.3, 0.1]);
+        let base = TelemetrySnapshot {
+            timestamp_ms: 1_000,
+            gpu_temp_c: 62.0,
+            gpu_power_w: 245.0,
+            cpu_tctl_c: 71.0,
+            cpu_package_power_w: 118.0,
+            heartbeat_signal: 0.2,
+            heartbeat_enabled: true,
+        };
+
+        for step in 0..6 {
+            let snap = TelemetrySnapshot {
+                timestamp_ms: 1_000 + step as u64 * 50,
+                ..base.clone()
+            };
+            let activity = sample_activity((step * 2) as usize, 0.15 + 0.05 * step as f32);
+
+            let legacy = legacy_solo.observe(&snap, &activity, &output).unwrap();
+            let v15 = v15_solo.observe(&snap, &activity, &output).unwrap();
+            let merged = dual.observe(&snap, &activity, &output).unwrap();
+
+            assert_eq!(merged.saaq_delta_q_legacy_prev, legacy.saaq_delta_q_prev);
+            assert_eq!(merged.saaq_delta_q_legacy_target, legacy.saaq_delta_q_target);
+            assert_eq!(merged.saaq_delta_q_v15_prev, v15.saaq_delta_q_prev);
+            assert_eq!(merged.saaq_delta_q_v15_target, v15.saaq_delta_q_target);
+            // Primary rule is v1.5, so legacy compatibility columns should
+            // track the v15 trajectory.
+            assert_eq!(merged.saaq_delta_q_prev, v15.saaq_delta_q_prev);
+            assert_eq!(merged.saaq_delta_q_target, v15.saaq_delta_q_target);
+            // Shared feature columns are rule-independent.
+            assert_eq!(merged.avg_pop_firing_rate_hz, legacy.avg_pop_firing_rate_hz);
+            assert_eq!(merged.avg_pop_firing_rate_hz, v15.avg_pop_firing_rate_hz);
+            assert_eq!(merged.routing_entropy, legacy.routing_entropy);
+        }
+    }
+
+    #[test]
+    fn dual_calibrator_primary_rule_legacy_fills_legacy_columns() {
+        let mut dual = SnnDualLatentCalibrator::new(SaaqUpdateRule::LegacyV1_0);
+        let output = sample_output(vec![0.5, 0.3, 0.2]);
+        let snap = TelemetrySnapshot {
+            timestamp_ms: 2_000,
+            gpu_temp_c: 65.0,
+            gpu_power_w: 240.0,
+            cpu_tctl_c: 70.0,
+            cpu_package_power_w: 120.0,
+            heartbeat_signal: 0.0,
+            heartbeat_enabled: false,
+        };
+        let merged = dual
+            .observe(&snap, &sample_activity(4, 0.25), &output)
+            .unwrap();
+        // Legacy primary -> saaq_delta_q_{prev,target} should equal the
+        // *_legacy_* fields, not the *_v15_* fields.
+        assert_eq!(merged.saaq_delta_q_prev, merged.saaq_delta_q_legacy_prev);
+        assert_eq!(merged.saaq_delta_q_target, merged.saaq_delta_q_legacy_target);
+    }
+
+    #[test]
+    fn exporter_header_includes_dual_saaq_columns() {
+        let path = std::env::temp_dir().join(format!(
+            "corinth_canal_dual_latent_{}.csv",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut exporter = SnnLatentCsvExporter::create(&path).unwrap();
+        exporter.flush().unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let header = contents.lines().next().unwrap();
+        for column in [
+            "saaq_delta_q_legacy_prev",
+            "saaq_delta_q_legacy_target",
+            "saaq_delta_q_v15_prev",
+            "saaq_delta_q_v15_target",
+        ] {
+            assert!(header.contains(column), "missing column: {column}");
+        }
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub use funnel::{
     FUNNEL_HIDDEN_NEURONS, FUNNEL_INPUT_NEURONS,
 };
 pub use heartbeat::HeartbeatInjector;
-pub use latent::{SaaqUpdateRule, SnnLatentCalibrator, SnnLatentCsvExporter, SnnLatentSnapshot};
+pub use latent::{
+    SaaqUpdateRule, SnnDualLatentCalibrator, SnnLatentCalibrator, SnnLatentCsvExporter,
+    SnnLatentSnapshot,
+};
 pub use telemetry::TelemetryEncoder;
 pub use types::{EMBEDDING_DIM, HeartbeatConfig, ModelFamily, TelemetrySnapshot};


### PR DESCRIPTION
## **User description**
## Summary
Implements Tier 1: wiring RE4 CSV telemetry into `saaq_latent_calibration` for symbolic regression-ready data, with lightweight repeat support.

## Key Changes

### Telemetry Source Handling ([examples/support/mod.rs](cci:7://file:///home/raulmc/corinth-canal/examples/support/mod.rs:0:0-0:0))
- `TelemetrySource` enum: `Synthetic` (default) or `Csv` (explicit opt-in)
- [ResolvedTelemetry](cci:2://file:///home/raulmc/corinth-canal/examples/support/mod.rs:280:0-285:1) with strict CSV header validation
- [telemetry_snapshot_for_tick()](cci:1://file:///home/raulmc/corinth-canal/examples/support/mod.rs:472:0-492:1) with wrap-around CSV replay
- [repeat_count_from_env()](cci:1://file:///home/raulmc/corinth-canal/examples/support/mod.rs:259:0-261:1) for deterministic repeat runs

### Dual-SAAQ Emission ([src/latent.rs](cci:7://file:///home/raulmc/corinth-canal/src/latent.rs:0:0-0:0))
- Extended [SnnLatentSnapshot](cci:2://file:///home/raulmc/corinth-canal/src/latent.rs:18:0-43:1) with 4 new columns
- [SnnDualLatentCalibrator](cci:2://file:///home/raulmc/corinth-canal/src/latent.rs:206:0-210:1) runs SAAQ 1.0 + 1.5 in parallel
- Legacy 12-column schema preserved for backward compatibility

### Validation Runner ([examples/saaq_latent_calibration.rs](cci:7://file:///home/raulmc/corinth-canal/examples/saaq_latent_calibration.rs:0:0-0:0))
- New directory layout: `<model>/<telemetry>/<heartbeat>/<run_id>/`
- Extended [ValidationManifest](cci:2://file:///home/raulmc/corinth-canal/examples/saaq_latent_calibration.rs:20:0-55:1) with telemetry metadata
- Wraparound hygiene: warns when `TICKS > CSV rows`
- `TICKS=0` with CSV uses exact row count (zero wraparound)

### Documentation
- README: Environment variables, dual-SAAQ schema, recipes
- AGENTS.md: Updated module descriptions

## Verification
- `cargo test`: 51 lib tests + 6 example tests pass
- Synthetic smoke (TICKS=16): 17 lines CSV, all 16 columns present
- RE4 CSV run (TICKS=0): 2001 lines, `wraparound_enabled=false`

## Usage

```bash
# Synthetic smoke test
TICKS=64 cargo run --release --example saaq_latent_calibration

# RE4 corpus run (SR.jl ready)
TELEMETRY_SOURCE=csv TICKS=0 REPEAT_COUNT=3 \
  cargo run --release --example saaq_latent_calibration- Add TelemetrySource enum (Synthetic default, CSV explicit opt-in)
- Add ResolvedTelemetry with CSV loader (strict header validation, fallback)
- Extend SnnLatentSnapshot with 4 dual-SAAQ columns (legacy+v15 prev/target)
- Add SnnDualLatentCalibrator running both SAAQ rules in parallel
- Rewire saaq_latent_calibration with telemetry_snapshot_for_tick, repeat count
- New directory layout: <root>/<model>/<telemetry>/<heartbeat>/<run_id>/
- Extended ValidationManifest with telemetry metadata, wraparound tracking
- Add wraparound hygiene warnings (TICKS>rows) for CSV replay
- Update README with env vars, dual-SAAQ schema, CWD routing CSV caveat
- Update AGENTS.md with new module descriptions
- Unit tests: 6 new support tests + 3 new latent tests, all passing


___

## **CodeAnt-AI Description**
**Run validation sweeps with CSV telemetry, repeated runs, and dual-SAAQ output**

### What Changed
- Validation runs can now replay telemetry from a CSV file instead of only using synthetic data
- Each run writes into a structured folder path that includes the model, telemetry source, heartbeat setting, and run ID
- The manifest now records the telemetry source, CSV path, row count, repeat number, and whether the run wrapped past the end of the CSV
- The latent CSV now keeps the original SAAQ columns and adds separate columns for both SAAQ 1.0 and SAAQ 1.5 so both results are available in one run
- When CSV replay would loop past the available rows, the runner prints a warning so contaminated corpus runs are easier to avoid

### Impact
`✅ CSV-backed corpus runs`
`✅ Fewer reruns for SAAQ comparison`
`✅ Clearer run tracing and repeat checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5tULV9pdYOzljA47UrHZM2qdejTNdVHCalogUd7tbwE&org=Limen-Neural)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
