### PR TITLE
feat(campaign): SAAQ 1.5 MoE baseline prep — lineup config, summary.json, append-only index, strict-repeat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,26 @@ VALIDATION_OUTPUT_ROOT=
 
 # "dense" | "stub" | anything else => spiking (default).
 ROUTING_MODE=spiking
+
+# ---------------------------------------------------------------------------
+# Campaign controls
+# ---------------------------------------------------------------------------
+
+# Path to a TOML lineup file listing MoE checkpoints
+# (see configs/saaq15_moe_lineup.toml). When set, takes precedence over
+# GGUF_CHECKPOINT_PATH and over machine-local autodiscovery.
+# A path that cannot be read or parsed is a hard error, not a fallback.
+LINEUP_CONFIG=
+
+# Optional free-form tag appended to every run_id and stamped into
+# run_manifest.json / summary.json. Must match [A-Za-z0-9._-]; other
+# characters are replaced with '_'. Leave blank to disable (no suffix,
+# no trailing underscore).
+RUN_TAG=
+
+# When REPEAT_COUNT>=2 and this is true, the calibration runner
+# byte-compares each repeat's latent_telemetry.csv to repeat 0 per
+# (model_slug, telemetry_source, heartbeat_slug, saaq_rule) group. Any
+# mismatch stamps summary.json with repeat_determinism="mismatch" and the
+# process exits non-zero. Default false.
+STRICT_REPEAT_CHECK=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "tracing",
 ]
 
@@ -114,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +149,22 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "itoa"
@@ -290,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +370,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +457,15 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rustc_version",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 dotenvy = "0.15"
+toml    = "0.8"
 
 [build-dependencies]
 cc = "1.0"

--- a/configs/saaq15_moe_lineup.toml
+++ b/configs/saaq15_moe_lineup.toml
@@ -1,0 +1,40 @@
+# corinth-canal SAAQ 1.5 MoE baseline lineup.
+#
+# Loaded by examples/saaq_latent_calibration.rs when LINEUP_CONFIG points at
+# this file. Each [[model]] entry defines one validation target; edit/extend
+# per machine without touching Rust sources.
+#
+# Fields:
+#   slug          directory-safe identifier (used in artifact paths)
+#   family        one of: olmoe | qwen3_moe | gemma4 | deepseek2 | llama_moe
+#   path          absolute path to a GGUF checkpoint
+#   routing_mode  optional: "spiking_sim" | "dense_sim" | "stub_uniform"
+#                 unset => ModelConfig::routing_mode default (SpikingSim)
+#
+# Paths are intentionally machine-local for this baseline. An example/local
+# split can come later if needed.
+
+[[model]]
+slug = "olmoe_baseline"
+family = "olmoe"
+path = "/home/raulmc/Downloads/SNN_Quantization/olmoe-0125-gguf/OLMoE-1B-7B-0125-Instruct-F16.gguf"
+
+[[model]]
+slug = "qwen3_moe_i1_iq3_m"
+family = "qwen3_moe"
+path = "/home/raulmc/Downloads/SNN_Quantization/models/qwen3-moe-i1-GGUF/qwen3-moe.i1-IQ3_M.gguf"
+
+[[model]]
+slug = "gemma4_26b_a4b_iq4_nl"
+family = "gemma4"
+path = "/home/raulmc/Downloads/SNN_Quantization/models/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-UD-IQ4_NL.gguf"
+
+[[model]]
+slug = "deepseek_coder_v2_lite_q6_k_l"
+family = "deepseek2"
+path = "/home/raulmc/Downloads/SNN_Quantization/models/DeepSeek-Coder-V2-Lite-Instruct-GGUF/DeepSeek-Coder-V2-Lite-Instruct-Q6_K_L.gguf"
+
+[[model]]
+slug = "llama_3_2_dark_champion_q5_k_m"
+family = "llama_moe"
+path = "/home/raulmc/Downloads/SNN_Quantization/models/Llama-3.2-8X3B-MOE-Dark-Champion-GGUF/L3.2-8X3B-MOE-Dark-Champion-Inst-18.4B-uncen-ablit_D_AU-q5_k_m.gguf"

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -5,9 +5,10 @@ use corinth_canal::{
     SnnLatentCsvExporter, gpu::GpuAccelerator, model::Model,
 };
 use serde::Serialize;
-use std::fs::{self, File};
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Error, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 use support::{
     ResolvedTelemetry, RunConfig, TelemetrySource, ValidationModelSpec,
@@ -96,6 +97,39 @@ struct RunMetrics {
     last_timestamp_ms: Option<u64>,
 }
 
+/// Row buffered in-memory during a sweep, flushed once at end-of-`main`
+/// into `artifacts/index.csv`. Append-only by construction: every row is
+/// written exactly once, after the strict-repeat pass has had a chance to
+/// stamp `repeat_determinism`.
+#[derive(Debug, Clone)]
+struct PendingIndexRow {
+    run_id: String,
+    run_tag: Option<String>,
+    model_slug: String,
+    model_family: String,
+    telemetry_source: String,
+    heartbeat_enabled: bool,
+    heartbeat_slug: &'static str,
+    repeat_idx: usize,
+    repeat_count: usize,
+    saaq_rule: &'static str,
+    validation_status: &'static str,
+    run_dir: String,
+    ticks_completed: usize,
+    latent_rows: usize,
+    mean_tick_elapsed_us: Option<f64>,
+    /// Absolute path to `latent_telemetry.csv` — consumed only by the
+    /// strict-repeat pass; never written out to the CSV index.
+    latent_path: PathBuf,
+    /// Absolute path to `summary.json` for in-place determinism stamping.
+    summary_path: PathBuf,
+    repeat_determinism: Option<&'static str>,
+}
+
+fn heartbeat_slug_for(enabled: bool) -> &'static str {
+    if enabled { "heartbeat_on" } else { "heartbeat_off" }
+}
+
 struct RunContext<'a> {
     spec: &'a ValidationModelSpec,
     prompt_profile: &'a str,
@@ -155,34 +189,66 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sanitized_tag: Option<String> = cfg.run_tag.as_deref().map(sanitize_run_tag);
     let run_tag_ref: Option<&str> = sanitized_tag.as_deref();
 
