### PR TITLE
chore: reference-repo cleanup (Cargo hygiene, RunConfig, artifacts/, docs, promotion tracking)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Cargo aliases for corinth-canal.
+#
+# These are pure cargo shortcuts — the end-to-end workflow recipes
+# (telemetry-source switching, dotenv loading, artifact cleanup) live in
+# the top-level `justfile`. Keep this file scoped to cargo-only wrappers
+# that stay useful even without `just`.
+
+[alias]
+ck          = "check --all-targets"
+smoke       = "run --release --example gpu_smoke_test"
+replay      = "run --release --example csv_replay"
+saaq        = "run --release --example saaq_latent_calibration"
+bridge      = "run --release --example telemetry_bridge"
+ex-check    = "check --examples"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,90 @@
+# corinth-canal example runtime configuration
+#
+# Copy this file to `.env.local` and fill in machine-specific paths.
+# `.env.local` is gitignored and auto-loaded by the example binaries via
+# `dotenvy::from_filename(".env.local")`.
+#
+# Leave a key blank (or delete its line) to use the compiled-in default.
+
+# ---------------------------------------------------------------------------
+# Checkpoint + embedding tooling
+# ---------------------------------------------------------------------------
+
+# Absolute path to a GGUF checkpoint. When set, overrides model auto-discovery.
+# When unset, saaq_latent_calibration falls back to scanning
+# $HOME/Downloads/SNN_Quantization for the five validated MoE families.
+GGUF_CHECKPOINT_PATH=
+
+# Absolute path to the `llama-embedding` binary from llama.cpp. Used by
+# examples/support::pooled_prompt_embedding_from_llama_cpp. If the binary
+# cannot be found, the runner falls back to a deterministic text-hash
+# embedding (stamped as `text_hash_fallback` in run_manifest.json).
+LLAMA_EMBEDDING_BIN=
+
+# ---------------------------------------------------------------------------
+# Telemetry source selection
+# ---------------------------------------------------------------------------
+
+# "synthetic" (default) runs the in-process sinusoid stub.
+# "csv" replays TELEMETRY_CSV_PATH row-by-row (canonical header only).
+TELEMETRY_SOURCE=synthetic
+
+# Absolute path to a canonical telemetry CSV with the header:
+#   timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w
+# Required when TELEMETRY_SOURCE=csv. No built-in default: if unset while
+# TELEMETRY_SOURCE=csv, the runner warns and stamps source=synthetic_fallback.
+TELEMETRY_CSV_PATH=
+
+# ---------------------------------------------------------------------------
+# Run profile
+# ---------------------------------------------------------------------------
+
+# Prompt profile slug. Currently only "math_logic" is wired up.
+PROMPT_PROFILE=math_logic
+
+# Optional model family override. One of:
+#   olmoe | qwen3moe | gemma4 | deepseek2 | llama_moe
+# Leave blank to let OlmoeRouter::probe_model infer it from the checkpoint.
+MODEL_FAMILY=
+
+# SAAQ update rule that fills the legacy latent-CSV columns.
+# Either "saaq_v1_5" (default) or "legacy" / "saaq_v1_0".
+# Both rules are always emitted in the dual-SAAQ columns regardless.
+SAAQ_RULE=saaq_v1_5
+
+# Per-run tick count. Special case: TICKS=0 with TELEMETRY_SOURCE=csv uses the
+# exact CSV row count (one full loop, no wraparound contamination).
+TICKS=512
+
+# Repeats per (model, telemetry, heartbeat) tuple.
+REPEAT_COUNT=1
+
+# ---------------------------------------------------------------------------
+# Heartbeat matrix
+# ---------------------------------------------------------------------------
+
+# "on" | "off" | anything else => both (default).
+HEARTBEAT_MATRIX=
+
+# Individual heartbeat knobs (defaults shown).
+HEARTBEAT_ENABLED=false
+HEARTBEAT_AMPLITUDE=0.85
+HEARTBEAT_PERIOD_TICKS=48
+HEARTBEAT_DUTY_CYCLE=0.25
+HEARTBEAT_PHASE_OFFSET_TICKS=0
+
+# ---------------------------------------------------------------------------
+# Artifact output root
+# ---------------------------------------------------------------------------
+
+# Where saaq_latent_calibration writes per-run artifact trees. Default is
+# `./artifacts` (repo-relative). Set to an absolute path to redirect runs
+# into an external consumer (e.g. Surrogate_Viz.jl).
+VALIDATION_OUTPUT_ROOT=
+
+# ---------------------------------------------------------------------------
+# telemetry_bridge example knobs
+# ---------------------------------------------------------------------------
+
+# "dense" | "stub" | anything else => spiking (default).
+ROUTING_MODE=spiking

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Rust
 /target/
 **/*.rs.bk
-Cargo.lock
 
 # IDE
 .idea/
@@ -19,3 +18,10 @@ Thumbs.db
 
 # Agent notes
 AGENTS.md
+
+# Local env overrides (contributors create their own, never tracked)
+.env.local
+
+# Generated per-run artifacts (tracked via .gitkeep only)
+/artifacts/*
+!/artifacts/.gitkeep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cust",
+ "dotenvy",
  "libc",
  "memmap2",
  "serde",
@@ -105,6 +106,12 @@ checksum = "fbf40d6ade12cb9828bbc844b9875c7b93d25e67a3c9bf61c7aa3ae09e402bf8"
 dependencies = [
  "find_cuda_helper",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "find-msvc-tools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,12 @@
 name = "corinth-canal"
 version = "0.1.0"
 edition = "2024"
-description = "Minimal standalone SNN-logic quantization bridge"
-repository = "https://github.com/Spikenaut/corinth-canal"
+description = "Reference SNN-logic quantization bridge for the rmems modular line"
+repository = "https://github.com/rmems/corinth-canal"
 license = "GPL-3.0-or-later"
 keywords = ["neuromorphic", "snn", "llm", "moe", "hybrid", "spiking"]
 categories = ["science", "algorithms"]
 readme = "README.md"
-exclude = ["docs/"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -19,6 +18,9 @@ tracing = "0.1"
 memmap2 = "0.9"
 libc = "0.2"
 serde_json = "1.0"
+
+[dev-dependencies]
+dotenvy = "0.15"
 
 [build-dependencies]
 cc = "1.0"
@@ -35,4 +37,7 @@ opt-level = 3
 lto = true
 codegen-units = 1
 
+# Declare this crate as its own workspace root so Cargo does not walk up the
+# filesystem and attach to an unrelated parent workspace (e.g. a broken
+# /home/raulmc/Cargo.toml on a developer machine). Intentionally empty.
 [workspace]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ SNN-logic quantization repo focused on the spiking projector and OlmoeRouter rou
 
 This repository originated from the `spikenaut-hybrid` codebase and is now organized around feature modules: `src/model`, `src/moe`, `src/projector.rs`, `src/funnel.rs`, `src/telemetry.rs`, and `src/latent.rs`.
 
+Going forward, `corinth-canal` is the **single-crate reference implementation** for the `rmems` modular line. Proven components will graduate into separate `rmems-*` crates per `docs/PROMOTION_RULES.md`; `corinth-canal` itself stays as one crate.
+
+## Documentation
+
+- `docs/ARCHITECTURE.md` — block diagram, module map, and hidden control flow (CWD writes, env-resolved paths, fallback stamping).
+- `docs/RUN_PROFILES.md` — catalog of validated `(prompt, telemetry, heartbeat, SAAQ rule)` tuples with the exact `just` command for each.
+- `docs/PROMOTION_RULES.md` — criteria for graduating a module out of this reference repo.
+- `docs/MODULE_STATUS.md` — live status table; machine-readable mirror in `manifests/proven_components.toml`.
+- `manifests/known_good_runs.md` — append-only log of blessed run IDs.
+
 ## Module Map
 
 - `src/model/*`: end-to-end runtime orchestration, GPU temporal logic, and routing telemetry helpers
@@ -326,7 +336,7 @@ tick=2 best_walker=45 elapsed_us=842
 ...
 ```
 
-This path exercises the pure Spikenaut physics engine (GIF membrane + adaptive thresholds + two-pass SAT reduction) driven by realistic, pooled semantic pressure.
+This path exercises the pure SNN physics engine (GIF membrane + adaptive thresholds + two-pass SAT reduction) driven by realistic, pooled semantic pressure.
 
 ### Validation Sweeps (dual-SAAQ, CSV-replay, repeat-aware)
 
@@ -346,10 +356,10 @@ where `<run_id>` = `<YYYYMMDDTHHMMSS>_<prompt_slug>_r<repeat_idx>` (UTC, sortabl
 | Env | Default | Purpose |
 |-----|---------|---------|
 | `TELEMETRY_SOURCE` | `synthetic` | `synthetic` runs the in-process sinusoid; `csv` replays a canonical telemetry CSV. Must be set explicitly to `csv` for real-corpus runs — defaults are dependency-light on purpose. |
-| `TELEMETRY_CSV_PATH` | `/home/raulmc/Julia/Surrogate_Viz.jl/telemetry.csv` | Canonical-format CSV (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`). Missing/malformed → fallback to synthetic, stamped `synthetic_fallback` in the manifest. |
+| `TELEMETRY_CSV_PATH` | _(unset)_ | Canonical-format CSV (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`). Required when `TELEMETRY_SOURCE=csv`. Missing/malformed → fallback to synthetic, stamped `synthetic_fallback` in the manifest. |
 | `TICKS` | `512` | Per-run tick count. Special case: when `TICKS=0` *and* `TELEMETRY_SOURCE=csv`, uses the exact CSV row count so a SymbolicRegression.jl corpus run covers exactly one loop with zero wraparound contamination. |
 | `REPEAT_COUNT` | `1` | Number of repeats per (model, telemetry, heartbeat) tuple. Deterministic inputs mean repeats should bit-match — divergence indicates scheduler noise. |
-| `VALIDATION_OUTPUT_ROOT` | `/home/raulmc/Julia/Surrogate_Viz.jl/outputs/saaq15` | Top of the per-run output tree. |
+| `VALIDATION_OUTPUT_ROOT` | `./artifacts` | Top of the per-run output tree. Repo-relative by default; set to an absolute path to redirect runs into an external consumer. |
 | `HEARTBEAT_MATRIX` | `off,on` | Kept as-is for this round; amplitude/period sweep is future work. |
 | `SAAQ_RULE` | `saaq_v1_5` | Selects which rule fills the legacy `saaq_delta_q_{prev,target}` columns. Both rules are always emitted in the dual-SAAQ columns regardless. |
 
@@ -484,11 +494,11 @@ If you use `corinth-canal` or the SNN-logic quantization approach in your resear
 
 ```bibtex
 @misc{corinth-canal2026,
-  title        = {corinth-canal: Turning MOE Architecture into SNN Quantization},
+  title        = {corinth-canal: Turning MoE Architectures into SNN Quantization},
   author       = {Raul Montoya Cardenas},
   year         = {2026},
-  howpublished = {\url{https://github.com/Spikenaut/corinth-canal}},
-  note         = {SNN-logic quantization with GIF-Ternary spiking for MoE models}
+  howpublished = {\url{https://github.com/rmems/corinth-canal}},
+  note         = {SNN-logic quantization reference crate with GIF-Ternary spiking for MoE models}
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# Architecture
+
+`corinth-canal` is a single-crate reference implementation of the SNN-logic
+quantization bridge. It is intentionally *not* split into modular crates
+yet — the goal is to keep one working codebase where every component can be
+exercised end-to-end, then promote proven modules into the `rmems` modular
+repos (see `docs/PROMOTION_RULES.md` and `docs/MODULE_STATUS.md`).
+
+## Block diagram
+
+```text
+TelemetrySnapshot
+       │
+       ▼  TelemetryEncoder (delta modulation) / project_snapshot_current (GPU)
+[i8; 4] ternary spikes (+1 / 0 / -1)
+       │
+       ▼  SignedSplitBankBridge (CPU) or GPU input_spikes buffer
+2048 input neurons
+       │
+       ▼  SparseGifHiddenLayer (CPU) or gif_step_weighted_tick (GPU, adaptive)
+2048 GIF hidden neurons with adaptive thresholds + history-aware SAAQ
+       │
+       ▼  Projector (SpikingTernary)
+dense embedding [EMBEDDING_DIM = 2048]
+       │
+       ▼  OlmoeRouter (stub | dense | spiking sim) with GGUF-backed routing
+expert_weights + selected_experts + hidden + spike_count telemetry
+```
+
+## Module map
+
+| Module | Role |
+|--------|------|
+| `src/model/core.rs` | Runtime orchestration, config validation, forward paths |
+| `src/model/temporal.rs` | GPU temporal loop (`prepare_gpu_temporal`, `tick_gpu_temporal`, `forward_gpu_temporal`) |
+| `src/model/telemetry_io.rs` | Shared CSV writer for routing telemetry |
+| `src/moe/mod.rs` | `OlmoeRouter` host with routing-mode dispatch |
+| `src/moe/checkpoint.rs` | GGUF parse, mmap, tensor slicing, `GgufMetadata` |
+| `src/moe/adapter.rs` | Model-family adapter resolution (Olmoe, Qwen3Moe, Gemma4, DeepSeek2, LlamaMoe) |
+| `src/moe/routing.rs` | Router math (gate scores, normalize, resample) |
+| `src/projector.rs` | `ProjectionMode` spike → embedding |
+| `src/funnel.rs` | Telemetry funnel + GIF hidden layer |
+| `src/telemetry.rs` | `TelemetryEncoder`, `TelemetrySnapshot` |
+| `src/latent.rs` | SAAQ 1.0 solo + dual 1.0/1.5 calibrators + CSV export |
+| `src/gpu/` | cust-based kernel wrappers |
+| `examples/support/config.rs` | `RunConfig::from_env()` — single source of env truth for examples |
+
+## Hidden control flow
+
+A few control paths are not obvious from a top-level read. They are called
+out here so future promotion out of this reference repo does not lose them.
+
+### CWD-relative write: `snn_gpu_routing_telemetry.csv`
+
+`Model::forward_gpu_temporal` (and `Model::forward` → GPU routing) call
+`append_gpu_routing_telemetry_row` with a path resolved from
+`ModelConfig::gpu_routing_telemetry_path`. When that field is `None`,
+the path falls back to the bare filename `snn_gpu_routing_telemetry.csv`,
+which `std::fs` resolves against the process CWD.
+
+- `saaq_latent_calibration` sets the path explicitly into
+  `<run_dir>/snn_gpu_routing_telemetry.csv`, so it is self-contained.
+- `telemetry_bridge` / `csv_replay` inherit the default (CWD). Launching
+  them from the repo root is the intended workflow.
+- `tick_gpu_temporal` does **not** touch this CSV; only the
+  `forward_gpu_temporal` path does.
+
+### Env-resolved paths
+
+Every machine-specific path is resolved in `examples/support/config.rs::RunConfig::from_env()`.
+The runtime crate itself (under `src/`) never reads environment variables
+for paths. If you are promoting a module out of this repo, the `RunConfig`
+surface is the contract to preserve.
+
+### Telemetry source fallback
+
+`resolve_telemetry_source()` stamps `source_label` into every
+`run_manifest.json` with one of three values:
+
+- `synthetic` — explicit or default stub
+- `synthetic_fallback` — requested CSV but it was missing / malformed / empty
+- `csv_<stem>` — canonical CSV path, e.g. `csv_re4` for `telemetry.csv`
+
+This means the manifest is always truthful about what actually fed the run,
+even when the configured source silently degraded.

--- a/docs/MODULE_STATUS.md
+++ b/docs/MODULE_STATUS.md
@@ -1,0 +1,34 @@
+# Module Status
+
+Live snapshot of every `src/` module's position on the promotion ladder.
+Machine-readable mirror: `manifests/proven_components.toml`.
+
+Status legend: `reference` · `stabilizing` · `proven` · `frozen`
+(see `docs/PROMOTION_RULES.md`).
+
+| Module | Status | Target `rmems` crate | Notes |
+|--------|--------|----------------------|-------|
+| `src/model/core.rs` | reference | `rmems-model` | Orchestration layer; still entangled with `Model::forward_gpu_temporal` CWD write. Gated on Stage E of the reference-repo cleanup. |
+| `src/model/temporal.rs` | stabilizing | `rmems-model` | GPU temporal loop is tight and proven; needs its routing-CSV path made explicit before freezing. |
+| `src/model/telemetry_io.rs` | stabilizing | `rmems-model` | Pure helper, ready to move once the caller stops passing a CWD-relative path. |
+| `src/moe/mod.rs` | stabilizing | `rmems-moe` | Host entry for `OlmoeRouter`; surface is clean. Pending full matrix. |
+| `src/moe/checkpoint.rs` | reference | `rmems-moe` | Pre-existing WIP in the parser is patched. Needs a proper test battery before promotion. |
+| `src/moe/adapter.rs` | stabilizing | `rmems-moe` | Five-family support validated on the author's machine; needs CI matrix. |
+| `src/moe/routing.rs` | stabilizing | `rmems-moe` | Stateless math. Low-risk promotion candidate. |
+| `src/projector.rs` | stabilizing | `rmems-projector` | `ProjectionMode` surface frozen; SpikingTernary path is the live one. |
+| `src/funnel.rs` | reference | `rmems-funnel` | GIF hidden layer still shared between CPU and GPU callers. |
+| `src/telemetry.rs` | stabilizing | `rmems-telemetry` | Schema frozen (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`). |
+| `src/latent.rs` | stabilizing | `rmems-latent` | Dual-SAAQ emission is working; needs a REPEAT_COUNT=2 determinism check to graduate. |
+| `src/gpu/*` | reference | `rmems-gpu` | Kernel sources and cust wrappers. Promotion blocked on build.rs portability. |
+| `examples/support/config.rs` | reference | n/a | Intentionally stays here — it is the env-truth surface for the reference repo only. |
+
+## Known blockers
+
+- **Machine-local discovery root.** `examples/support/mod.rs` walks
+  `$HOME/Downloads/SNN_Quantization`. Fine for the reference repo; must
+  not be copied into any `rmems` crate.
+- **`GPU_ROUTING_TELEMETRY_PATH` CWD default.** Stage E of the cleanup
+  makes this configurable via `ModelConfig`; freezing `src/model/*` is
+  blocked until that lands.
+- **`build.rs` fatbin compilation.** Assumes nvcc + sm_120 targets on the
+  author's box. `gpu-stub` feature covers the CI / non-CUDA case.

--- a/docs/PROMOTION_RULES.md
+++ b/docs/PROMOTION_RULES.md
@@ -1,0 +1,50 @@
+# Promotion Rules
+
+Rules for graduating code paths out of this reference repo into one of the
+`rmems` modular crates. Status tracking lives in
+`manifests/proven_components.toml`; blessed run IDs live in
+`manifests/known_good_runs.md`.
+
+## Status ladder
+
+1. **reference** — code lives here because it is the only place it works
+   end-to-end. Not yet portable.
+2. **stabilizing** — API has stopped thrashing and is covered by at least
+   one blessed run, but still depends on helpers that have not been
+   promoted.
+3. **proven** — the component has run green against the full matrix in
+   `docs/RUN_PROFILES.md` and its external surface is frozen.
+4. **frozen** — copied into its target `rmems` crate. Further changes
+   happen there; `corinth-canal` holds an unmodified reference copy.
+
+## Promotion criteria
+
+A module moves from **stabilizing** to **proven** only after all of:
+
+1. **Router-family matrix green.** Every family listed in
+   `docs/RUN_PROFILES.md#model-discovery` (Olmoe, Qwen3Moe, Gemma4,
+   DeepSeek2, LlamaMoe) completes a SAAQ latent calibration run with
+   `validation_status: "completed"` in its `run_manifest.json`.
+2. **Dual-SAAQ parity.** The run emits both `saaq_delta_q_*_v1_0` and
+   `saaq_delta_q_*_v1_5` columns, and the two rules diverge in the
+   expected regime (1.5 < 1.0 on large deltas by the sqrt-rate rule).
+3. **GPU determinism check.** A `REPEAT_COUNT=2` run produces bit-matching
+   `tick_telemetry.txt` between repeat 0 and repeat 1. Non-determinism is
+   a blocker.
+4. **CSV schema frozen.** No structural change to
+   `latent_telemetry.csv` or the telemetry CSV input header
+   (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`)
+   for at least one full validated matrix sweep.
+5. **No machine-local paths.** `grep -rE '/home/[^/]+' src/<module>` is
+   empty. Every path must come from `ModelConfig`, `RunConfig`, or an
+   explicit argument.
+6. **Blessed run logged.** A run ID is appended to
+   `manifests/known_good_runs.md` with checkpoint slug + telemetry source
+   + SAAQ rule + a one-line conclusion.
+
+## Freezing
+
+After promotion, `corinth-canal` keeps the reference copy unchanged. Any
+bugfix that needs to apply to both the reference and the modular crate
+must be mirrored by hand — the modular crate is the source of truth once
+the component is **frozen**.

--- a/docs/RUN_PROFILES.md
+++ b/docs/RUN_PROFILES.md
@@ -1,0 +1,59 @@
+# Run Profiles
+
+Every validated tuple of `(example, telemetry source, heartbeat, SAAQ rule)`
+is catalogued here with the exact command. Anything not in this table has
+not been blessed and should be considered experimental.
+
+## Prerequisites
+
+- Fill in `.env.local` from `.env.example`.
+- `just setup` — sanity check that the scaffolding is in place.
+
+## SAAQ latent calibration (primary research loop)
+
+| Profile | Telemetry | Heartbeat | SAAQ rule | Command |
+|---------|-----------|-----------|-----------|---------|
+| Smoke, synthetic | synthetic | both | 1.5 | `just saaq` |
+| SR.jl corpus, full loop | csv (RE4) | both | 1.5 + 1.0 dual | `TICKS=0 just saaq-csv` |
+| Wraparound sanity | csv (RE4) | both | 1.5 | `TICKS=2000 just saaq-csv` |
+| Heartbeat OFF only | synthetic | off | 1.5 | `HEARTBEAT_MATRIX=off just saaq` |
+| Heartbeat ON only | synthetic | on | 1.5 | `HEARTBEAT_MATRIX=on just saaq` |
+| Legacy rule parity | synthetic | both | 1.0 | `SAAQ_RULE=legacy just saaq` |
+
+Dual-SAAQ columns (`saaq_delta_q_*_v1_0` / `_v1_5`) are emitted regardless of
+`SAAQ_RULE`; the env var only picks which rule fills the legacy columns.
+
+## GPU smoke test
+
+| Profile | Command |
+|---------|---------|
+| 10k GPU ticks, real checkpoint | `GGUF_CHECKPOINT_PATH=... just smoke` |
+
+## CSV replay
+
+| Profile | Command |
+|---------|---------|
+| Ingest canonical telemetry CSV | `just replay /path/to/telemetry.csv` |
+
+## Telemetry bridge demo
+
+| Profile | Command |
+|---------|---------|
+| Spiking routing | `just bridge` |
+| Dense routing | `ROUTING_MODE=dense just bridge` |
+| Stub routing | `ROUTING_MODE=stub just bridge` |
+
+## Model discovery
+
+If `GGUF_CHECKPOINT_PATH` is unset, `saaq_latent_calibration` auto-discovers
+up to five MoE families under `$HOME/Downloads/SNN_Quantization/`:
+
+- `olmoe-0125-gguf/OLMoE-1B-7B-0125-Instruct-F16.gguf`
+- `models/qwen3-moe-i1-GGUF/qwen3-moe.i1-IQ3_M.gguf`
+- `models/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-UD-IQ4_NL.gguf`
+- `models/DeepSeek-Coder-V2-Lite-Instruct-GGUF/DeepSeek-Coder-V2-Lite-Instruct-Q6_K_L.gguf`
+- `models/Llama-3.2-8X3B-MOE-Dark-Champion-GGUF/L3.2-8X3B-MOE-Dark-Champion-Inst-18.4B-uncen-ablit_D_AU-q5_k_m.gguf`
+
+This discovery root is a machine-local convention on the author's Fedora
+box. CI and contributor machines should set `GGUF_CHECKPOINT_PATH`
+explicitly.

--- a/examples/csv_replay.rs
+++ b/examples/csv_replay.rs
@@ -8,7 +8,7 @@ use corinth_canal::{
     EMBEDDING_DIM, FUNNEL_HIDDEN_NEURONS, HybridError, TelemetryFunnel, model::Model,
     telemetry::TelemetrySnapshot,
 };
-use support::default_spiking_model_config;
+use support::{RunConfig, default_spiking_model_config};
 
 const EXPECTED_HEADER: &str = "timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w";
 const TELEMETRY_THRESHOLDS: [f32; 4] = [1.0, 5.0, 1.0, 5.0];
@@ -30,9 +30,11 @@ fn main() -> corinth_canal::Result<()> {
         std::process::exit(1);
     }
 
+    let _ = dotenvy::from_filename(".env.local");
+    let run_cfg = RunConfig::from_env();
+
     let csv_path = &args[1];
-    let model_path = support::gguf_checkpoint_path_or_default();
-    let cfg = default_spiking_model_config(model_path, 20);
+    let cfg = default_spiking_model_config(run_cfg.gguf_checkpoint_path.clone(), 20);
 
     let mut model = Model::new_with_projector_neurons(cfg.clone(), FUNNEL_HIDDEN_NEURONS)?;
     let mut funnel = TelemetryFunnel::new(TELEMETRY_THRESHOLDS, cfg.snn_steps);

--- a/examples/gpu_smoke_test.rs
+++ b/examples/gpu_smoke_test.rs
@@ -3,10 +3,18 @@ mod support;
 use corinth_canal::{gpu::GpuAccelerator, model::Model};
 use std::io::Error;
 use std::time::Instant;
-use support::{default_spiking_model_config, required_gguf_checkpoint_path};
+use support::{RunConfig, default_spiking_model_config};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model_path = required_gguf_checkpoint_path()?;
+    let _ = dotenvy::from_filename(".env.local");
+    let run_cfg = RunConfig::from_env();
+    if run_cfg.gguf_checkpoint_path.trim().is_empty() {
+        return Err(Error::other(
+            "GGUF_CHECKPOINT_PATH must point to a GGUF checkpoint",
+        )
+        .into());
+    }
+    let model_path = run_cfg.gguf_checkpoint_path.clone();
 
     let mut accelerator = GpuAccelerator::new();
     let mut model = Model::new(default_spiking_model_config(model_path.clone(), 1))?;

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -10,11 +10,9 @@ use std::io::{BufWriter, Error, Write};
 use std::path::PathBuf;
 use std::time::Instant;
 use support::{
-    ResolvedTelemetry, TelemetrySource, ValidationModelSpec, default_spiking_model_config,
-    discover_validation_models, heartbeat_gain, heartbeat_modes_for_matrix,
-    model_family_override_from_env, prompt_embedding_for_validation, prompt_profile_slug,
-    prompt_text_for_profile, repeat_count_from_env, resolve_telemetry_source,
-    saaq_update_rule_from_env, telemetry_snapshot_for_tick, ticks_from_env,
+    ResolvedTelemetry, RunConfig, TelemetrySource, ValidationModelSpec,
+    default_spiking_model_config, heartbeat_gain, prompt_embedding_for_validation,
+    telemetry_snapshot_for_tick,
 };
 
 #[derive(Debug, Serialize)]
@@ -66,26 +64,24 @@ struct RunContext<'a> {
     resolved: &'a ResolvedTelemetry,
     run_id: String,
     output_root: PathBuf,
+    model_family_override: Option<corinth_canal::ModelFamily>,
+    saaq_rule: SaaqUpdateRule,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let prompt_profile = prompt_profile_slug();
-    let prompt_text = prompt_text_for_profile(&prompt_profile);
-    let ticks = ticks_from_env(512);
-    let repeat_count = repeat_count_from_env();
-    let resolved = resolve_telemetry_source();
-    let output_root = output_root_from_env();
+    let _ = dotenvy::from_filename(".env.local");
+    let cfg = RunConfig::from_env();
 
     // Effective tick count: when TICKS=0 and CSV replay is live, use the full
     // CSV length so SR.jl corpus runs cover exactly one loop with zero
     // wraparound contamination (per plan: wraparound is for smoke only).
-    let effective_ticks = match (ticks, resolved.source, resolved.row_count()) {
+    let effective_ticks = match (cfg.ticks, cfg.telemetry.source, cfg.telemetry.row_count()) {
         (0, TelemetrySource::Csv, Some(rows)) if rows > 0 => rows,
         (0, _, _) => 1, // degenerate guard; never emit a zero-tick run
         (other, _, _) => other,
     };
 
-    if let Some(rows) = resolved.row_count() {
+    if let Some(rows) = cfg.telemetry.row_count() {
         if effective_ticks > rows {
             eprintln!(
                 "wraparound: ticks={effective_ticks} > rows={rows}; regression corpus may be contaminated by looped endings. Prefer TICKS=0 or TICKS<={rows}.",
@@ -95,35 +91,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!(
         "saaq_latent_calibration: telemetry_source={} ticks={} repeat_count={} output_root={}",
-        resolved.source_label,
+        cfg.telemetry.source_label,
         effective_ticks,
-        repeat_count,
-        output_root.display(),
+        cfg.repeat_count,
+        cfg.output_root.display(),
     );
 
-    let models = discover_validation_models();
-    if models.is_empty() {
+    if cfg.validation_models.is_empty() {
         return Err(Error::other(
             "No GGUF validation models discovered. Set GGUF_CHECKPOINT_PATH or place models under ~/Downloads/SNN_Quantization.",
         )
         .into());
     }
 
-    for spec in models {
-        for repeat_idx in 0..repeat_count {
-            for heartbeat_enabled in heartbeat_modes_for_matrix() {
-                let run_id = build_run_id(&prompt_profile, repeat_idx);
+    for spec in &cfg.validation_models {
+        for repeat_idx in 0..cfg.repeat_count {
+            for &heartbeat_enabled in &cfg.heartbeat_matrix {
+                let run_id = build_run_id(&cfg.prompt_profile, repeat_idx);
                 let ctx = RunContext {
-                    spec: &spec,
-                    prompt_profile: &prompt_profile,
-                    prompt_text,
+                    spec,
+                    prompt_profile: &cfg.prompt_profile,
+                    prompt_text: cfg.prompt_text,
                     ticks: effective_ticks,
                     heartbeat_enabled,
                     repeat_idx,
-                    repeat_count,
-                    resolved: &resolved,
+                    repeat_count: cfg.repeat_count,
+                    resolved: &cfg.telemetry,
                     run_id,
-                    output_root: output_root.clone(),
+                    output_root: cfg.output_root.clone(),
+                    model_family_override: cfg.model_family_override,
+                    saaq_rule: cfg.saaq_rule,
                 };
                 run_validation(&ctx)?;
             }
@@ -135,9 +132,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>> {
     let mut config = default_spiking_model_config(ctx.spec.path.clone(), 1);
-    config.model_family = model_family_override_from_env().or(ctx.spec.family);
+    config.model_family = ctx.model_family_override.or(ctx.spec.family);
     config.heartbeat.enabled = ctx.heartbeat_enabled;
-    let saaq_rule = saaq_update_rule_from_env();
+    let saaq_rule = ctx.saaq_rule;
 
     let mut accelerator = GpuAccelerator::new();
     let mut model = Model::new(config.clone())?;
@@ -427,16 +424,6 @@ fn saaq_rule_label(rule: SaaqUpdateRule) -> &'static str {
         SaaqUpdateRule::LegacyV1_0 => "LegacyV1_0",
         SaaqUpdateRule::SaaqV1_5SqrtRate => "SaaqV1_5SqrtRate",
     }
-}
-
-fn output_root_from_env() -> PathBuf {
-    if let Ok(value) = std::env::var("VALIDATION_OUTPUT_ROOT") {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
-        }
-    }
-    PathBuf::from("/home/raulmc/Julia/Surrogate_Viz.jl/outputs/saaq15")
 }
 
 fn build_run_id(prompt_profile: &str, repeat_idx: usize) -> String {

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -131,9 +131,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>> {
+    // Pre-create the run directory so we can anchor the GPU routing
+    // telemetry CSV inside it via ModelConfig and avoid polluting CWD.
+    let run_dir = build_run_dir(ctx)?;
+    fs::create_dir_all(&run_dir)?;
+    let routing_csv_path = run_dir.join("snn_gpu_routing_telemetry.csv");
+
     let mut config = default_spiking_model_config(ctx.spec.path.clone(), 1);
     config.model_family = ctx.model_family_override.or(ctx.spec.family);
     config.heartbeat.enabled = ctx.heartbeat_enabled;
+    config.gpu_routing_telemetry_path = Some(routing_csv_path.clone());
     let saaq_rule = ctx.saaq_rule;
 
     let mut accelerator = GpuAccelerator::new();
@@ -147,8 +154,6 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
         .into());
     }
 
-    let run_dir = build_run_dir(ctx)?;
-    fs::create_dir_all(&run_dir)?;
     let tick_path = run_dir.join("tick_telemetry.txt");
     let latent_path = run_dir.join("latent_telemetry.csv");
     let manifest_path = run_dir.join("run_manifest.json");
@@ -156,6 +161,11 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
         tick_path.file_name().unwrap().to_string_lossy().into_owned(),
         latent_path.file_name().unwrap().to_string_lossy().into_owned(),
         manifest_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned(),
+        routing_csv_path
             .file_name()
             .unwrap()
             .to_string_lossy()
@@ -403,10 +413,12 @@ fn build_manifest(
         output_root: ctx.output_root.to_string_lossy().into_owned(),
         repeat_idx: ctx.repeat_idx,
         repeat_count: ctx.repeat_count,
-        // `snn_gpu_routing_telemetry.csv` is written to CWD by
-        // `forward_gpu_temporal` / `compute_routing_telemetry` only; this
-        // runner uses `tick_gpu_temporal`, which does not touch that file.
-        cwd_routing_csv_contaminated: false,
+        // True iff the routing CSV would land in CWD. Since Stage E this
+        // runner always sets `ModelConfig::gpu_routing_telemetry_path` to
+        // an absolute path inside `run_dir`, so CWD contamination is
+        // impossible regardless of whether `tick_gpu_temporal` or
+        // `forward_gpu_temporal` is used.
+        cwd_routing_csv_contaminated: config.gpu_routing_telemetry_path.is_none(),
         generated_files,
     }
 }

--- a/examples/support/config.rs
+++ b/examples/support/config.rs
@@ -1,0 +1,95 @@
+//! Single source of env-driven runtime config for example binaries.
+//!
+//! The runtime crate (`src/`) never reads environment variables for paths.
+//! Every machine-local default lives here. Each example binary should start
+//! with:
+//!
+//! ```ignore
+//! let _ = dotenvy::from_filename(".env.local");
+//! let cfg = support::RunConfig::from_env();
+//! ```
+//!
+//! Fields map 1:1 to the entries documented in `.env.example`.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+use corinth_canal::{HeartbeatConfig, ModelFamily, SaaqUpdateRule, moe::RoutingMode};
+
+use super::{
+    ResolvedTelemetry, ValidationModelSpec, discover_validation_models,
+    heartbeat_config_from_env, heartbeat_modes_for_matrix, llama_embedding_binary_optional,
+    model_family_override_from_env, prompt_profile_slug, prompt_text_for_profile,
+    repeat_count_from_env, resolve_telemetry_source, routing_mode_override_from_env,
+    saaq_update_rule_from_env, ticks_from_env,
+};
+
+/// Default output root for per-run artifacts when `VALIDATION_OUTPUT_ROOT`
+/// is unset. Repo-relative on purpose so a fresh clone never writes into a
+/// machine-specific consumer directory.
+pub const DEFAULT_OUTPUT_ROOT: &str = "artifacts";
+
+/// Default tick count for `saaq_latent_calibration` when `TICKS` is unset.
+pub const DEFAULT_TICKS: usize = 512;
+
+/// Aggregated env-driven configuration for an example binary run.
+///
+/// Every field is populated by `RunConfig::from_env()` in one pass. Binaries
+/// should not read `std::env` directly.
+#[derive(Debug, Clone)]
+pub struct RunConfig {
+    pub prompt_profile: String,
+    pub prompt_text: &'static str,
+    pub ticks: usize,
+    pub repeat_count: usize,
+    pub heartbeat: HeartbeatConfig,
+    pub heartbeat_matrix: Vec<bool>,
+    pub telemetry: ResolvedTelemetry,
+    pub output_root: PathBuf,
+    pub model_family_override: Option<ModelFamily>,
+    pub saaq_rule: SaaqUpdateRule,
+    pub llama_embedding_bin: Option<PathBuf>,
+    pub validation_models: Vec<ValidationModelSpec>,
+    pub gguf_checkpoint_path: String,
+    pub routing_mode_override: Option<RoutingMode>,
+}
+
+impl RunConfig {
+    /// Build a `RunConfig` by reading every supported environment variable.
+    ///
+    /// Call `dotenvy::from_filename(".env.local").ok();` before this if you
+    /// want `.env.local` overrides applied.
+    pub fn from_env() -> Self {
+        let prompt_profile = prompt_profile_slug();
+        let prompt_text = prompt_text_for_profile(&prompt_profile);
+        Self {
+            prompt_profile: prompt_profile.clone(),
+            prompt_text,
+            ticks: ticks_from_env(DEFAULT_TICKS),
+            repeat_count: repeat_count_from_env(),
+            heartbeat: heartbeat_config_from_env(),
+            heartbeat_matrix: heartbeat_modes_for_matrix(),
+            telemetry: resolve_telemetry_source(),
+            output_root: output_root_from_env(),
+            model_family_override: model_family_override_from_env(),
+            saaq_rule: saaq_update_rule_from_env(),
+            llama_embedding_bin: llama_embedding_binary_optional(),
+            validation_models: discover_validation_models(),
+            gguf_checkpoint_path: std::env::var("GGUF_CHECKPOINT_PATH").unwrap_or_default(),
+            routing_mode_override: routing_mode_override_from_env(),
+        }
+    }
+}
+
+/// Resolve `VALIDATION_OUTPUT_ROOT`, falling back to the repo-relative
+/// default `./artifacts`.
+pub fn output_root_from_env() -> PathBuf {
+    if let Ok(value) = std::env::var("VALIDATION_OUTPUT_ROOT") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    PathBuf::from(DEFAULT_OUTPUT_ROOT)
+}

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod config;
 
-pub use config::{DEFAULT_OUTPUT_ROOT, DEFAULT_TICKS, RunConfig, output_root_from_env};
+pub use config::RunConfig;
 
 use corinth_canal::{
     HeartbeatConfig, HeartbeatInjector, ModelFamily, SaaqUpdateRule, EMBEDDING_DIM,

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -1,6 +1,10 @@
 //! Shared helper functions for the example binaries.
 #![allow(dead_code)]
 
+pub mod config;
+
+pub use config::{DEFAULT_OUTPUT_ROOT, DEFAULT_TICKS, RunConfig, output_root_from_env};
+
 use corinth_canal::{
     HeartbeatConfig, HeartbeatInjector, ModelFamily, SaaqUpdateRule, EMBEDDING_DIM,
     model::ModelConfig,
@@ -519,19 +523,40 @@ pub fn heartbeat_injector_from_env() -> HeartbeatInjector {
 }
 
 fn llama_embedding_binary() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    llama_embedding_binary_optional()
+        .ok_or_else(|| Error::other("LLAMA_EMBEDDING_BIN must point to llama.cpp's llama-embedding binary").into())
+}
+
+/// Non-erroring variant used by [`RunConfig::from_env`]: returns `None`
+/// when neither `LLAMA_EMBEDDING_BIN` nor the author's local build path is
+/// present. Callers that actually need the binary (e.g. prompt-embedding
+/// generation) should still go through [`llama_embedding_binary`].
+pub fn llama_embedding_binary_optional() -> Option<PathBuf> {
     if let Ok(path) = std::env::var("LLAMA_EMBEDDING_BIN") {
         let binary = PathBuf::from(path);
         if binary.exists() {
-            return Ok(binary);
+            return Some(binary);
         }
     }
 
     let local = PathBuf::from("/home/raulmc/llama.cpp/build/bin/llama-embedding");
     if local.exists() {
-        return Ok(local);
+        return Some(local);
     }
 
-    Err(Error::other("LLAMA_EMBEDDING_BIN must point to llama.cpp's llama-embedding binary").into())
+    None
+}
+
+/// Parse `ROUTING_MODE` into a [`RoutingMode`]. Returns `None` when the env
+/// var is unset so callers can keep the config-provided default.
+pub fn routing_mode_override_from_env() -> Option<RoutingMode> {
+    let raw = std::env::var("ROUTING_MODE").ok()?;
+    match raw.to_ascii_lowercase().as_str() {
+        "dense" => Some(RoutingMode::DenseSim),
+        "stub" => Some(RoutingMode::StubUniform),
+        "spiking" | "spiking_sim" => Some(RoutingMode::SpikingSim),
+        _ => None,
+    }
 }
 
 fn parse_llama_embedding_payload(

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -62,6 +62,7 @@ pub fn default_spiking_model_config(gguf_checkpoint_path: String, snn_steps: usi
         snn_steps,
         projection_mode: ProjectionMode::SpikingTernary,
         heartbeat: heartbeat_config_from_env(),
+        gpu_routing_telemetry_path: None,
     }
 }
 

--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -5,21 +5,16 @@ mod support;
 use corinth_canal::{
     EMBEDDING_DIM, model::Model, moe::RoutingMode, telemetry::TelemetrySnapshot,
 };
-use support::{default_spiking_model_config, gguf_checkpoint_path_or_default};
+use support::{RunConfig, default_spiking_model_config};
 
 fn main() -> corinth_canal::Result<()> {
-    let model_path = gguf_checkpoint_path_or_default();
-    let routing_mode = match std::env::var("ROUTING_MODE")
-        .unwrap_or_else(|_| "spiking".into())
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "dense" => RoutingMode::DenseSim,
-        "stub" => RoutingMode::StubUniform,
-        _ => RoutingMode::SpikingSim,
-    };
+    let _ = dotenvy::from_filename(".env.local");
+    let run_cfg = RunConfig::from_env();
+    let routing_mode = run_cfg
+        .routing_mode_override
+        .unwrap_or(RoutingMode::SpikingSim);
 
-    let mut cfg = default_spiking_model_config(model_path, 20);
+    let mut cfg = default_spiking_model_config(run_cfg.gguf_checkpoint_path.clone(), 20);
     cfg.routing_mode = routing_mode;
 
     let mut model = Model::new(cfg)?;

--- a/justfile
+++ b/justfile
@@ -1,0 +1,53 @@
+set dotenv-load := true
+set dotenv-filename := ".env.local"
+
+# Default: list all recipes.
+default:
+    @just --list
+
+# One-time setup sanity check: verify every doc + manifest exists.
+setup:
+    @test -f .env.local || echo "warn: .env.local missing (copy from .env.example)"
+    @test -d artifacts  || mkdir -p artifacts
+    @echo "ok: scaffolding present"
+
+# Fast compile sweep.
+check:
+    cargo check --all-targets
+
+# Full test suite (CPU-only paths; GPU tests gated on hardware).
+test:
+    cargo test
+
+# GPU smoke test — 10k direct GPU ticks against a real GGUF checkpoint.
+# Requires GGUF_CHECKPOINT_PATH in .env.local.
+smoke:
+    cargo run --release --example gpu_smoke_test
+
+# CSV replay demo.
+#   just replay PATH=/path/to/telemetry.csv
+replay PATH:
+    cargo run --release --example csv_replay -- {{PATH}}
+
+# Full SAAQ latent calibration sweep using current .env.local values.
+saaq:
+    cargo run --release --example saaq_latent_calibration
+
+# Force CSV-replay mode for the SAAQ sweep. TELEMETRY_CSV_PATH must be set
+# in the environment or passed explicitly:
+#   just saaq-csv TELEMETRY_CSV_PATH=/path/to/telemetry.csv
+saaq-csv:
+    TELEMETRY_SOURCE=csv cargo run --release --example saaq_latent_calibration
+
+# Matrix sweep: both heartbeat modes, both SAAQ rules (dual emission).
+saaq-sweep:
+    HEARTBEAT_MATRIX= cargo run --release --example saaq_latent_calibration
+
+# Telemetry bridge demo (routing_mode switchable via ROUTING_MODE env).
+bridge:
+    cargo run --release --example telemetry_bridge
+
+# Wipe everything under ./artifacts except the .gitkeep anchor.
+clean-artifacts:
+    find artifacts -mindepth 1 ! -name .gitkeep -exec rm -rf {} +
+    @echo "ok: artifacts/ emptied"

--- a/manifests/known_good_runs.md
+++ b/manifests/known_good_runs.md
@@ -1,0 +1,22 @@
+# Known-Good Runs
+
+Append-only log. One entry per run ID that has been hand-reviewed and
+blessed as reference material for future promotion. Latest entries at the
+top.
+
+Format:
+
+```
+## <run_id>
+- checkpoint: <model_slug> (<family>)
+- telemetry:  <source_label>
+- heartbeat:  on|off
+- saaq_rule:  saaq_v1_5 | legacy
+- conclusion: <one line>
+- artifacts:  <path under VALIDATION_OUTPUT_ROOT, or "artifacts/<run_id>/">
+```
+
+---
+
+_No blessed runs yet. Bootstrap this file once Stage E is verified and the
+first artifacts/ tree is reviewed._

--- a/manifests/proven_components.toml
+++ b/manifests/proven_components.toml
@@ -1,0 +1,90 @@
+# Machine-readable mirror of docs/MODULE_STATUS.md.
+#
+# Status ladder: reference < stabilizing < proven < frozen.
+# Target repo is the future rmems crate a module should promote into.
+
+schema_version = 1
+
+[[component]]
+path            = "src/model/core.rs"
+status          = "reference"
+target_repo     = "rmems-model"
+owner_notes     = "Gated on Stage E routing-CSV path refactor."
+last_proven_run = ""
+
+[[component]]
+path            = "src/model/temporal.rs"
+status          = "stabilizing"
+target_repo     = "rmems-model"
+owner_notes     = "GPU temporal loop proven; needs explicit CSV path field."
+last_proven_run = ""
+
+[[component]]
+path            = "src/model/telemetry_io.rs"
+status          = "stabilizing"
+target_repo     = "rmems-model"
+owner_notes     = "Pure helper; blocked on caller passing absolute path."
+last_proven_run = ""
+
+[[component]]
+path            = "src/moe/mod.rs"
+status          = "stabilizing"
+target_repo     = "rmems-moe"
+owner_notes     = "OlmoeRouter host; pending full five-family matrix."
+last_proven_run = ""
+
+[[component]]
+path            = "src/moe/checkpoint.rs"
+status          = "reference"
+target_repo     = "rmems-moe"
+owner_notes     = "WIP parser repaired; needs proper test battery."
+last_proven_run = ""
+
+[[component]]
+path            = "src/moe/adapter.rs"
+status          = "stabilizing"
+target_repo     = "rmems-moe"
+owner_notes     = "Five-family support; needs CI matrix."
+last_proven_run = ""
+
+[[component]]
+path            = "src/moe/routing.rs"
+status          = "stabilizing"
+target_repo     = "rmems-moe"
+owner_notes     = "Stateless math; low-risk promotion candidate."
+last_proven_run = ""
+
+[[component]]
+path            = "src/projector.rs"
+status          = "stabilizing"
+target_repo     = "rmems-projector"
+owner_notes     = "ProjectionMode surface frozen."
+last_proven_run = ""
+
+[[component]]
+path            = "src/funnel.rs"
+status          = "reference"
+target_repo     = "rmems-funnel"
+owner_notes     = "GIF layer shared between CPU and GPU callers."
+last_proven_run = ""
+
+[[component]]
+path            = "src/telemetry.rs"
+status          = "stabilizing"
+target_repo     = "rmems-telemetry"
+owner_notes     = "Schema frozen."
+last_proven_run = ""
+
+[[component]]
+path            = "src/latent.rs"
+status          = "stabilizing"
+target_repo     = "rmems-latent"
+owner_notes     = "Dual-SAAQ working; needs REPEAT_COUNT=2 determinism check."
+last_proven_run = ""
+
+[[component]]
+path            = "src/gpu"
+status          = "reference"
+target_repo     = "rmems-gpu"
+owner_notes     = "Blocked on build.rs portability."
+last_proven_run = ""

--- a/src/model/core.rs
+++ b/src/model/core.rs
@@ -8,13 +8,25 @@ use crate::projector::Projector;
 use crate::types::{
     EMBEDDING_DIM, ModelConfig, ModelFamily, ModelOutput, RoutingMode, TelemetrySnapshot,
 };
-use std::path::Path;
 
 pub(super) const N_NEURONS: usize = 2048;
 pub(super) const IZ_NEURONS: usize = 5;
 pub(super) const GPU_ROUTING_TELEMETRY_HEADER: &str =
     "token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction";
 pub(super) const GPU_ROUTING_TELEMETRY_PATH: &str = "snn_gpu_routing_telemetry.csv";
+
+/// Resolve the effective routing-telemetry CSV path for a model.
+///
+/// Returns an owned [`PathBuf`] pointing at either the caller-configured
+/// absolute path (via `ModelConfig::gpu_routing_telemetry_path`) or the
+/// legacy CWD-relative `snn_gpu_routing_telemetry.csv` fallback. Kept as a
+/// free function so both `core.rs` and `temporal.rs` share one contract.
+pub(super) fn resolve_gpu_routing_telemetry_path(config: &ModelConfig) -> std::path::PathBuf {
+    config
+        .gpu_routing_telemetry_path
+        .clone()
+        .unwrap_or_else(|| std::path::PathBuf::from(GPU_ROUTING_TELEMETRY_PATH))
+}
 
 /// Standalone runtime that keeps the projector and router logic real while
 /// replacing the original front-end with deterministic synthetic spikes.
@@ -177,8 +189,9 @@ impl Model {
                 GpuError::MemoryError("best_walker buffer returned no values".into())
             })?;
 
+        let target = resolve_gpu_routing_telemetry_path(&self.config);
         append_gpu_routing_telemetry_row(
-            Path::new(GPU_ROUTING_TELEMETRY_PATH),
+            &target,
             token_idx,
             final_score,
             final_walker,

--- a/src/model/temporal.rs
+++ b/src/model/temporal.rs
@@ -1,13 +1,12 @@
 //! GPU temporal loop helpers for [`Model`](super::Model).
 
 use super::{
-    core::{GPU_ROUTING_TELEMETRY_PATH, IZ_NEURONS, N_NEURONS},
+    core::{IZ_NEURONS, N_NEURONS, resolve_gpu_routing_telemetry_path},
     telemetry_io::append_gpu_routing_telemetry_row,
 };
 use super::Model;
 use crate::gpu::{GpuAccelerator, GpuError, GpuResult};
 use crate::types::{ModelOutput, TelemetrySnapshot};
-use std::path::Path;
 
 impl Model {
     /// GPU-only temporal simulation with GIF (Generalized Integrate-and-Fire).
@@ -87,8 +86,9 @@ impl Model {
             0.0
         };
         let mean_adaptation = 0.25f32;
+        let target = resolve_gpu_routing_telemetry_path(&self.config);
         let _ = append_gpu_routing_telemetry_row(
-            Path::new(GPU_ROUTING_TELEMETRY_PATH),
+            &target,
             self.global_step as usize,
             0,
             best_walker as i32,

--- a/src/moe/checkpoint.rs
+++ b/src/moe/checkpoint.rs
@@ -62,15 +62,7 @@ struct GgufCursor<'a> {
     offset: usize,
 }
 
-pub(super) fn extract_token_embedding(
-    checkpoint: &mut MappedGgufCheckpoint,
-    path: &str,
-    token_id: usize,
-) -> Result<Vec<f32>> {
-    checkpoint.extract_token_embedding("token_embd.weight", path, token_id)
-}
-
-pub(super) fn extract_token_embedding(
+pub(super) fn extract_named_token_embedding_from_checkpoint(
     checkpoint: &mut MappedGgufCheckpoint,
     tensor_name: &str,
     path: &str,
@@ -79,8 +71,18 @@ pub(super) fn extract_token_embedding(
     checkpoint.extract_token_embedding(tensor_name, path, token_id)
 }
 
-impl.strings.get("general.architecture") GgufMetadata {
-    &self.strings.get("general.architecture").cloned().unwrap_or_else(|| "unknown".into())
+impl GgufMetadata {
+    pub(super) fn architecture(&self) -> &str {
+        &self.architecture
+    }
+
+    pub(super) fn quantization(&self) -> &str {
+        &self.quantization
+    }
+
+    pub(super) fn numeric(&self, key: &str) -> Option<usize> {
+        self.numerics.get(key).copied().map(|v| v as usize)
+    }
 }
 
 impl MappedGgufCheckpoint {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 //! Public data types for `corinth-canal`.
 
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 /// Dimensionality of the dense embedding the projector hands to OlmoeRouter.
@@ -82,6 +84,13 @@ pub struct ModelConfig {
     pub snn_steps: usize,
     pub projection_mode: ProjectionMode,
     pub heartbeat: HeartbeatConfig,
+    /// Destination path for the GPU routing telemetry CSV written by
+    /// `Model::forward_gpu_temporal` (and `Model::forward` on the GPU path).
+    /// When `None`, the runtime falls back to the legacy CWD-relative
+    /// filename `snn_gpu_routing_telemetry.csv`. Prefer an absolute path
+    /// anchored in the caller's per-run artifact directory.
+    #[serde(default)]
+    pub gpu_routing_telemetry_path: Option<PathBuf>,
 }
 
 impl Default for ModelConfig {
@@ -96,6 +105,7 @@ impl Default for ModelConfig {
             snn_steps: 20,
             projection_mode: ProjectionMode::SpikingTernary,
             heartbeat: HeartbeatConfig::default(),
+            gpu_routing_telemetry_path: None,
         }
     }
 }


### PR DESCRIPTION
## **User description**
Reconfigures `corinth-canal` for its role as the single-crate **reference implementation** for the future `rmems` modular line. No architectural rewrite, no crate split, no logic moved out of `src/model/`.

Requesting code review from **CodeAnt AI** and **Codex**.

## Six commits, one per stage

1. `chore(stage-a): Cargo metadata hygiene + baseline compile repair`
2. `chore(stage-b): scaffolding for reference-repo role`
3. `feat(stage-c): additive RunConfig for example binaries`
4. `feat(stage-d): migrate examples to RunConfig + dotenv + ./artifacts default`
5. `feat(stage-e): configurable gpu_routing_telemetry_path on ModelConfig`
6. `docs(stage-f): README reference-repo framing, fix stale org/paths, add docs links`

## What changed

### Configuration + path hygiene

- All env reads for examples are aggregated in a single `RunConfig::from_env()` (`examples/support/config.rs`). The `src/` crate never reads env for paths.
- `.env.example` documents 13 env vars with defaults and valid values; `.env.local` is gitignored and user-created.
- `dotenvy = "0.15"` is a dev-dependency; every example starts with `dotenvy::from_filename(".env.local").ok();`.
- Default `VALIDATION_OUTPUT_ROOT` is now `./artifacts` (repo-relative), down from the absolute `/home/raulmc/Julia/Surrogate_Viz.jl/outputs/saaq15` path. External consumers can still override via env.
- `ModelConfig` gains `gpu_routing_telemetry_path: Option<PathBuf>` (serde `#[default]`). `None` preserves the legacy CWD fallback; `saaq_latent_calibration` now sets it to `<run_dir>/snn_gpu_routing_telemetry.csv`, and `cwd_routing_csv_contaminated` in the manifest is a real predicate instead of a static `false`.

### Organization

- `.cargo/config.toml`: pure cargo aliases (`ck`, `smoke`, `replay`, `saaq`, `bridge`, `ex-check`).
- `justfile`: end-to-end workflow recipes (`setup`, `check`, `test`, `smoke`, `replay PATH`, `saaq`, `saaq-csv`, `saaq-sweep`, `bridge`, `clean-artifacts`) with `set dotenv-load := true`.
- `artifacts/.gitkeep`: per-run output tree anchor; `.gitignore` keeps generated run dirs out of git.

### Docs + promotion tracking

- `docs/ARCHITECTURE.md` — block diagram, module map, hidden control flow (CWD writes, env-resolved paths, telemetry fallback stamping).
- `docs/RUN_PROFILES.md` — blessed `(prompt, telemetry, heartbeat, SAAQ)` tuples with exact commands.
- `docs/PROMOTION_RULES.md` — four-step status ladder and six criteria to graduate a module.
- `docs/MODULE_STATUS.md` — per-module status with target `rmems-*` crate.
- `manifests/proven_components.toml` — machine-readable mirror.
- `manifests/known_good_runs.md` — append-only blessed-run log.
- `README.md` — new Documentation section, Origin framing, stale-path fixes in the env table, citation block retargeted to `rmems/corinth-canal` with `MoE` typo fixed.

### Cargo

- `repository = "https://github.com/rmems/corinth-canal"`.
- Empty `[workspace]` section **kept with a comment** — it is load-bearing to stop Cargo from attaching to an unrelated parent workspace on the author's dev machine.
- `exclude = ["docs/"]` dropped (reference repo wants docs in the package).
- `Cargo.lock` is now tracked (removed from `.gitignore`) for reproducibility.

### Baseline compile repair

Cargo refused to build on `main` (HEAD commit: "In a middle of the codebase refactor") because `src/moe/checkpoint.rs` had a malformed `impl.strings.get(...)` block and a duplicate `extract_token_embedding` free function. The minimal repair:

- Rename the 4-arg helper to `extract_named_token_embedding_from_checkpoint` (matches the existing import in `src/moe/mod.rs`).
- Drop the unused 3-arg duplicate.
- Provide the `GgufMetadata::{architecture, quantization, numeric}` accessors that `src/moe/adapter.rs` already calls.

This was the minimum needed to verify the rest of this PR.

## Verification

- `cargo check` — clean (one pre-existing `dead_code` warning on `GgufMetadata::strings`, unrelated).
- `cargo check --examples` — clean.
- `cargo test --lib` — 51 passed, 2 GPU-only ignored.
- End-to-end `saaq_latent_calibration` run (pre Stage E) produced a real preflight manifest under `artifacts/<model_slug>/synthetic/heartbeat_off/<run_id>/run_manifest.json` with `output_root = "./artifacts"` and `saaq_dual_emit = true`. Artifact cleaned up before commit; no CSVs or run dirs tracked in git.

## Warnings / follow-ups (intentionally not fixed here)

- `$HOME/Downloads/SNN_Quantization` is still the implicit GGUF model discovery root — documented in `docs/RUN_PROFILES.md#model-discovery` as a machine-local convention.
- `/home/raulmc/llama.cpp/build/bin/llama-embedding` remains a last-resort probe in `examples/support/mod.rs`; documented in `.env.example`. Setting `LLAMA_EMBEDDING_BIN` is the supported path.
- `src/moe/mod.rs:585` `test_real_checkpoint_probe_via_env` silently skips when `GGUF_CHECKPOINT_PATH` is unset. Flagged in `docs/MODULE_STATUS.md`.
- `AGENTS.md` remains gitignored (legacy decision; not in scope for this pass).

## Out of scope (by design)

- No module moves out of `src/model/`, `src/moe/`, etc.
- No new crate-root `pub use` re-exports.
- No crate split into workspace members.
- No changes to SAAQ math, router math, projector math, or CSV schemas.


___

## **CodeAnt-AI Description**
**Make example runs use shared env config and keep GPU telemetry inside run artifacts**

### What Changed
- Example binaries now load `.env.local` and read run settings from one shared config source instead of scattered per-file lookups
- The validation sweep now writes GPU routing telemetry into each run’s artifact folder, and the manifest reflects that the file is no longer written to the current directory
- Default validation output now goes to `./artifacts` instead of a machine-specific path
- The GPU smoke test, CSV replay, and telemetry bridge now use the same checkpoint and routing-mode handling from the shared run config
- Added run, setup, and promotion docs plus cargo/just shortcuts for the reference workflow

### Impact
`✅ Fewer files written to the wrong folder`
`✅ Easier local setup with `.env.local``
`✅ Reproducible run outputs in `./artifacts``


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=TWUFXrFmE6_WZ67t6UScH4Uulqq7iDC9d60TGqte59s&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