-    for spec in &cfg.validation_models {
-        for repeat_idx in 0..cfg.repeat_count {
-            for &heartbeat_enabled in &cfg.heartbeat_matrix {
-                let run_id = build_run_id(&cfg.prompt_profile, repeat_idx, run_tag_ref);
-                let ctx = RunContext {
-                    spec,
-                    prompt_profile: &cfg.prompt_profile,
-                    prompt_text: cfg.prompt_text,
-                    ticks: effective_ticks,
-                    heartbeat_enabled,
-                    repeat_idx,
-                    repeat_count: cfg.repeat_count,
-                    resolved: &cfg.telemetry,
-                    run_id,
-                    output_root: cfg.output_root.clone(),
-                    model_family_override: cfg.model_family_override,
-                    saaq_rule: cfg.saaq_rule,
-                    run_tag: run_tag_ref,
-                };
-                run_validation(&ctx)?;
+    // In-memory index buffer. Every successful write_manifest_and_summary
+    // call at a TERMINAL status pushes a row here; the CSV is materialized
+    // exactly once at the end of main() after strict-repeat stamping.
+    let mut pending: Vec<PendingIndexRow> = Vec::new();
+
+    let sweep_result = (|pending: &mut Vec<PendingIndexRow>| -> Result<(), Box<dyn std::error::Error>> {
+        for spec in &cfg.validation_models {
+            for repeat_idx in 0..cfg.repeat_count {
+                for &heartbeat_enabled in &cfg.heartbeat_matrix {
+                    let run_id = build_run_id(&cfg.prompt_profile, repeat_idx, run_tag_ref);
+                    let ctx = RunContext {
+                        spec,
+                        prompt_profile: &cfg.prompt_profile,
+                        prompt_text: cfg.prompt_text,
+                        ticks: effective_ticks,
+                        heartbeat_enabled,
+                        repeat_idx,
+                        repeat_count: cfg.repeat_count,
+                        resolved: &cfg.telemetry,
+                        run_id,
+                        output_root: cfg.output_root.clone(),
+                        model_family_override: cfg.model_family_override,
+                        saaq_rule: cfg.saaq_rule,
+                        run_tag: run_tag_ref,
+                    };
+                    run_validation(&ctx, pending)?;
+                }
             }
         }
+        Ok(())
+    })(&mut pending);
+
+    // Strict-repeat verdict only runs on a clean sweep; partial sweeps can't
+    // give a trustworthy grouping. On opt-in + success, stamp verdicts into
+    // `pending` AND rewrite the referenced summary.json files in-place.
+    let mut strict_mismatch = false;
+    if sweep_result.is_ok() && cfg.strict_repeat_check && cfg.repeat_count >= 2 {
+        strict_mismatch = apply_strict_repeat_check(&mut pending)?;
+    }
+
+    // Flush the append-only index last, so every row already carries its
+    // final `repeat_determinism` verdict.
+    flush_index_csv(&cfg.output_root, &pending)?;
+
+    sweep_result?;
+
+    if strict_mismatch {
+        return Err(Error::other(
+            "strict_repeat_check: latent_telemetry.csv mismatch between repeats; see summary.json files stamped repeat_determinism=\"mismatch\"",
+        )
+        .into());
     }
 
     Ok(())
 }
 
-fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>> {
+fn run_validation(
+    ctx: &RunContext<'_>,
+    pending: &mut Vec<PendingIndexRow>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Pre-create the run directory so we can anchor the GPU routing
     // telemetry CSV inside it via ModelConfig and avoid polluting CWD.
     let run_dir = build_run_dir(ctx)?;
@@ -259,6 +325,15 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
                     &metrics,
                     generated_files.clone(),
                 )?;
+                pending.push(pending_row_from_state(
+                    ctx,
+                    &model,
+                    &run_dir,
+                    &latent_path,
+                    &summary_path,
+                    &metrics,
+                    "prompt_embedding_failed",
+                ));
                 return Err(error);
             }
         };
@@ -297,6 +372,15 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
             &metrics,
             generated_files.clone(),
         )?;
+        pending.push(pending_row_from_state(
+            ctx,
+            &model,
+            &run_dir,
+            &latent_path,
+            &summary_path,
+            &metrics,
+            "gpu_setup_failed",
+        ));
         return Err(Box::new(error));
     }
 
@@ -417,6 +501,15 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
             &metrics,
             generated_files.clone(),
         )?;
+        pending.push(pending_row_from_state(
+            ctx,
+            &model,
+            &run_dir,
+            &latent_path,
+            &summary_path,
+            &metrics,
+            "tick_failed",
+        ));
         return Err(error);
     }
 
@@ -436,6 +529,15 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
         &metrics,
         generated_files,
     )?;
+    pending.push(pending_row_from_state(
+        ctx,
+        &model,
+        &run_dir,
+        &latent_path,
+        &summary_path,
+        &metrics,
+        "completed",
+    ));
 
     println!(
         "validation_complete model_slug={} heartbeat_enabled={} repeat={}/{} run_dir={}",
@@ -646,6 +748,203 @@ fn saaq_rule_label(rule: SaaqUpdateRule) -> &'static str {
     }
 }
 
+/// Build a `PendingIndexRow` from the live model + run state. Mirrors the
+/// shape of the CSV header and keeps paths that `apply_strict_repeat_check`
+/// and `flush_index_csv` both need.
+fn pending_row_from_state(
+    ctx: &RunContext<'_>,
+    model: &Model,
+    run_dir: &Path,
+    latent_path: &Path,
+    summary_path: &Path,
+    metrics: &RunMetrics,
+    validation_status: &'static str,
+) -> PendingIndexRow {
+    PendingIndexRow {
+        run_id: ctx.run_id.clone(),
+        run_tag: ctx.run_tag.map(|s| s.to_owned()),
+        model_slug: ctx.spec.slug.clone(),
+        model_family: format!("{:?}", model.router_family()),
+        telemetry_source: ctx.resolved.source_label.clone(),
+        heartbeat_enabled: ctx.heartbeat_enabled,
+        heartbeat_slug: heartbeat_slug_for(ctx.heartbeat_enabled),
+        repeat_idx: ctx.repeat_idx,
+        repeat_count: ctx.repeat_count,
+        saaq_rule: saaq_rule_label(ctx.saaq_rule),
+        validation_status,
+        run_dir: run_dir.to_string_lossy().into_owned(),
+        ticks_completed: metrics.ticks_completed,
+        latent_rows: metrics.latent_rows,
+        mean_tick_elapsed_us: metrics.mean_tick_elapsed_us,
+        latent_path: latent_path.to_path_buf(),
+        summary_path: summary_path.to_path_buf(),
+        repeat_determinism: None,
+    }
+}
+
+const INDEX_CSV_HEADER: &str =
+    "run_id,run_tag,model_slug,model_family,telemetry_source,heartbeat_enabled,repeat_idx,repeat_count,saaq_rule,validation_status,run_dir,ticks_completed,latent_rows,mean_tick_elapsed_us,repeat_determinism";
+
+/// Append every buffered row to `<output_root>/index.csv`. The file is
+/// opened once per `main()` invocation with `append(true)`; if it's empty
+/// (new file or zero-byte), the header is emitted first. No row that has
+/// already been written out is ever rewritten.
+fn flush_index_csv(
+    output_root: &Path,
+    rows: &[PendingIndexRow],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    fs::create_dir_all(output_root)?;
+    let path = output_root.join("index.csv");
+    let needs_header = fs::metadata(&path).map(|m| m.len() == 0).unwrap_or(true);
+    let file = OpenOptions::new().create(true).append(true).open(&path)?;
+    let mut writer = BufWriter::new(file);
+    if needs_header {
+        writeln!(writer, "{INDEX_CSV_HEADER}")?;
+    }
+    for row in rows {
+        writeln!(writer, "{}", format_index_row(row))?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+fn format_index_row(row: &PendingIndexRow) -> String {
+    let mean_us = row
+        .mean_tick_elapsed_us
+        .map(|v| format!("{v:.3}"))
+        .unwrap_or_default();
+    let tag = row.run_tag.as_deref().unwrap_or("");
+    let determinism = row.repeat_determinism.unwrap_or("");
+    let fields = [
+        csv_escape(&row.run_id),
+        csv_escape(tag),
+        csv_escape(&row.model_slug),
+        csv_escape(&row.model_family),
+        csv_escape(&row.telemetry_source),
+        row.heartbeat_enabled.to_string(),
+        row.repeat_idx.to_string(),
+        row.repeat_count.to_string(),
+        csv_escape(row.saaq_rule),
+        csv_escape(row.validation_status),
+        csv_escape(&row.run_dir),
+        row.ticks_completed.to_string(),
+        row.latent_rows.to_string(),
+        mean_us,
+        csv_escape(determinism),
+    ];
+    fields.join(",")
+}
+
+/// Minimal RFC-4180-style escaping: wrap in double quotes iff the field
+/// contains a comma, quote, CR, or LF, and double any embedded quotes.
+fn csv_escape(s: &str) -> String {
+    if s.bytes().any(|b| matches!(b, b',' | b'"' | b'\r' | b'\n')) {
+        let mut out = String::with_capacity(s.len() + 2);
+        out.push('"');
+        for ch in s.chars() {
+            if ch == '"' {
+                out.push_str("\"\"");
+            } else {
+                out.push(ch);
+            }
+        }
+        out.push('"');
+        out
+    } else {
+        s.to_owned()
+    }
+}
+
+/// Strict-repeat verdict pass. Groups rows by
+/// `(model_slug, telemetry_source, heartbeat_slug, saaq_rule)` and compares
+/// each repeat `k >= 1`'s `latent_telemetry.csv` to repeat `0`'s byte-wise.
+///
+/// Only rows with `validation_status == "completed"` participate — partial
+/// / failed runs can't meaningfully claim determinism. Groups with fewer
+/// than two completed repeats are skipped silently (they can't mismatch).
+///
+/// Side effects:
+///   - Stamps `repeat_determinism` on every participating row in-place.
+///   - Rewrites each participating row's `summary.json` with the verdict.
+///
+/// Returns `true` if any mismatch was recorded.
+fn apply_strict_repeat_check(
+    rows: &mut [PendingIndexRow],
+) -> Result<bool, Box<dyn std::error::Error>> {
+    type GroupKey = (String, String, &'static str, &'static str);
+    let mut groups: BTreeMap<GroupKey, Vec<usize>> = BTreeMap::new();
+    for (idx, row) in rows.iter().enumerate() {
+        if row.validation_status != "completed" {
+            continue;
+        }
+        let key = (
+            row.model_slug.clone(),
+            row.telemetry_source.clone(),
+            row.heartbeat_slug,
+            row.saaq_rule,
+        );
+        groups.entry(key).or_default().push(idx);
+    }
+
+    let mut any_mismatch = false;
+    for (_, indices) in groups {
+        if indices.len() < 2 {
+            continue;
+        }
+        // Order repeats by repeat_idx so we always compare against the
+        // canonical repeat 0.
+        let mut sorted = indices.clone();
+        sorted.sort_by_key(|i| rows[*i].repeat_idx);
+        let baseline_idx = sorted[0];
+        let baseline_bytes = fs::read(&rows[baseline_idx].latent_path)?;
+
+        let mut group_mismatch = false;
+        for &i in sorted.iter().skip(1) {
+            let candidate_bytes = fs::read(&rows[i].latent_path)?;
+            if candidate_bytes != baseline_bytes {
+                rows[i].repeat_determinism = Some("mismatch");
+                rewrite_summary_determinism(&rows[i].summary_path, "mismatch")?;
+                group_mismatch = true;
+                any_mismatch = true;
+            }
+        }
+        if group_mismatch {
+            // Mark baseline as mismatch too so the group has a single verdict.
+            rows[baseline_idx].repeat_determinism = Some("mismatch");
+            rewrite_summary_determinism(&rows[baseline_idx].summary_path, "mismatch")?;
+        } else {
+            for &i in &sorted {
+                rows[i].repeat_determinism = Some("matched");
+                rewrite_summary_determinism(&rows[i].summary_path, "matched")?;
+            }
+        }
+    }
+    Ok(any_mismatch)
+}
+
+/// Rewrite `summary.json` in place to stamp `repeat_determinism`. We load
+/// the JSON, mutate one field, and write it back pretty-printed. This is
+/// the only rewrite path in the whole runner and only fires when
+/// strict-repeat check is active and produced a verdict.
+fn rewrite_summary_determinism(
+    summary_path: &Path,
+    verdict: &'static str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let raw = fs::read_to_string(summary_path)?;
+    let mut value: serde_json::Value = serde_json::from_str(&raw)?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "repeat_determinism".to_owned(),
+            serde_json::Value::String(verdict.to_owned()),
+        );
+    }
+    fs::write(summary_path, serde_json::to_string_pretty(&value)?)?;
+    Ok(())
+}
+
 fn build_run_id(prompt_profile: &str, repeat_idx: usize, run_tag: Option<&str>) -> String {
     let timestamp = format_local_timestamp_compact();
     match run_tag {
@@ -685,16 +984,11 @@ fn sanitize_run_tag(raw: &str) -> String {
 }
 
 fn build_run_dir(ctx: &RunContext<'_>) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let heartbeat_slug = if ctx.heartbeat_enabled {
-        "heartbeat_on"
-    } else {
-        "heartbeat_off"
-    };
     Ok(ctx
         .output_root
         .join(&ctx.spec.slug)
         .join(&ctx.resolved.source_label)
-        .join(heartbeat_slug)
+        .join(heartbeat_slug_for(ctx.heartbeat_enabled))
         .join(&ctx.run_id))
 }
 

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -50,7 +50,50 @@ struct ValidationManifest {
     repeat_idx: usize,
     repeat_count: usize,
     cwd_routing_csv_contaminated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    routing_mode: Option<&'static str>,
     generated_files: Vec<String>,
+}
+
+/// Compact, stable per-run summary consumed by downstream aggregators. Lives
+/// alongside `run_manifest.json` inside every run directory.
+#[derive(Debug, Serialize)]
+struct RunSummary {
+    run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_tag: Option<String>,
+    model_slug: String,
+    model_family: String,
+    telemetry_source: String,
+    heartbeat_enabled: bool,
+    repeat_idx: usize,
+    repeat_count: usize,
+    saaq_rule: &'static str,
+    validation_status: &'static str,
+    run_dir: String,
+    manifest_path: String,
+    tick_telemetry_path: String,
+    latent_telemetry_path: String,
+    metrics: RunMetrics,
+    /// `None` when strict-repeat is disabled or `repeat_count < 2`; populated
+    /// to `"matched"` / `"mismatch"` by the strict-repeat pass at the end of
+    /// `main()` only when the check actually ran.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repeat_determinism: Option<&'static str>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct RunMetrics {
+    ticks_completed: usize,
+    latent_rows: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mean_tick_elapsed_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_timestamp_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_timestamp_ms: Option<u64>,
 }
 
 struct RunContext<'a> {
@@ -66,6 +109,9 @@ struct RunContext<'a> {
     output_root: PathBuf,
     model_family_override: Option<corinth_canal::ModelFamily>,
     saaq_rule: SaaqUpdateRule,
+    /// Already-sanitized run tag (or `None`). Sanitization is performed
+    /// once in `main()` so manifest/summary/run_id all see the same value.
+    run_tag: Option<&'a str>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -104,10 +150,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into());
     }
 
+    // Sanitize the run tag once so run_id, manifest, and summary all agree
+    // on the canonical form.
+    let sanitized_tag: Option<String> = cfg.run_tag.as_deref().map(sanitize_run_tag);
+    let run_tag_ref: Option<&str> = sanitized_tag.as_deref();
+
     for spec in &cfg.validation_models {
         for repeat_idx in 0..cfg.repeat_count {
             for &heartbeat_enabled in &cfg.heartbeat_matrix {
-                let run_id = build_run_id(&cfg.prompt_profile, repeat_idx);
+                let run_id = build_run_id(&cfg.prompt_profile, repeat_idx, run_tag_ref);
                 let ctx = RunContext {
                     spec,
                     prompt_profile: &cfg.prompt_profile,
@@ -121,6 +172,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     output_root: cfg.output_root.clone(),
                     model_family_override: cfg.model_family_override,
                     saaq_rule: cfg.saaq_rule,
+                    run_tag: run_tag_ref,
                 };
                 run_validation(&ctx)?;
             }
@@ -141,6 +193,10 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
     config.model_family = ctx.model_family_override.or(ctx.spec.family);
     config.heartbeat.enabled = ctx.heartbeat_enabled;
     config.gpu_routing_telemetry_path = Some(routing_csv_path.clone());
+    // Per-model routing mode override from lineup config (Stage-campaign).
+    if let Some(rm) = ctx.spec.routing_mode {
+        config.routing_mode = rm;
+    }
     let saaq_rule = ctx.saaq_rule;
 
     let mut accelerator = GpuAccelerator::new();
@@ -157,10 +213,16 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
     let tick_path = run_dir.join("tick_telemetry.txt");
     let latent_path = run_dir.join("latent_telemetry.csv");
     let manifest_path = run_dir.join("run_manifest.json");
+    let summary_path = run_dir.join("summary.json");
     let generated_files = vec![
         tick_path.file_name().unwrap().to_string_lossy().into_owned(),
         latent_path.file_name().unwrap().to_string_lossy().into_owned(),
         manifest_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned(),
+        summary_path
             .file_name()
             .unwrap()
             .to_string_lossy()
@@ -171,58 +233,69 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
             .to_string_lossy()
             .into_owned(),
     ];
+
+    // Metrics accumulator. Populated during the tick loop; stamped into
+    // summary.json at every terminal status (completed / *_failed).
+    let mut metrics = RunMetrics::default();
+
     let target_neurons = model.projector_mut().input_neurons();
     let (prompt_embedding, prompt_embedding_source) =
         match prompt_embedding_for_validation(&ctx.spec.path, ctx.prompt_text, target_neurons) {
             Ok(result) => result,
             Err(error) => {
-                write_manifest(
+                write_manifest_and_summary(
+                    ctx,
+                    &config,
+                    &model,
+                    &run_dir,
                     &manifest_path,
-                    build_manifest(
-                        ctx,
-                        &config,
-                        &model,
-                        &run_dir,
-                        "unavailable",
-                        saaq_rule,
-                        "prompt_embedding_failed",
-                        Some(error.to_string()),
-                        generated_files.clone(),
-                    ),
+                    &summary_path,
+                    &tick_path,
+                    &latent_path,
+                    "unavailable",
+                    saaq_rule,
+                    "prompt_embedding_failed",
+                    Some(error.to_string()),
+                    &metrics,
+                    generated_files.clone(),
                 )?;
                 return Err(error);
             }
         };
 
-    write_manifest(
+    write_manifest_and_summary(
+        ctx,
+        &config,
+        &model,
+        &run_dir,
         &manifest_path,
-        build_manifest(
+        &summary_path,
+        &tick_path,
+        &latent_path,
+        &prompt_embedding_source,
+        saaq_rule,
+        "preflight",
+        None,
+        &metrics,
+        generated_files.clone(),
+    )?;
+
+    if let Err(error) = model.prepare_gpu_temporal(&mut accelerator) {
+        write_manifest_and_summary(
             ctx,
             &config,
             &model,
             &run_dir,
+            &manifest_path,
+            &summary_path,
+            &tick_path,
+            &latent_path,
             &prompt_embedding_source,
             saaq_rule,
-            "preflight",
-            None,
+            "gpu_setup_failed",
+            Some(error.to_string()),
+            &metrics,
             generated_files.clone(),
-        ),
-    )?;
-
-    if let Err(error) = model.prepare_gpu_temporal(&mut accelerator) {
-        write_manifest(
-            &manifest_path,
-            build_manifest(
-                ctx,
-                &config,
-                &model,
-                &run_dir,
-                &prompt_embedding_source,
-                saaq_rule,
-                "gpu_setup_failed",
-                Some(error.to_string()),
-                generated_files,
-            ),
         )?;
         return Err(Box::new(error));
     }
@@ -246,6 +319,8 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
         ctx.resolved.source_label,
     );
 
+    let mut elapsed_sum_us: u128 = 0;
+    let mut elapsed_count: usize = 0;
     let run_result = (|| -> Result<(), Box<dyn std::error::Error>> {
         for tick in 0..ctx.ticks {
             let snap = telemetry_snapshot_for_tick(tick, ctx.resolved);
@@ -254,9 +329,20 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
             let input_spikes: Vec<f32> =
                 prompt_embedding.iter().map(|value| value * gain).collect();
 
+            // First/last timestamp bookkeeping. `telemetry_snapshot_for_tick`
+            // rewrites timestamps to `tick + 1` for 1-to-1 CSV join but we
+            // still want the summary to reflect the exact values emitted.
+            if metrics.first_timestamp_ms.is_none() {
+                metrics.first_timestamp_ms = Some(snap.timestamp_ms);
+            }
+            metrics.last_timestamp_ms = Some(snap.timestamp_ms);
+
             let started = Instant::now();
             let best_walker = model.tick_gpu_temporal(&mut accelerator, &input_spikes)?;
             let elapsed_us = started.elapsed().as_micros();
+            elapsed_sum_us = elapsed_sum_us.saturating_add(elapsed_us);
+            elapsed_count += 1;
+            metrics.ticks_completed = elapsed_count;
 
             let spikes = accelerator.temporal_spikes_to_vec(target_neurons)?;
             let active_neurons: Vec<usize> = spikes
@@ -284,6 +370,7 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
             )?;
             let latent = calibrator.observe(&snap, &activity, &output)?;
             latent_exporter.write_row(&latent)?;
+            metrics.latent_rows += 1;
 
             writeln!(
                 tick_writer,
@@ -304,38 +391,51 @@ fn run_validation(ctx: &RunContext<'_>) -> Result<(), Box<dyn std::error::Error>
         Ok(())
     })();
 
+    // Finalize mean-tick metric (f64 microseconds). Safe for any
+    // elapsed_count <= usize::MAX; `as f64` lossiness is acceptable here.
+    if elapsed_count > 0 {
+        metrics.mean_tick_elapsed_us =
+            Some(elapsed_sum_us as f64 / elapsed_count as f64);
+    }
+
     if let Err(error) = run_result {
         let _ = latent_exporter.flush();
         let _ = tick_writer.flush();
-        write_manifest(
+        write_manifest_and_summary(
+            ctx,
+            &config,
+            &model,
+            &run_dir,
             &manifest_path,
-            build_manifest(
-                ctx,
-                &config,
-                &model,
-                &run_dir,
-                &prompt_embedding_source,
-                saaq_rule,
-                "tick_failed",
-                Some(error.to_string()),
-                generated_files.clone(),
-            ),
+            &summary_path,
+            &tick_path,
+            &latent_path,
+            &prompt_embedding_source,
+            saaq_rule,
+            "tick_failed",
+            Some(error.to_string()),
+            &metrics,
+            generated_files.clone(),
         )?;
         return Err(error);
     }
 
-    let manifest = build_manifest(
+    write_manifest_and_summary(
         ctx,
         &config,
         &model,
         &run_dir,
+        &manifest_path,
+        &summary_path,
+        &tick_path,
+        &latent_path,
         &prompt_embedding_source,
         saaq_rule,
         "completed",
         None,
+        &metrics,
         generated_files,
-    );
-    write_manifest(&manifest_path, manifest)?;
+    )?;
 
     println!(
         "validation_complete model_slug={} heartbeat_enabled={} repeat={}/{} run_dir={}",
@@ -419,7 +519,18 @@ fn build_manifest(
         // impossible regardless of whether `tick_gpu_temporal` or
         // `forward_gpu_temporal` is used.
         cwd_routing_csv_contaminated: config.gpu_routing_telemetry_path.is_none(),
+        run_tag: ctx.run_tag.map(|s| s.to_owned()),
+        routing_mode: Some(routing_mode_label(config.routing_mode)),
         generated_files,
+    }
+}
+
+fn routing_mode_label(mode: corinth_canal::moe::RoutingMode) -> &'static str {
+    use corinth_canal::moe::RoutingMode::*;
+    match mode {
+        StubUniform => "stub_uniform",
+        DenseSim => "dense_sim",
+        SpikingSim => "spiking_sim",
     }
 }
 
@@ -431,6 +542,103 @@ fn write_manifest(
     Ok(())
 }
 
+fn write_summary(
+    summary_path: &std::path::Path,
+    summary: &RunSummary,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fs::write(summary_path, serde_json::to_string_pretty(summary)?)?;
+    Ok(())
+}
+
+/// Convenience wrapper that builds + writes both `run_manifest.json` and
+/// `summary.json`. Lives here (not in config.rs) because it pulls on
+/// several run-local paths + live model state.
+#[allow(clippy::too_many_arguments)]
+fn write_manifest_and_summary(
+    ctx: &RunContext<'_>,
+    config: &corinth_canal::model::ModelConfig,
+    model: &Model,
+    run_dir: &std::path::Path,
+    manifest_path: &PathBuf,
+    summary_path: &std::path::Path,
+    tick_path: &std::path::Path,
+    latent_path: &std::path::Path,
+    prompt_embedding_source: &str,
+    saaq_rule: SaaqUpdateRule,
+    validation_status: &'static str,
+    error: Option<String>,
+    metrics: &RunMetrics,
+    generated_files: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    write_manifest(
+        manifest_path,
+        build_manifest(
+            ctx,
+            config,
+            model,
+            run_dir,
+            prompt_embedding_source,
+            saaq_rule,
+            validation_status,
+            error,
+            generated_files,
+        ),
+    )?;
+    write_summary(
+        summary_path,
+        &build_summary(
+            ctx,
+            model.router_family(),
+            run_dir,
+            manifest_path,
+            tick_path,
+            latent_path,
+            saaq_rule,
+            validation_status,
+            metrics,
+        ),
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_summary(
+    ctx: &RunContext<'_>,
+    model_family: corinth_canal::ModelFamily,
+    run_dir: &std::path::Path,
+    manifest_path: &std::path::Path,
+    tick_path: &std::path::Path,
+    latent_path: &std::path::Path,
+    saaq_rule: SaaqUpdateRule,
+    validation_status: &'static str,
+    metrics: &RunMetrics,
+) -> RunSummary {
+    RunSummary {
+        run_id: ctx.run_id.clone(),
+        run_tag: ctx.run_tag.map(|s| s.to_owned()),
+        model_slug: ctx.spec.slug.clone(),
+        model_family: format!("{model_family:?}"),
+        telemetry_source: ctx.resolved.source_label.clone(),
+        heartbeat_enabled: ctx.heartbeat_enabled,
+        repeat_idx: ctx.repeat_idx,
+        repeat_count: ctx.repeat_count,
+        saaq_rule: saaq_rule_label(saaq_rule),
+        validation_status,
+        run_dir: run_dir.to_string_lossy().into_owned(),
+        manifest_path: manifest_path.to_string_lossy().into_owned(),
+        tick_telemetry_path: tick_path.to_string_lossy().into_owned(),
+        latent_telemetry_path: latent_path.to_string_lossy().into_owned(),
+        metrics: RunMetrics {
+            ticks_completed: metrics.ticks_completed,
+            latent_rows: metrics.latent_rows,
+            mean_tick_elapsed_us: metrics.mean_tick_elapsed_us,
+            first_timestamp_ms: metrics.first_timestamp_ms,
+            last_timestamp_ms: metrics.last_timestamp_ms,
+        },
+        repeat_determinism: None,
+    }
+}
+
 fn saaq_rule_label(rule: SaaqUpdateRule) -> &'static str {
     match rule {
         SaaqUpdateRule::LegacyV1_0 => "LegacyV1_0",
@@ -438,13 +646,42 @@ fn saaq_rule_label(rule: SaaqUpdateRule) -> &'static str {
     }
 }
 
-fn build_run_id(prompt_profile: &str, repeat_idx: usize) -> String {
-    format!(
-        "{}_{}_r{}",
-        format_local_timestamp_compact(),
-        prompt_profile,
-        repeat_idx
-    )
+fn build_run_id(prompt_profile: &str, repeat_idx: usize, run_tag: Option<&str>) -> String {
+    let timestamp = format_local_timestamp_compact();
+    match run_tag {
+        Some(tag) if !tag.is_empty() => {
+            format!("{timestamp}_{prompt_profile}_r{repeat_idx}_{tag}")
+        }
+        _ => format!("{timestamp}_{prompt_profile}_r{repeat_idx}"),
+    }
+}
+
+/// Keep only `[A-Za-z0-9._-]` from the raw tag; any other character becomes
+/// `_`. Runs of `_` are collapsed so the result never produces the visual
+/// `__` join with the preceding `r<idx>_`. Empty / whitespace-only -> `""`.
+fn sanitize_run_tag(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let mut out = String::with_capacity(trimmed.len());
+    let mut last_was_underscore = false;
+    for ch in trimmed.chars() {
+        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-');
+        let c = if ok { ch } else { '_' };
+        if c == '_' {
+            if !last_was_underscore {
+                out.push('_');
+            }
+            last_was_underscore = true;
+        } else {
+            out.push(c);
+            last_was_underscore = false;
+        }
+    }
+    // Trim leading/trailing underscores introduced by sanitization so we
+    // never append `_r0__tag` or `_r0_tag_`.
+    out.trim_matches('_').to_owned()
 }
 
 fn build_run_dir(ctx: &RunContext<'_>) -> Result<PathBuf, Box<dyn std::error::Error>> {

--- a/examples/support/config.rs
+++ b/examples/support/config.rs
@@ -13,16 +13,17 @@
 
 #![allow(dead_code)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use corinth_canal::{HeartbeatConfig, ModelFamily, SaaqUpdateRule, moe::RoutingMode};
+use serde::Deserialize;
 
 use super::{
-    ResolvedTelemetry, ValidationModelSpec, discover_validation_models,
+    ResolvedTelemetry, ValidationModelSpec, discover_validation_models, env_flag,
     heartbeat_config_from_env, heartbeat_modes_for_matrix, llama_embedding_binary_optional,
-    model_family_override_from_env, prompt_profile_slug, prompt_text_for_profile,
-    repeat_count_from_env, resolve_telemetry_source, routing_mode_override_from_env,
-    saaq_update_rule_from_env, ticks_from_env,
+    model_family_override_from_env, parse_family_slug, parse_routing_mode, prompt_profile_slug,
+    prompt_text_for_profile, repeat_count_from_env, resolve_telemetry_source,
+    routing_mode_override_from_env, saaq_update_rule_from_env, ticks_from_env,
 };
 
 /// Default output root for per-run artifacts when `VALIDATION_OUTPUT_ROOT`
@@ -53,6 +54,16 @@ pub struct RunConfig {
     pub validation_models: Vec<ValidationModelSpec>,
     pub gguf_checkpoint_path: String,
     pub routing_mode_override: Option<RoutingMode>,
+    /// Path to the parsed lineup config (if `LINEUP_CONFIG` was set and
+    /// successfully resolved). Stamped into the run manifest for provenance.
+    pub lineup_config_path: Option<PathBuf>,
+    /// Free-form run tag from `RUN_TAG`. Empty / unset maps to `None` so
+    /// callers can just do `if let Some(tag) = cfg.run_tag { ... }`.
+    pub run_tag: Option<String>,
+    /// When `true` and `repeat_count >= 2`, the calibration runner asserts
+    /// byte-equality of `latent_telemetry.csv` across repeats per
+    /// `(model_slug, telemetry_source, heartbeat_slug, saaq_rule)` group.
+    pub strict_repeat_check: bool,
 }
 
 impl RunConfig {
@@ -63,6 +74,12 @@ impl RunConfig {
     pub fn from_env() -> Self {
         let prompt_profile = prompt_profile_slug();
         let prompt_text = prompt_text_for_profile(&prompt_profile);
+        let gguf_checkpoint_path = std::env::var("GGUF_CHECKPOINT_PATH").unwrap_or_default();
+        let lineup_config_path = lineup_config_path_from_env();
+        let validation_models = resolve_validation_models(
+            lineup_config_path.as_deref(),
+            &gguf_checkpoint_path,
+        );
         Self {
             prompt_profile: prompt_profile.clone(),
             prompt_text,
@@ -75,11 +92,139 @@ impl RunConfig {
             model_family_override: model_family_override_from_env(),
             saaq_rule: saaq_update_rule_from_env(),
             llama_embedding_bin: llama_embedding_binary_optional(),
-            validation_models: discover_validation_models(),
-            gguf_checkpoint_path: std::env::var("GGUF_CHECKPOINT_PATH").unwrap_or_default(),
+            validation_models,
+            gguf_checkpoint_path,
             routing_mode_override: routing_mode_override_from_env(),
+            lineup_config_path,
+            run_tag: run_tag_from_env(),
+            strict_repeat_check: strict_repeat_check_from_env(),
         }
     }
+}
+
+/// Resolve the validation-model list with the documented precedence:
+///
+///   1. `LINEUP_CONFIG` file (hard error if set but unparseable).
+///   2. `GGUF_CHECKPOINT_PATH` (single-model override via the legacy path).
+///   3. Machine-local autodiscovery under `$HOME/Downloads/SNN_Quantization`.
+fn resolve_validation_models(
+    lineup_path: Option<&Path>,
+    gguf_checkpoint_path: &str,
+) -> Vec<ValidationModelSpec> {
+    if let Some(path) = lineup_path {
+        match load_lineup_file(path) {
+            Ok(models) => return models,
+            Err(err) => {
+                // Hard-fail with a loud message so a typo / missing path is
+                // never silently papered over by autodiscovery.
+                panic!(
+                    "LINEUP_CONFIG={} could not be loaded: {err}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    // Legacy single-model override or autodiscovery — let the existing
+    // helper keep its current contract.
+    let _ = gguf_checkpoint_path; // discover_validation_models reads it directly
+    discover_validation_models()
+}
+
+#[derive(Debug, Deserialize)]
+struct RawLineup {
+    #[serde(default)]
+    model: Vec<RawLineupModel>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawLineupModel {
+    slug: String,
+    family: String,
+    path: String,
+    #[serde(default)]
+    routing_mode: Option<String>,
+}
+
+/// Parse the lineup TOML and convert each entry to a `ValidationModelSpec`.
+/// Missing files are skipped with a warning (same non-fatal behavior as
+/// `discover_validation_models`); unknown family / routing-mode slugs are
+/// reported to stderr but do not abort the run.
+fn load_lineup_file(path: &Path) -> Result<Vec<ValidationModelSpec>, Box<dyn std::error::Error>> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let parsed: RawLineup = toml::from_str(&raw)
+        .map_err(|e| format!("parse {}: {e}", path.display()))?;
+
+    let mut out = Vec::with_capacity(parsed.model.len());
+    for entry in parsed.model {
+        let RawLineupModel { slug, family, path: gguf_path, routing_mode } = entry;
+        let trimmed_path = gguf_path.trim();
+        if trimmed_path.is_empty() {
+            eprintln!(
+                "lineup_config: skipping entry slug={slug}: empty path",
+            );
+            continue;
+        }
+        if !Path::new(trimmed_path).exists() {
+            eprintln!(
+                "lineup_config: skipping entry slug={slug} path={trimmed_path}: file not found",
+            );
+            continue;
+        }
+        let parsed_family = parse_family_slug(&family);
+        if parsed_family.is_none() {
+            eprintln!(
+                "lineup_config: unknown family '{family}' for slug={slug}; leaving family inference to probe",
+            );
+        }
+        let parsed_routing = match routing_mode.as_deref() {
+            Some(value) => {
+                let resolved = parse_routing_mode(value);
+                if resolved.is_none() {
+                    eprintln!(
+                        "lineup_config: unknown routing_mode '{value}' for slug={slug}; using ModelConfig default",
+                    );
+                }
+                resolved
+            }
+            None => None,
+        };
+
+        out.push(ValidationModelSpec {
+            slug,
+            family: parsed_family,
+            path: trimmed_path.to_owned(),
+            routing_mode: parsed_routing,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Parse `LINEUP_CONFIG`. Empty / unset => `None`.
+pub fn lineup_config_path_from_env() -> Option<PathBuf> {
+    std::env::var("LINEUP_CONFIG")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Parse `RUN_TAG`. Empty / unset => `None`. Whitespace-only values are
+/// normalized to `None`.
+pub fn run_tag_from_env() -> Option<String> {
+    std::env::var("RUN_TAG")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+/// Parse `STRICT_REPEAT_CHECK`. Default `false` so existing workflows keep
+/// their current behavior when the env var is unset.
+pub fn strict_repeat_check_from_env() -> bool {
+    env_flag("STRICT_REPEAT_CHECK", false)
 }
 
 /// Resolve `VALIDATION_OUTPUT_ROOT`, falling back to the repo-relative

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -25,6 +25,10 @@ pub struct ValidationModelSpec {
     pub slug: String,
     pub family: Option<ModelFamily>,
     pub path: String,
+    /// Optional per-model routing mode override. Set by lineup-config entries
+    /// (`configs/saaq15_moe_lineup.toml`); autodiscovered / CLI-injected
+    /// specs leave this `None` and fall back to `ModelConfig::routing_mode`.
+    pub routing_mode: Option<RoutingMode>,
 }
 
 pub fn gguf_checkpoint_path_or_default() -> String {
@@ -98,12 +102,32 @@ pub fn prompt_text_for_profile(profile: &str) -> &'static str {
 
 pub fn model_family_override_from_env() -> Option<ModelFamily> {
     let value = std::env::var("MODEL_FAMILY").ok()?;
-    match value.to_ascii_lowercase().as_str() {
+    parse_family_slug(&value)
+}
+
+/// Shared family-slug parser used by `MODEL_FAMILY` and by lineup-config
+/// `family = "..."` entries. Case-insensitive; returns `None` for unknown
+/// slugs so callers can treat that as a soft validation error.
+pub fn parse_family_slug(value: &str) -> Option<ModelFamily> {
+    match value.trim().to_ascii_lowercase().as_str() {
         "olmoe" => Some(ModelFamily::Olmoe),
         "qwen3moe" | "qwen3_moe" | "qwen" => Some(ModelFamily::Qwen3Moe),
         "gemma4" | "gemma_4" | "gemma" => Some(ModelFamily::Gemma4),
         "deepseek2" | "deepseek_v2" | "deepseek" => Some(ModelFamily::DeepSeek2),
         "llama" | "llama_moe" | "llama3_moe" => Some(ModelFamily::LlamaMoe),
+        _ => None,
+    }
+}
+
+/// Same precedence rules as `routing_mode_override_from_env` but reading
+/// from an arbitrary string (used for lineup-config entries). Returns
+/// `None` for unknown values so callers can treat that as a soft validation
+/// error without aborting the whole sweep.
+pub fn parse_routing_mode(value: &str) -> Option<RoutingMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "dense" | "dense_sim" => Some(RoutingMode::DenseSim),
+        "stub" | "stub_uniform" => Some(RoutingMode::StubUniform),
+        "spiking" | "spiking_sim" => Some(RoutingMode::SpikingSim),
         _ => None,
     }
 }
@@ -209,6 +233,7 @@ pub fn discover_validation_models() -> Vec<ValidationModelSpec> {
                 slug: slug_from_path(&path),
                 family,
                 path,
+                routing_mode: None,
             }];
         }
     }
@@ -253,6 +278,7 @@ pub fn discover_validation_models() -> Vec<ValidationModelSpec> {
                 slug: slug.into(),
                 family,
                 path: path.to_string_lossy().into_owned(),
+                routing_mode: None,
             })
         })
         .collect()
@@ -684,7 +710,7 @@ fn env_usize(key: &str, default_value: usize) -> usize {
         .unwrap_or(default_value)
 }
 
-fn env_flag(key: &str, default_value: bool) -> bool {
+pub(super) fn env_flag(key: &str, default_value: bool) -> bool {
     std::env::var(key)
         .ok()
         .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))


### PR DESCRIPTION
## **User description**
Minimal, additive prep for the 5-model SAAQ 1.5 MoE baseline campaign. No architecture refactor, no crate split, no SAAQ math changes, no touching `src/model/`, `src/moe/`, or Grok work.

Four of the five planned commits landed here. **Commit 5 (the `just saaq-campaign` recipe)** was deliberately stopped and is tracked in #25 so this PR stays small and reviewable.

## Commits in this PR

1. `feat(campaign): add configs/saaq15_moe_lineup.toml + toml dev-dep`
2. `feat(campaign): RunConfig support for LINEUP_CONFIG, RUN_TAG, STRICT_REPEAT_CHECK`
3. `feat(campaign): per-run summary.json, run_tag in run_id, per-model routing_mode`
4. `feat(campaign): aggregate artifacts/index.csv writer + strict repeat check`

## What changed

### `configs/saaq15_moe_lineup.toml` (new)

One `[[model]]` entry per checkpoint: OLMoE baseline + Qwen3-MoE + Gemma-4 + DeepSeek-Coder-V2-Lite + Llama-3.2 Dark Champion. Schema is `slug / family / path / routing_mode (optional)`. Paths are machine-local for this first pass by design.

### `Cargo.toml`

`toml = "0.8"` added as a dev-dependency (examples-only). Runtime crate deps unchanged.

### `examples/support/*`

- `ValidationModelSpec` gains `routing_mode: Option<RoutingMode>`; both existing construction sites (`GGUF_CHECKPOINT_PATH` override, autodiscovery) set `None`.
- Shared parsers extracted: `parse_family_slug`, `parse_routing_mode` (reused by lineup entries).
- `env_flag` promoted to `pub(super)` for reuse.
- `RunConfig` gains three additive fields: `lineup_config_path`, `run_tag`, `strict_repeat_check`.
- New `resolve_validation_models()` implements the agreed precedence: **LINEUP_CONFIG → GGUF_CHECKPOINT_PATH → autodiscovery**. A set-but-unparseable LINEUP_CONFIG is a hard panic (never silent fallback).
- `.env.example` gains a `Campaign controls` section documenting the three new variables.

### `examples/saaq_latent_calibration.rs`

- Per-model `routing_mode` from the lineup overrides `ModelConfig::routing_mode`.
- `build_run_id(prompt, repeat_idx, run_tag)` now accepts an optional tag; non-empty tags produce `<timestamp>_<prompt>_r<idx>_<tag>`. `sanitize_run_tag` keeps `[A-Za-z0-9._-]`, collapses `_` runs, and trims leading/trailing underscores.
- `RunContext` gains `run_tag: Option<&str>`.
- `ValidationManifest` gains `run_tag` + `routing_mode` (both `skip_serializing_if None`).
- **Per-run `summary.json`** written alongside `run_manifest.json` at every terminal status (`prompt_embedding_failed`, `gpu_setup_failed`, `tick_failed`, `completed`, plus `preflight`). Fields: run identity, saaq_rule, validation_status, run paths, and a `RunMetrics` block (`ticks_completed`, `latent_rows`, `mean_tick_elapsed_us`, `first_timestamp_ms`, `last_timestamp_ms`).
- **Append-only `artifacts/index.csv`** via an in-memory `PendingIndexRow` buffer. Terminal-status sites push rows; `main()` flushes once at the end with `OpenOptions::create(true).append(true)`, emitting the header only when the file was empty. RFC-4180 escaping for string fields. **No row is ever rewritten.**
- **Strict-repeat check** (opt-in via `STRICT_REPEAT_CHECK=true` when `REPEAT_COUNT>=2`): groups completed rows by `(model_slug, telemetry_source, heartbeat_slug, saaq_rule)` per the adjusted grouping key, byte-compares repeat-0's `latent_telemetry.csv` against each k≥1, stamps `repeat_determinism="matched" | "mismatch"` into both the buffered row (so the CSV carries the verdict) and the on-disk `summary.json` (sole rewrite path). Any mismatch → non-zero exit after the index flush.

### Small refactors (mechanical)

- `build_run_dir` uses the new `heartbeat_slug_for(enabled)` helper.
- `cwd_routing_csv_contaminated` manifest field stays honest (was already correct post-Stage-E; kept for provenance).

## Scope fence (unchanged)

- No edits to `src/model/`, `src/moe/`, `src/latent.rs`, `src/telemetry.rs`, `src/projector.rs`, `src/funnel.rs`, `src/gpu/`.
- No SAAQ math changes.
- No new workspace members / crate extractions.
- Existing `telemetry_bridge`, `csv_replay`, `gpu_smoke_test` binaries unchanged in behavior.

## Preserved defaults

With none of the new env vars set:
- `LINEUP_CONFIG` unset → old autodiscovery path unchanged.
- `RUN_TAG` unset → `run_id` format unchanged (three-part `<timestamp>_<prompt>_r<idx>`).
- `STRICT_REPEAT_CHECK` unset → no byte-compare, no summary rewrites, `repeat_determinism` omitted from JSON / empty in CSV.
- `summary.json` + `artifacts/index.csv` are new but purely additive.

## Verification

- `cargo check --examples` clean (only pre-existing `dead_code` warning on `GgufMetadata::strings`).
- `cargo test --lib` → **51 passed, 2 GPU-only ignored** (same as `main`).
- No end-to-end GPU run executed in this session per user instruction (no artifact pollution).

## Launch note

Once #25 adds the `just saaq-campaign` recipe, the campaign launches as:

> Copy `.env.example` → `.env.local`, set `LINEUP_CONFIG=configs/saaq15_moe_lineup.toml` and (for csv phases) `TELEMETRY_CSV_PATH=/path/to/telemetry.csv`. Then `just saaq-campaign` runs all five MoEs × three phases (synthetic/off, csv/off, csv/on) × two repeats. Artifacts land at `artifacts/<model_slug>/<telemetry_source>/<heartbeat>/<run_id>/` with `run_manifest.json`, `summary.json`, `latent_telemetry.csv`, `tick_telemetry.txt`, `snn_gpu_routing_telemetry.csv`. Aggregate index: `artifacts/index.csv`. Set `STRICT_REPEAT_CHECK=true` to fail fast on determinism drift.

## Follow-ups

- #25 — add `just saaq-campaign` recipe (commit 5).
- Review targets: CodeAnt AI + Codex.

Closes nothing yet; do not squash-merge before #25 is resolved one way or the other.


___

## **CodeAnt-AI Description**
**Add lineup-based campaign runs with run tags, summaries, and repeat checks**

### What Changed
- Runs can now load a full model lineup from `LINEUP_CONFIG`, replacing the old single-path or autodiscovery flow when set
- Each run now writes a `summary.json` alongside the existing manifest, and the output index is built once at the end of the sweep
- `RUN_TAG` is added to run IDs and stamped into run metadata, with unsafe characters normalized before use
- `STRICT_REPEAT_CHECK` can now compare repeat outputs and mark matching or mismatching runs in the saved summaries and index
- Model lineup entries can set a routing mode per model, and the new campaign lineup file lists the five SAAQ 1.5 baseline checkpoints

### Impact
`✅ Easier multi-model campaign setup`
`✅ Clearer run provenance`
`✅ Fewer accidental fallback runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=HuLXKwx_1MhZOMCXL_Agmr6eIkEsQlONYVBWbTE-4Gs&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
