### PR TITLE
docs: align implementation docs and document agent executor tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Thumbs.db
 *.log
 
 # Agent notes
-AGENTS.md
 
 # Local Kilo planning scratch
 .kilo/plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,12 @@ Basic commands:
 
 ```bash
 just setup
-just check
-just test
+cargo check --all-targets --no-default-features
+cargo test --no-default-features
 ```
+
+On CUDA-equipped setups with `nvcc` available, `just check` and `just test`
+exercise the default feature set.
 
 ## Entry Order
 
@@ -169,7 +172,8 @@ just test
 
 - Prefer `git` commands over MCP tools for branch and PR operations in this environment.
 - Keep behavioral changes separate from structural refactors when possible.
-- Run `cargo check`, `cargo test`, and `cargo build --examples` before closing substantial Rust changes.
+- Run `cargo check --no-default-features` and `cargo test --no-default-features` before closing substantial Rust changes.
+- On CUDA-equipped setups with `nvcc` available, also run the default-feature path and `cargo build --examples`.
 
 ## Repository Context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,18 +45,23 @@ Experimental tooling:
 
 - Goose Agent — experimental only. Do not treat it as the default execution
   path.
+- OpenClaw — experimental only. Do not treat it as the default execution path.
 - Blocks — experimental only. Blocks uses the maintainer's ChatGPT Pro
   subscription and should be treated as an optional, non-default path.
 
-Optional third-party integrations:
+Optional third-party integrations and evaluated tooling:
 
 - Google APIs
 - NVIDIA NIM
 - OpenRouter
 - Grok APIs
+- CodeHawk — optional evaluated tooling; currently available via a 30-day free
+  trial.
+- IBM bob — potential evaluated tooling; needs verification before being
+  documented as enabled.
 
-These integrations are optional and should only be referenced at a high level
-in repository docs and examples.
+These integrations and tool references are optional and should only be
+referenced at a high level in repository docs and examples.
 
 Safety and documentation rules for executor tooling:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ Basic commands:
 just setup
 just check
 just test
+```
+
 ## Entry Order
 
 - Start at `src/lib.rs` for the exported crate surface.
@@ -159,9 +161,9 @@ just test
 
 ## Workflow Policy
 
-- All `corinth-canal` work stays in `/home/raulmc/corinth-canal`.
-- Do not create or use additional `corinth-canal` worktrees outside the main repo path.
-- External edits are limited to `/home/raulmc/Julia/Surrogate_Viz.jl` and `/home/raulmc/llama.cpp` unless explicitly requested.
+- All `corinth-canal` work stays in the repository root.
+- Do not create or use additional `corinth-canal` worktrees outside the main repo.
+- External edits are limited to approved research tools and dependencies unless explicitly requested.
 
 ## Git Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,172 @@
+# AGENTS.md
+
+## Project identity
+
+`corinth-canal` is the single-crate reference implementation for the `rmems`
+SNN-logic quantization line.
+
+The core pipeline is:
+
+TelemetrySnapshot
+-> TelemetryEncoder / GPU snapshot projection
+-> ternary spikes
+-> SignedSplitBankBridge or GPU input_spikes
+-> SparseGifHiddenLayer / GPU GIF temporal loop
+-> Projector
+-> OlmoeRouter
+-> routing telemetry / SAAQ latent calibration
+
+This repository is intentionally not split into modular crates yet. Do not
+extract modules into separate crates unless explicitly asked. Proven components
+graduate later according to `docs/PROMOTION_RULES.md` and
+`docs/MODULE_STATUS.md`.
+
+## Agent and executor tooling
+
+Primary executor for this repository:
+
+- Codex is the primary executor for repository tasks and follow-up
+  implementation work.
+
+Memory-agent backbone:
+
+- Hermes Agents and GitHub Copilot are approved at a high level as part of the
+  memory-agent backbone for planning, recall, review support, and follow-up
+  execution assistance.
+
+Approved fallback executors:
+
+- Opencode — backup executor path, including free-API usage scenarios.
+- Kilo — fallback executor for repository tasks.
+- Cline — fallback executor for repository tasks.
+- Gemini CLI — occasional fallback for large-context tasks.
+
+Experimental tooling:
+
+- Goose Agent — experimental only. Do not treat it as the default execution
+  path.
+- Blocks — experimental only. Blocks uses the maintainer's ChatGPT Pro
+  subscription and should be treated as an optional, non-default path.
+
+Optional third-party integrations:
+
+- Google APIs
+- NVIDIA NIM
+- OpenRouter
+- Grok APIs
+
+These integrations are optional and should only be referenced at a high level
+in repository docs and examples.
+
+Safety and documentation rules for executor tooling:
+
+- Do not commit or document secrets, tokens, DSNs, API keys, private telemetry,
+  or local absolute paths.
+- Do not assume optional third-party APIs are configured.
+- Local/offline behavior must remain safe when optional external integrations
+  are unset.
+- Documentation changes about agent tooling should stay high level and should
+  not publish machine-specific setup details unless explicitly requested.
+- Keep executor/tooling documentation limited to markdown and closely related
+  repo docs unless a task explicitly asks for implementation work.
+
+## Non-negotiable rules
+
+- Keep this as a single Rust crate unless the task explicitly says otherwise.
+- Do not delete or bypass the SNN/GIF/SAAQ routing logic.
+- Do not replace real GGUF-backed routing with stubs except in tests or explicit
+  fallback paths.
+- Do not introduce machine-local absolute paths such as `/home/...` into `src/`.
+- Do not hardcode checkpoint paths, telemetry CSV paths, CUDA paths, or artifact
+  output paths.
+- Do not add new dependencies unless they are clearly justified.
+- Preserve CPU-only buildability.
+- Preserve CUDA/GPU behavior when touching GPU code.
+- Keep diffs small and reviewable.
+- Add or update tests when behavior changes.
+- Do not change CSV schemas unless explicitly instructed.
+- Do not silently change public APIs exported from `src/lib.rs`.
+- Do not touch generated artifacts unless the task is specifically about run
+  manifests, validation outputs, or known-good run logs.
+
+## Repository structure
+
+Important paths:
+
+- `src/model/core.rs`
+  - Runtime orchestration, config validation, forward paths.
+- `src/model/temporal.rs`
+  - GPU temporal loop:
+    `prepare_gpu_temporal`, `tick_gpu_temporal`, `forward_gpu_temporal`.
+- `src/model/telemetry_io.rs`
+  - Routing telemetry CSV helpers.
+- `src/moe/checkpoint.rs`
+  - GGUF parsing, mmap access, tensor slicing, metadata.
+- `src/moe/adapter.rs`
+  - Model-family adapter resolution.
+- `src/moe/routing.rs`
+  - Router math, gate scores, expert selection.
+- `src/projector.rs`
+  - Spike-to-embedding projection.
+- `src/funnel.rs`
+  - Telemetry funnel and GIF hidden layer.
+- `src/telemetry.rs`
+  - `TelemetryEncoder` and `TelemetrySnapshot`.
+- `src/latent.rs`
+  - SAAQ latent calibration and CSV export.
+- `src/gpu/`
+  - CUDA/cust wrapper layer and GPU kernels.
+- `src/gpu/kernels/`
+  - CUDA `.cu` / `.cuh` sources.
+- `examples/support/config.rs`
+  - Environment/config resolution for examples.
+- `examples/support/observability.rs`
+  - Shared tracing/Sentry wrapper for example binaries.
+- `docs/ARCHITECTURE.md`
+  - Architecture, hidden control flow, path behavior.
+- `docs/RUN_PROFILES.md`
+  - Validated run profiles.
+- `docs/PROMOTION_RULES.md`
+  - Rules for graduating modules into `rmems-*` crates.
+- `docs/MODULE_STATUS.md`
+  - Current status of each module.
+- `manifests/proven_components.toml`
+  - Machine-readable promotion status.
+- `manifests/known_good_runs.md`
+  - Blessed run ID log.
+
+## Build and validation commands
+
+Prefer the checked-in `justfile` recipes.
+
+Basic commands:
+
+```bash
+just setup
+just check
+just test
+## Entry Order
+
+- Start at `src/lib.rs` for the exported crate surface.
+- Read `src/model/mod.rs` before descending into `core.rs` and `temporal.rs`.
+- Read `src/moe/mod.rs` before descending into `adapter.rs`, `checkpoint.rs`, and `routing.rs`.
+- Use `examples/saaq_latent_calibration.rs` as the research loop entrypoint.
+
+## Workflow Policy
+
+- All `corinth-canal` work stays in `/home/raulmc/corinth-canal`.
+- Do not create or use additional `corinth-canal` worktrees outside the main repo path.
+- External edits are limited to `/home/raulmc/Julia/Surrogate_Viz.jl` and `/home/raulmc/llama.cpp` unless explicitly requested.
+
+## Git Workflow
+
+- Prefer `git` commands over MCP tools for branch and PR operations in this environment.
+- Keep behavioral changes separate from structural refactors when possible.
+- Run `cargo check`, `cargo test`, and `cargo build --examples` before closing substantial Rust changes.
+
+## Repository Context
+
+- **Repo**: `rmems/corinth-canal`
+- **Main branch**: `main`
+- **Language**: Rust (edition 2024)
+- **Key concepts**: SNN-LLM hybrid, GGUF checkpoints, MoE routing, GPU temporal simulation, SAAQ validation

--- a/README.md
+++ b/README.md
@@ -1,554 +1,158 @@
 # corinth-canal
 
-SNN-logic quantization repo focused on the spiking projector and OlmoeRouter routing path.
+Single-crate reference implementation of the `rmems` SNN-logic quantization
+bridge.
 
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE)
 
 ## Overview
 
-`corinth-canal` keeps the real projector and first-block OlmoeRouter routing bridge, while the old telemetry/SNN front-end is replaced by a deterministic in-repo spike generator. That keeps the crate self-contained and runnable from a fresh clone while still supporting a real GGUF-backed path.
+`corinth-canal` keeps the telemetry encoder, spiking hidden layer, projector,
+GGUF-backed routing bridge, and SAAQ validation loop in one repository so the
+full research path can be exercised end to end.
 
-## Origin
-
-This repository originated from the `spikenaut-hybrid` codebase and is now organized around feature modules: `src/model`, `src/moe`, `src/projector.rs`, `src/funnel.rs`, `src/telemetry.rs`, and `src/latent.rs`.
-
-Going forward, `corinth-canal` is the **single-crate reference implementation** for the `rmems` modular line. Proven components will graduate into separate `rmems-*` crates per `docs/PROMOTION_RULES.md`; `corinth-canal` itself stays as one crate.
-
-## SAAQ 1.5 Experiment MoE Lineup
-
-The following models are used in the SAAQ 1.5 baseline campaign:
-
-- `OMLoE-1B-7B.gguf` (baseline)
-- `L3.2-8X3B-MOE-Dark-Champion-Inst-18.4B-uncen-ablit_D_AU-q5_k_m.gguf`
-- `qwen3-moe-i1-IQ3_M.gguf`
-- `gemma-4-26B-A4B-it-UD-IQ4_NL.gguf`
-- `DeepSeek-Coder-V2-Lite-Instruct-Q6_K_L.gguf`
-
-## Documentation
-
-- `docs/ARCHITECTURE.md` — block diagram, module map, and hidden control flow (CWD writes, env-resolved paths, fallback stamping).
-- `docs/RUN_PROFILES.md` — catalog of validated `(prompt, telemetry, heartbeat, SAAQ rule)` tuples with the exact `just` command for each.
-- `docs/PROMOTION_RULES.md` — criteria for graduating a module out of this reference repo.
-- `docs/MODULE_STATUS.md` — live status table; machine-readable mirror in `manifests/proven_components.toml`.
-- `manifests/known_good_runs.md` — append-only log of blessed run IDs.
-
-## Observability
-
-The example binaries ship with a shared observability wrapper for command-level
-telemetry and failure triage. This layer is intentionally optional:
-
-- If `SENTRY_DSN` is unset or blank, examples stay fully local/offline.
-- No Sentry client is initialized in `src/lib.rs`, so downstream library
-  consumers do not inherit global error-reporting behavior.
-- Every example emits `command_start` and `command_finish` tracing events with
-  `repo`, `command`, `run_id`, `git_sha`, `latency_ms`, `success`, and
-  `error_category`.
-- Sentry, when enabled, only receives safe diagnostic tags such as `repo`,
-  `command`, `git_sha`, `model_slug`, `telemetry_source`,
-  `heartbeat_enabled`, `validation_status`, and `error_category`.
-
-The wrappers do not attach absolute checkpoint paths to Sentry scope or
-breadcrumbs. Machine-local config examples belong in `.env.local` or in
-uncommitted copies of the lineup templates under `configs/`.
-
-## Module Map
-
-- `src/model/*`: end-to-end runtime orchestration, GPU temporal logic, and routing telemetry helpers
-- `src/moe/*`: GGUF checkpoint parsing, router math, and token embedding extraction
-- `src/projector.rs`: spike-to-embedding projection and `ProjectionMode`
-- `src/funnel.rs`: telemetry funnel and GIF hidden layer
-- `src/telemetry.rs`: `TelemetryEncoder` plus `TelemetrySnapshot` re-export
-- `src/latent.rs`: latent calibration snapshots and CSV export
-- `examples/support/mod.rs`: shared example bootstrap helpers
-
-## Migration Note
-
-Core runtime imports now come from feature modules instead of flat crate-root exports:
-
-```rust
-use corinth_canal::model::{Model, ModelConfig};
-use corinth_canal::moe::RoutingMode;
-use corinth_canal::projector::ProjectionMode;
-use corinth_canal::telemetry::TelemetrySnapshot;
-```
-
-## Architecture
-
-### CPU Fallback + GPU GIF Path
+The current runtime flow is:
 
 ```text
 TelemetrySnapshot
        |
-       v  TelemetryEncoder (delta modulation) / project_snapshot_current (GPU)
-[i8; 4] ternary spikes (+1/0/-1)
+       v  TelemetryEncoder (CPU) / project_snapshot_current (GPU)
+ternary telemetry events (+1 / 0 / -1)
        |
-       v  SignedSplitBankBridge or GPU input_spikes
-2048 input neurons
+       v  SignedSplitBankBridge (CPU) / GPU input_spikes
+input spike train
        |
-       v  SparseGifHiddenLayer (CPU) or gif_step_weighted (GPU with adaptation)
-2048 GIF hidden neurons with adaptive thresholds + history-aware SAAQ
+       v  SparseGifHiddenLayer (CPU) / gif_step_weighted_tick (GPU)
+hidden spike train + membrane state
        |
-       v  Projector (SpikingTernary GIF mode for 2048-neuron input)
-dense embedding [2048]
+       v  Projector
+embedding [2048]
        |
-       v  OlmoeRouter (stub/dense/spiking sim) with GGUF-backed first-block routing
-expert_weights + selected_experts + hidden + spike_count telemetry
+       v  OlmoeRouter
+expert_weights + selected_experts + routed hidden state
+       |
+       v  SAAQ latent calibration / telemetry export
 ```
 
-### GPU Acceleration (NVIDIA Blackwell sm_120+ with GIF)
+## Scope
 
-When a compatible GPU is detected, the crate offloads the 2048-neuron GIF SNN to CUDA via `GpuAccelerator` (temporal tick loop with `gif_step_weighted` / `gif_step_weighted_f16`, adaptation buffer, dynamic thresholds). The temporal path now supports a GGUF-backed first-layer synapse upload: `blk.0.attn_q.weight` is memory-mapped, host-registered with CUDA, uploaded once as FP16, and then reused across forwards. The SAAQ winner selection now runs as a race-free two-pass on-device reduction: pass 1 emits one winner per block, pass 2 reduces those 8 partials to a single best walker before the 4-byte result is copied back to Rust.
+This repository is intentionally kept as a single crate. Proven components are
+expected to graduate later into `rmems-*` crates according to
+`docs/PROMOTION_RULES.md`, but `corinth-canal` itself remains the reference repo
+for the full end-to-end loop.
+
+## Implementation highlights
+
+### Custom GGUF-backed routing bridge
+
+The model-loading interface is custom to this repository.
+
+`OlmoeRouter`:
+
+- parses GGUF checkpoints in-repo
+- resolves a supported model family from checkpoint metadata
+- extracts routing tensors and token embeddings
+- selects a GPU synapse source from one of:
+  - real `F16`
+  - dequantized `Q8_0`
+  - dequantized `Q5_K`
+  - synthetic fallback
+
+Supported families in code:
+
+- `Olmoe`
+- `Qwen3Moe`
+- `Gemma4`
+- `DeepSeek2`
+- `LlamaMoe`
+
+### Projection modes
+
+- `RateSum`
+- `TemporalHistogram`
+- `MembraneSnapshot`
+- `SpikingTernary`
+
+### Routing modes
+
+- `StubUniform`
+- `DenseSim`
+- `SpikingSim`
+
+### Telemetry / heartbeat
+
+`TelemetrySnapshot` carries:
+
+- `gpu_temp_c`
+- `gpu_power_w`
+- `cpu_tctl_c`
+- `cpu_package_power_w`
+- `heartbeat_signal`
+- `heartbeat_enabled`
+- `timestamp_ms`
+
+### SAAQ calibration
+
+The validation path uses `SnnDualLatentCalibrator`, which emits both the legacy
+and v1.5 SAAQ trajectories in latent telemetry output while preserving legacy
+compatibility columns.
+
+## Primary docs
+
+- `docs/ARCHITECTURE.md` — runtime architecture, module map, hidden control flow
+- `docs/RUN_PROFILES.md` — validated commands and per-run outputs
+- `docs/PROMOTION_RULES.md` — module promotion rules
+- `docs/MODULE_STATUS.md` — current module stability/promotion status
+- `manifests/proven_components.toml` — machine-readable module status mirror
+
+## Main entrypoints
+
+- `examples/saaq_latent_calibration.rs` — primary research / validation loop
+- `examples/gpu_smoke_test.rs` — GPU temporal smoke validation
+- `examples/csv_replay.rs` — canonical telemetry CSV replay
+- `examples/telemetry_bridge.rs` — routing demonstration
+
+## Validation outputs
+
+The validation runner writes per-run artifacts including:
+
+- `tick_telemetry.txt`
+- `latent_telemetry.csv`
+- `run_manifest.json`
+- `summary.json`
+- `snn_gpu_routing_telemetry.csv`
+
+GPU routing telemetry CSV schema:
 
 ```text
-TelemetrySnapshot
-       |
-       v  project_snapshot_current (to input_current)
-       |
-       v  mmap GGUF tensor + cuMemHostRegister_v2 + resident synapse upload
-       |
-       v  gif_step_weighted_tick loop (adaptation decay, adaptive threshold = base + scale*adaptation, weighted synapses, refractory)
-       |
-       v  two-pass SAAQ reduction (block partials -> final best walker)
-       |
-       v  temporal_*_to_vec (membrane, adaptation, spikes)
-       |
-       v  forward_activity + Projector (GIF mode) + OlmoeRouter routing + SAAQ/sparsity CSV (spike_count, mean_adaptation, active_fraction)
+token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
 ```
-
-## GGUF First-Block Bridge
-
-The current OlmoeRouter integration is intentionally scoped to a first-block bridge:
-
-- `blk.0.ffn_gate_inp.weight` is used as the real routing matrix for `DenseSim` and `SpikingSim`
-- `blk.0.attn_q.weight` is the default recurrent synapse matrix for `forward_gpu_temporal`
-- the GGUF file is memory-mapped and the GPU synapse slice is registered with CUDA via `cuMemHostRegister_v2`
-- the temporal GPU path reuses resident device weights across forwards instead of rebuilding dummy weights
-
-This phase does not implement the full expert MLP block. Hidden outputs remain a route-weighted passthrough of the projector embedding so the repo can exercise real routing without pretending to be a full multi-layer OlmoeRouter runtime.
 
 ## Quick start
 
-```rust
-use corinth_canal::{
-    FUNNEL_HIDDEN_NEURONS,
-    funnel::TelemetryFunnel,
-    model::{Model, ModelConfig},
-    telemetry::TelemetrySnapshot,
-};
-
-// Configure the telemetry funnel
-let thresholds = [1.0, 5.0, 1.0, 5.0];
-let snn_steps = 20;
-let mut funnel = TelemetryFunnel::new(thresholds, snn_steps);
-
-// Create a telemetry snapshot
-let snap = TelemetrySnapshot {
-    gpu_temp_c: 60.0,
-    gpu_power_w: 260.0,
-    cpu_tctl_c: 77.0,
-    cpu_package_power_w: 153.0,
-    timestamp_ms: 0,
-};
-
-// Run the full funnel: encoder -> bridge -> 512-neuron GIF hidden layer
-let activity = funnel.encode_snapshot(&snap);
-
-// Or use the complete hybrid pipeline
-let cfg = ModelConfig::default();
-let mut model = Model::new_with_projector_neurons(cfg, FUNNEL_HIDDEN_NEURONS)?;
-let output = model.forward_activity(
-    &activity.spike_train,
-    &activity.potentials,
-    &activity.iz_potentials,
-)?;
-
-println!("Selected experts: {:?}", output.selected_experts);
-```
-
-To point the model at a real GGUF checkpoint while keeping the default GPU synapse tensor:
-
-```rust
-use corinth_canal::model::{Model, ModelConfig};
-
-let cfg = ModelConfig {
-    gguf_checkpoint_path: "/models/olmoe.gguf".into(),
-    gpu_synapse_tensor_name: "blk.0.attn_q.weight".into(),
-    ..Default::default()
-};
-
-let mut model = Model::new(cfg)?;
-```
-
-## TelemetryEncoder
-
-The `TelemetryEncoder` converts continuous telemetry values into ternary spike vectors using delta modulation. This bridges raw telemetry data into the spiking projection path.
-
-### Delta modulation
-
-For each telemetry channel (GPU temp, GPU power, CPU temp, CPU power), the encoder:
-
-- Stores a baseline value (seeded from the first sample)
-- Compares each new value to its baseline
-- Emits `+1` if the change exceeds the positive threshold
-- Emits `-1` if the change exceeds the negative threshold
-- Emits `0` otherwise
-- Updates the baseline only when a spike fires
-
-### Usage
-
-```rust
-use corinth_canal::{telemetry::TelemetryEncoder, telemetry::TelemetrySnapshot};
-
-// Configure thresholds: [temp, power, temp, power]
-let thresholds = [1.0, 5.0, 1.0, 5.0];
-let mut encoder = TelemetryEncoder::new(thresholds);
-
-let snap = TelemetrySnapshot {
-    gpu_temp_c: 60.0,
-    gpu_power_w: 260.0,
-    cpu_tctl_c: 77.0,
-    cpu_package_power_w: 153.0,
-    timestamp_ms: 0,
-};
-
-// First call seeds the baseline, returns [0, 0, 0, 0]
-let spikes = encoder.encode(&snap);
-
-// Subsequent calls emit spikes based on delta
-let spikes = encoder.encode(&snap);
-```
-
-## TelemetryFunnel
-
-The `TelemetryFunnel` orchestrates the full spiking pipeline from raw telemetry to hidden-layer activity ready for projection.
-
-### Architecture
-
-```
-TelemetrySnapshot
-       |
-       v  TelemetryEncoder (delta modulation)
-[i8; 4] ternary spikes
-       |
-       v  SignedSplitBankBridge
-16 input neurons (4 channels × 2 polarities × 2 neurons)
-       |
-       v  SparseGifHiddenLayer
-2048 GIF neurons with adaptive thresholds (sparse 16→2048 weights)
-       |
-       v  FunnelActivity
-spike_train + potentials + iz_potentials
-```
-
-### Components
-
-| Component | Description |
-|-----------|-------------|
-| `SignedSplitBankBridge` | Expands 4-channel ternary spikes into 16 input neurons using signed split banks (positive/negative pairs per channel) |
-| `SparseGifHiddenLayer` | Pure-Rust Generalized Integrate-and-Fire (GIF) layer with adaptive thresholds. Uses sparse 4-edge connectivity per hidden neuron for fast inference |
-| `FunnelActivity` / `ModelOutput` | Output struct containing the 2048-neuron GIF spike train, membrane potentials, adaptation stats, and Izhikevich potentials. Extended with spike_count telemetry for SAAQ. |
-
-### GIF neuron parameters (synced in GPU kernel, funnel.rs, projector.rs)
-
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| `leak` | 0.92 | Membrane leak factor (GIF_LEAK) |
-| `threshold_base` | 0.65 | Base firing threshold (GIF_THRESHOLD_BASE) |
-| `adaptation_scale` | 0.22 | Adaptive threshold scaling (GIF_ADAPTATION_SCALE) |
-| `adaptation_decay` | 0.94 | Adaptation variable decay (GIF_ADAPTATION_DECAY) |
-| `reset_ratio` | 0.35 | Post-spike membrane reset (GIF_RESET_RATIO) |
-| `drive_scale` | 0.75 | Input drive scaling |
-
-### Usage with GIF GPU Path
-
-```rust
-use corinth_canal::{
-    gpu::GpuAccelerator,
-    model::{Model, ModelConfig},
-    telemetry::TelemetrySnapshot,
-};
-
-let mut model = Model::new(ModelConfig::default()).unwrap();
-let mut accelerator = GpuAccelerator::new();  // falls back gracefully
-let output = model.forward_gpu_temporal(&mut accelerator, &TelemetrySnapshot::default()).unwrap();
-
-// GIF adaptation drives sparsity pruning; CSV now logs spike_count, mean_adaptation, active_fraction for VRAM optimization and Julia symbolic regression
-```
-
-## GPU Smoke Test
-
-To validate the actual Blackwell temporal path on hardware, use the dedicated smoke test:
+### Check the repo
 
 ```bash
-GGUF_CHECKPOINT_PATH=/path/to/gguf cargo run --release --example gpu_smoke_test
+just setup
+just check
+just test
 ```
 
-This example exercises:
-
-- GGUF mmap plus `cuMemHostRegister_v2` host registration for `blk.0.attn_q.weight`
-- resident FP16 synapse upload into the GPU temporal state
-- `gif_step_weighted_f16`
-- the two-pass SAAQ reduction returning `best_walker`
-- per-tick timing output in microseconds
-
-This is the correct example for validating the real GPU temporal path. `saaq_latent_calibration` is CPU-side calibration logic and does not exercise the direct GPU temporal loop.
-
-## OlmoeRouter Modes
-
-| Mode | Behavior |
-|------|----------|
-| `StubUniform` | No checkpoint required. Returns uniform expert weights and zero hidden output |
-| `DenseSim` | Uses the real GGUF first-block routing tensor when a model path is provided |
-| `SpikingSim` | Uses the same real routing tensor but integrates expert and hidden membrane state over time |
-
-## Run example
+### Run the primary validation loop
 
 ```bash
-cargo run --example telemetry_bridge
+just saaq
 ```
 
-With a real GGUF checkpoint:
+### Run the GPU smoke path with a real checkpoint
 
 ```bash
-GGUF_CHECKPOINT_PATH=/models/olmoe.gguf \
-  cargo run --example telemetry_bridge --release
+GGUF_CHECKPOINT_PATH=/path/to/model.gguf just smoke
 ```
 
-## CSV Replay Contract
-
-`corinth-canal` consumes canonical CSV exported by `gaming-telemetry`:
-
-`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`
-
-Producer/consumer flow:
-
-`collector -> gpu_telemetry_v1_batch_N.parquet -> export_csv -> csv_replay`
-
-Replay command:
-
-```bash
-cargo run --example csv_replay /path/to/canonical.csv
-```
-
-`csv_replay` validates the header strictly, counts malformed rows, and prints:
-- `rows_processed`
-- `rows_skipped`
-- `global_step`
-- `router_loaded`
-
-## Latent Telemetry Calibration
-
-The crate provides a separate calibration path for driving the GPU temporal SNN logic with real context embeddings. This ensures the MoE gating and temporal threshold adaptation are tested against actual semantic distributions rather than uniform noise.
-
-### Direct Token Embedding Extraction
-
-Rather than bringing in a heavy text tokenizer dependency, the `saaq_latent_calibration` example bypasses text parsing entirely:
-
-1. It memory-maps the `token_embd.weight` tensor from the provided OlmoeRouter GGUF checkpoint.
-2. It extracts the raw 2048-dimensional embedding rows for a hard-coded sequence of token IDs (representing the prompt: *"Let's teach this MoE model the language of SNN"*).
-3. It mean-pools these tokens into a single `[f32; 2048]` context vector.
-4. It feeds this single context vector continuously into the direct GPU temporal loop (`tick_gpu_temporal`) for 10,000 ticks.
-
-### Calibration Runner
-
-Run the calibration test by pointing it to your local OlmoeRouter checkpoint:
-
-```bash
-GGUF_CHECKPOINT_PATH=/path/to/olmoe.gguf cargo run --example saaq_latent_calibration --release
-```
-
-The runner will output the per-tick performance and the winning SAAQ walker ID selected by the on-device reduction:
-
-```text
-tick=1 best_walker=12 elapsed_us=850
-tick=2 best_walker=45 elapsed_us=842
-...
-```
-
-This path exercises the pure SNN physics engine (GIF membrane + adaptive thresholds + two-pass SAT reduction) driven by realistic, pooled semantic pressure.
-
-### Validation Sweeps (dual-SAAQ, CSV-replay, repeat-aware)
-
-The `saaq_latent_calibration` runner is a sweep orchestrator over every discovered GGUF model. Per-run artifacts land under a fully-labeled directory tree:
-
-```text
-<VALIDATION_OUTPUT_ROOT>/<model_slug>/<telemetry_source>/<heartbeat_slug>/<run_id>/
-    tick_telemetry.txt
-    latent_telemetry.csv
-    run_manifest.json
-    summary.json
-```
-
-where `<run_id>` = `<YYYYMMDDTHHMMSS>_<prompt_slug>_r<repeat_idx>` (UTC, sortable).
-
-#### Environment knobs
-
-| Env | Default | Purpose |
-|-----|---------|---------|
-| `TELEMETRY_SOURCE` | `synthetic` | `synthetic` runs the in-process sinusoid; `csv` replays a canonical telemetry CSV. Must be set explicitly to `csv` for real-corpus runs — defaults are dependency-light on purpose. |
-| `TELEMETRY_CSV_PATH` | _(unset)_ | Canonical-format CSV (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`). Required when `TELEMETRY_SOURCE=csv`. Missing/malformed → fallback to synthetic, stamped `synthetic_fallback` in the manifest. |
-| `TICKS` | `512` | Per-run tick count. Special case: when `TICKS=0` *and* `TELEMETRY_SOURCE=csv`, uses the exact CSV row count so a SymbolicRegression.jl corpus run covers exactly one loop with zero wraparound contamination. |
-| `REPEAT_COUNT` | `1` | Number of repeats per (model, telemetry, heartbeat) tuple. Deterministic inputs mean repeats should bit-match — divergence indicates scheduler noise. |
-| `VALIDATION_OUTPUT_ROOT` | `./artifacts` | Top of the per-run output tree. Repo-relative by default; set to an absolute path to redirect runs into an external consumer. |
-| `HEARTBEAT_MATRIX` | `off,on` | Kept as-is for this round; amplitude/period sweep is future work. |
-| `SAAQ_RULE` | `saaq_v1_5` | Selects which rule fills the legacy `saaq_delta_q_{prev,target}` columns. Both rules are always emitted in the dual-SAAQ columns regardless. |
-| `LINEUP_CONFIG` | _(unset)_ | Optional path to a TOML file (e.g. `configs/saaq15_moe_lineup.toml`) specifying a lineup of GGUF checkpoints to sweep. Takes precedence over `GGUF_CHECKPOINT_PATH` and autodiscovery. |
-| `RUN_TAG` | _(unset)_ | Optional tag to append to the generated `run_id` (e.g. producing `YYYYMMDDTHHMMSS_prompt_r0_tag`). |
-| `STRICT_REPEAT_CHECK` | `false` | When true, strict bit-for-bit CSV comparison is performed across all repeats in a group. Mismatches are flagged in `summary.json`. |
-
-#### Wraparound hygiene
-
-For `TELEMETRY_SOURCE=csv`, if `TICKS > rows.len()` the runner emits a warning:
-
-```text
-wraparound: ticks={N} > rows={M}; regression corpus may be contaminated by looped endings. Prefer TICKS=0 or TICKS<={M}.
-```
-
-The manifest records `wraparound_enabled`, `wraparound_loops`, and `ticks_effective` so any downstream filter can reject contaminated traces with one predicate. **For SymbolicRegression.jl corpus generation, always use `TICKS=0` (or `TICKS ≤ CSV row count`).** Wraparound is intended for smoke tests only.
-
-#### Dual-SAAQ CSV schema
-
-`latent_telemetry.csv` preserves the original 12 columns for backward compatibility with existing SR.jl scripts, and appends 4 new columns so both SAAQ rules can be fitted without rerunning:
-
-```text
-timestamp_ms, avg_pop_firing_rate_hz, membrane_dv_dt, routing_entropy,
-saaq_delta_q_prev, saaq_delta_q_target,           # primary rule (selected via SAAQ_RULE)
-heartbeat_signal, heartbeat_enabled,
-gpu_temp_c, gpu_power_w, cpu_tctl_c, cpu_package_power_w,
-saaq_delta_q_legacy_prev, saaq_delta_q_legacy_target,   # SAAQ 1.0 trajectory
-saaq_delta_q_v15_prev, saaq_delta_q_v15_target          # SAAQ 1.5 trajectory
-```
-
-The feature columns fed to SR.jl (`avg_pop_firing_rate_hz`, `membrane_dv_dt`, `routing_entropy`) are computed from activity/routing only and are therefore identical across rules — this makes dual-emission paired data for free. See `SnnDualLatentCalibrator` in `src/latent.rs`.
-
-#### Recipes
-
-Synthetic smoke (no CSV dependency, fast wiring check):
-
-```bash
-TICKS=64 HEARTBEAT_MATRIX=off \
-  cargo run --release --example saaq_latent_calibration
-```
-
-Stage-0 campaign entrypoint (three-phase recipe over the checked-in lineup):
-
-```bash
-just saaq-campaign
-```
-
-`just saaq-campaign` runs three phases back-to-back, each with `REPEAT_COUNT=2` and `SAAQ_RULE=saaq_v1_5`:
-
-1. `TELEMETRY_SOURCE=synthetic`, `HEARTBEAT_MATRIX=off`, `RUN_TAG=campaign_syn_off`
-2. `TELEMETRY_SOURCE=csv`, `HEARTBEAT_MATRIX=off`, `RUN_TAG=campaign_csv_off`
-3. `TELEMETRY_SOURCE=csv`, `HEARTBEAT_MATRIX=on`, `RUN_TAG=campaign_csv_on`
-
-Set `LINEUP_CONFIG` in `.env.local` to override the default lineup (`configs/saaq15_moe_lineup.toml`). Phases 2 and 3 require `TELEMETRY_CSV_PATH` to point at a canonical telemetry CSV. With the default 5-model lineup the campaign appends `5 × 3 × 2 = 30` rows to `artifacts/index.csv`. Set `STRICT_REPEAT_CHECK=true` to fail fast on any repeat-0 vs repeat-k `latent_telemetry.csv` divergence.
-
-RE4 corpus run (exact CSV length, zero wraparound):
-
-```bash
-TELEMETRY_SOURCE=csv TICKS=0 REPEAT_COUNT=1 HEARTBEAT_MATRIX=off \
-  cargo run --release --example saaq_latent_calibration
-```
-
-Repeatability check (3 runs per model per heartbeat, deterministic inputs):
-
-```bash
-TELEMETRY_SOURCE=csv TICKS=0 REPEAT_COUNT=3 \
-  cargo run --release --example saaq_latent_calibration
-```
-
-#### CWD routing-CSV caveat
-
-`snn_gpu_routing_telemetry.csv` is hardcoded to the current working directory by `forward_gpu_temporal` / `compute_routing_telemetry` (see `src/model/core.rs`). `saaq_latent_calibration` drives the GPU via `tick_gpu_temporal`, which does **not** write that file, so it is safe today. If a future change starts invoking `forward_gpu_temporal` from the validation runner, every model's writes will silently merge into the same CWD-scoped file — move the sink into the per-run directory before doing that.
-
-## GPU Routing Telemetry
-
-For high-performance expert routing analysis, the crate utilizes the NVIDIA Blackwell (RTX 5080) GPU to perform two-pass SAT reductions directly in VRAM. This telemetry path captures the final winning scores and walkers for every token processed.
-
-### GPU Routing Snapshot
-
-| Field | Description |
-|-------|-------------|
-| `token_idx` | Sequential index of the processed token |
-| `best_score` | Final optimized SAT score from the second-pass reduction |
-| `best_walker` | ID of the winning walker that achieved the best score |
-
-### Mechanism: Two-Pass Reduction
-
-Unlike the latent calibration path which runs on the CPU, the routing telemetry is powered by the `GpuAccelerator`:
-
-1.  **SAT Extraction**: `satsolver_extract` prepares the initial state in VRAM.
-2.  **Best-Reduction**: `satsolver_aux_reduce_best` performs a massively parallel reduction across the GPU grid to find the global optimum.
-3.  **8-Byte Transfer**: Only the final `best_score` and `best_walker` (8 bytes total) are transferred back to the CPU for logging.
-
-### Output
-
-Rows are appended to `snn_gpu_routing_telemetry.csv` with the header:
-
-```text
-token_idx,best_score,best_walker
-```
-
-This file is created automatically on the first call to `compute_routing_telemetry` and grows sequentially as more tokens are processed.
-
-## Project Layout
-
-| Path | Responsibility |
-|------|----------------|
-| `Cargo.toml` | crate config and dependencies |
-| `src/lib.rs` | public API and crate docs |
-| `src/types.rs` | shared scalar types and metadata structs |
-| `src/error.rs` | `HybridError`, `Result` |
-| `src/telemetry.rs` | `TelemetryEncoder` and `TelemetrySnapshot` |
-| `src/projector.rs` | 2-bit spiking projector logic |
-| `src/moe/mod.rs` | public MoE router shell |
-| `src/moe/checkpoint.rs` | GGUF parsing and mapped tensor access |
-| `src/moe/routing.rs` | routing math and expert selection |
-| `src/funnel.rs` | TelemetryFunnel: encoder + split-bank bridge + sparse GIF hidden layer |
-| `src/model/mod.rs` | public runtime shell and re-exports |
-| `src/model/core.rs` | deterministic front-end + projector + OlmoeRouter orchestration |
-| `src/model/temporal.rs` | GPU temporal tick orchestration |
-| `src/model/telemetry_io.rs` | routing telemetry CSV helpers |
-| `src/latent.rs` | `SnnLatentSnapshot`, `SnnLatentCalibrator`, `SnnLatentCsvExporter` for symbolic regression |
-| `src/gpu/mod.rs` | GPU accelerator public API and module switchboard |
-| `src/gpu/kernels/` | CUDA kernels (`.cu`, `.cuh`) for GPU-accelerated tasks |
-| `src/gpu/wrappers/` | Safe Rust wrappers for CUDA context, memory, and kernel launches |
-| `build.rs` | Build script to compile CUDA kernels to PTX |
-| `examples/support/mod.rs` | shared example bootstrap and prompt helpers |
-| `examples/telemetry_bridge.rs` | end-to-end standalone example |
-| `examples/csv_replay.rs` | canonical CSV replay adapter (funnel-driven) |
-| `examples/saaq_latent_calibration.rs` | calibration-only latent telemetry exporter |
-
-## Acknowledgments
-
-This work builds directly on prior research in spiking and spike-driven LLMs.
-
-- Xing et al. (2024), *SpikeLLM: Scaling up Spiking Neural Network to Large Language Models via Saliency-based Spiking*.
-  - arXiv: [2407.04752](https://arxiv.org/abs/2407.04752)
-  - DOI: [10.48550/arXiv.2407.04752](https://doi.org/10.48550/arXiv.2407.04752)
-- Xu et al. (2025), *Neuromorphic spike-based large language model* (`NSLLM`).
-  - Journal page: [National Science Review](https://academic.oup.com/nsr/advance-article/doi/10.1093/nsr/nwaf551/8365570)
-  - DOI: [10.1093/nsr/nwaf551](https://doi.org/10.1093/nsr/nwaf551)
-- Qiu et al. (2025), *Quantized Spike-driven Transformer* (`QSD-Transformer`).
-  - ICLR poster: [OpenReview / ICLR 2025](https://iclr.cc/virtual/2025/poster/30954)
-  - arXiv: [2501.13492](https://arxiv.org/abs/2501.13492)
-- The Allen Institute for AI for releasing the open OlmoeRouter models used as the primary testbed.
-
-## Citation
-
-If you use `corinth-canal` or the SNN-logic quantization approach in your research, please cite:
-
-```bibtex
-@misc{corinth-canal2026,
-  title        = {corinth-canal: Turning MoE Architectures into SNN Quantization},
-  author       = {Raul Montoya Cardenas},
-  year         = {2026},
-  howpublished = {\url{https://github.com/rmems/corinth-canal}},
-  note         = {SNN-logic quantization reference crate with GIF-Ternary spiking for MoE models}
-}
-```
-
-## License
-
-GPL-3.0-or-later. See [LICENSE](LICENSE).
+## Notes
+
+- CPU-only buildability is preserved.
+- CUDA/GPU behavior is preserved behind the `cuda` feature.
+- Machine-local checkpoint discovery under `$HOME/Downloads/SNN_Quantization`
+  is a reference-repo convention, not a portable interface.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ The validation runner writes per-run artifacts including:
 - `latent_telemetry.csv`
 - `run_manifest.json`
 - `summary.json`
-- `snn_gpu_routing_telemetry.csv`
 
-GPU routing telemetry CSV schema:
+`snn_gpu_routing_telemetry.csv` is conditional: it is produced only by GPU
+routing paths that append telemetry rows (for example
+`Model::forward_gpu_temporal`). The normal `saaq_latent_calibration` loop uses
+`Model::tick_gpu_temporal`, so this CSV is not created in standard validation
+runs.
+
+When emitted, the GPU routing telemetry CSV schema is:
 
 ```text
 token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
@@ -134,9 +139,12 @@ token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
 
 ```bash
 just setup
-just check
-just test
+cargo check --all-targets --no-default-features
+cargo test --no-default-features
 ```
+
+On CUDA-equipped setups with `nvcc` available, `just check` and `just test`
+exercise the default feature set.
 
 ### Run the primary validation loop
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,10 @@
 # Architecture
 
 `corinth-canal` is the single-crate reference implementation of the `rmems`
-SNN-logic quantization bridge. It intentionally keeps the telemetry encoder,
-spiking hidden layer, projector, GGUF-backed routing bridge, and validation
-artifacts in one repository so the full research loop can be exercised before
-proven components are promoted into separate `rmems-*` crates.
+SNN-logic quantization bridge. It keeps the telemetry encoder, spiking hidden
+layer, projector, GGUF-backed routing bridge, and validation artifacts in one
+repository so the full research loop can be exercised within the required
+single-crate layout.
 
 ## Block diagram
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,31 +1,66 @@
 # Architecture
 
-`corinth-canal` is a single-crate reference implementation of the SNN-logic
-quantization bridge. It is intentionally *not* split into modular crates
-yet — the goal is to keep one working codebase where every component can be
-exercised end-to-end, then promote proven modules into the `rmems` modular
-repos (see `docs/PROMOTION_RULES.md` and `docs/MODULE_STATUS.md`).
+`corinth-canal` is the single-crate reference implementation of the `rmems`
+SNN-logic quantization bridge. It intentionally keeps the telemetry encoder,
+spiking hidden layer, projector, GGUF-backed routing bridge, and validation
+artifacts in one repository so the full research loop can be exercised before
+proven components are promoted into separate `rmems-*` crates.
 
 ## Block diagram
 
 ```text
 TelemetrySnapshot
        │
-       ▼  TelemetryEncoder (delta modulation) / project_snapshot_current (GPU)
-[i8; 4] ternary spikes (+1 / 0 / -1)
+       ▼  TelemetryEncoder (CPU) / project_snapshot_current (GPU)
+[i8; 4] ternary telemetry events (+1 / 0 / -1)
        │
-       ▼  SignedSplitBankBridge (CPU) or GPU input_spikes buffer
-2048 input neurons
+       ▼  SignedSplitBankBridge (CPU) / GPU input_spikes buffer
+input spike train
        │
-       ▼  SparseGifHiddenLayer (CPU) or gif_step_weighted_tick (GPU, adaptive)
-2048 GIF hidden neurons with adaptive thresholds + history-aware SAAQ
+       ▼  SparseGifHiddenLayer (CPU) / gif_step_weighted_tick (GPU)
+hidden spike train + membrane/adaptation state
        │
-       ▼  Projector (SpikingTernary)
-dense embedding [EMBEDDING_DIM = 2048]
+       ▼  Projector
+embedding [EMBEDDING_DIM = 2048]
        │
-       ▼  OlmoeRouter (stub | dense | spiking sim) with GGUF-backed routing
-expert_weights + selected_experts + hidden + spike_count telemetry
+       ▼  OlmoeRouter (stub | dense | spiking sim)
+expert_weights + selected_experts + routed hidden state
+       │
+       ▼  SAAQ latent calibration / telemetry export
 ```
+
+## CPU and GPU paths
+
+### CPU path
+
+The CPU path is assembled from pure Rust components:
+
+- `TelemetryEncoder` converts a `TelemetrySnapshot` into `[i8; 4]` ternary
+  events using per-channel delta thresholds.
+- `SignedSplitBankBridge` expands those ternary events into an input spike
+  train.
+- `SparseGifHiddenLayer` runs a 2048-neuron GIF hidden layer with adaptive
+  thresholds.
+- `Projector` converts hidden activity into a 2048-dimensional embedding.
+- `OlmoeRouter` consumes the embedding and produces expert weights / selected
+  experts.
+
+### GPU path
+
+The GPU temporal path is orchestrated by `Model::prepare_gpu_temporal`,
+`Model::tick_gpu_temporal`, and `Model::forward_gpu_temporal`.
+
+Key pieces:
+
+- `project_snapshot_current` projects 4-channel telemetry into the GPU temporal
+  input buffer.
+- `gif_step_weighted_tick` advances the resident GIF temporal state.
+- GPU synapse weights are loaded from a GGUF-backed source when available.
+- The GPU path reuses resident synapse weights across calls using a source
+  signature cached in `GpuAccelerator`.
+- `forward_gpu_temporal` writes routing telemetry through the shared CSV helper.
+- `tick_gpu_temporal` advances GPU state but does not itself append routing CSV
+  rows.
 
 ## Module map
 
@@ -33,69 +68,125 @@ expert_weights + selected_experts + hidden + spike_count telemetry
 |--------|------|
 | `src/model/core.rs` | Runtime orchestration, config validation, forward paths |
 | `src/model/temporal.rs` | GPU temporal loop (`prepare_gpu_temporal`, `tick_gpu_temporal`, `forward_gpu_temporal`) |
-| `src/model/telemetry_io.rs` | Shared CSV writer for routing telemetry |
+| `src/model/telemetry_io.rs` | Shared CSV writer for GPU routing telemetry |
 | `src/moe/mod.rs` | `OlmoeRouter` host with routing-mode dispatch |
-| `src/moe/checkpoint.rs` | GGUF parse, mmap, tensor slicing, `GgufMetadata` |
-| `src/moe/adapter.rs` | Model-family adapter resolution (Olmoe, Qwen3Moe, Gemma4, DeepSeek2, LlamaMoe) |
-| `src/moe/routing.rs` | Router math (gate scores, normalize, resample) |
-| `src/projector.rs` | `ProjectionMode` spike → embedding |
-| `src/funnel.rs` | Telemetry funnel + GIF hidden layer |
-| `src/telemetry.rs` | `TelemetryEncoder`, `TelemetrySnapshot` |
-| `src/latent.rs` | SAAQ 1.0 solo + dual 1.0/1.5 calibrators + CSV export |
-| `src/gpu/` | cust-based kernel wrappers |
-| `examples/support/config.rs` | `RunConfig::from_env()` — single source of env truth for examples |
+| `src/moe/checkpoint.rs` | GGUF parse, mmap, tensor slicing, dequantization helpers |
+| `src/moe/adapter.rs` | Model-family adapter resolution and tensor selection |
+| `src/moe/routing.rs` | Router math (gate scores, resampling, normalization, top-k) |
+| `src/projector.rs` | `ProjectionMode` spike-to-embedding projection |
+| `src/funnel.rs` | Telemetry funnel, signed split banks, GIF hidden layer |
+| `src/telemetry.rs` | `TelemetryEncoder` and `TelemetrySnapshot` bridge |
+| `src/latent.rs` | SAAQ 1.0 / 1.5 calibration and CSV export |
+| `src/gpu/` | CUDA wrappers, buffers, kernel launchers |
+| `examples/support/config.rs` | Example-only environment/config resolution |
+
+## Model loading and routing bridge
+
+The model-loading interface is custom and GGUF-backed.
+
+`OlmoeRouter`:
+
+- memory-maps GGUF checkpoints in-repo
+- resolves a supported model family from GGUF metadata
+- locates the routing tensor and token embedding tensor
+- exposes token embedding extraction for validation workflows
+- selects a GPU synapse source from one of:
+  - real `F16`
+  - dequantized `Q8_0`
+  - dequantized `Q5_K`
+  - synthetic fallback
+
+Supported families in code today:
+
+- `Olmoe`
+- `Qwen3Moe`
+- `Gemma4`
+- `DeepSeek2`
+- `LlamaMoe`
+
+## Routing / projection modes
+
+### Projection modes
+
+- `RateSum`
+- `TemporalHistogram`
+- `MembraneSnapshot`
+- `SpikingTernary`
+
+### Routing modes
+
+- `StubUniform`
+- `DenseSim`
+- `SpikingSim`
+
+## Validation entrypoint and artifacts
+
+The primary research/validation loop is `examples/saaq_latent_calibration.rs`.
+For each run it writes artifacts including:
+
+- `tick_telemetry.txt`
+- `latent_telemetry.csv`
+- `run_manifest.json`
+- `summary.json`
+- `snn_gpu_routing_telemetry.csv`
+
+The GPU routing telemetry CSV schema is:
+
+```text
+token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
+```
+
+The latent telemetry CSV includes both SAAQ trajectories via
+`SnnDualLatentCalibrator`; one rule is selected as the primary/legacy
+compatibility projection while the legacy and v1.5 columns are both emitted.
 
 ## Hidden control flow
 
-A few control paths are not obvious from a top-level read. They are called
-out here so future promotion out of this reference repo does not lose them.
+A few control paths are easy to miss from a top-level read.
 
-### CWD-relative write: `snn_gpu_routing_telemetry.csv`
+### Routing telemetry CSV path behavior
 
-`Model::forward_gpu_temporal` (and `Model::forward` → GPU routing) call
-`append_gpu_routing_telemetry_row` with a path resolved from
-`ModelConfig::gpu_routing_telemetry_path`. When that field is `None`,
-the path falls back to the bare filename `snn_gpu_routing_telemetry.csv`,
-which `std::fs` resolves against the process CWD.
+`Model::forward_gpu_temporal` and `Model::compute_routing_telemetry` resolve the
+routing telemetry sink through `ModelConfig::gpu_routing_telemetry_path`.
+When this field is `None`, the runtime falls back to the legacy
+CWD-relative filename `snn_gpu_routing_telemetry.csv`.
 
-- `saaq_latent_calibration` sets the path explicitly into
-  `<run_dir>/snn_gpu_routing_telemetry.csv`, so it is self-contained.
-- `telemetry_bridge` / `csv_replay` inherit the default (CWD). Launching
-  them from the repo root is the intended workflow.
-- `tick_gpu_temporal` does **not** touch this CSV; only the
-  `forward_gpu_temporal` path does.
+Implications:
+
+- `examples/saaq_latent_calibration.rs` sets the path explicitly into the run
+  directory, so its routing telemetry stays per-run.
+- Other call sites may still rely on the legacy fallback when they do not set
+  the path explicitly.
 
 ### Env-resolved paths
 
-Every machine-specific path is resolved in `examples/support/config.rs::RunConfig::from_env()`.
-The runtime crate itself (under `src/`) never reads environment variables
-for paths. If you are promoting a module out of this repo, the `RunConfig`
-surface is the contract to preserve.
+Machine-specific path discovery belongs in `examples/support/config.rs`.
+The library code under `src/` does not perform environment-variable path
+resolution for checkpoints, telemetry CSVs, or artifact roots.
 
-### Telemetry source fallback
+### Telemetry source stamping
 
-`resolve_telemetry_source()` stamps `source_label` into every
-`run_manifest.json` with one of three values:
+The validation runner stamps a source label into `run_manifest.json` using one
+of:
 
-- `synthetic` — explicit or default stub
-- `synthetic_fallback` — requested CSV but it was missing / malformed / empty
-- `csv_<stem>` — canonical CSV path, e.g. `csv_re4` for `telemetry.csv`
+- `synthetic`
+- `synthetic_fallback`
+- `csv_<stem>`
 
-This means the manifest is always truthful about what actually fed the run,
-even when the configured source silently degraded.
-# Observability
+This makes fallback behavior explicit in artifacts instead of hiding it behind a
+successful run.
 
-The example binaries use a shared observability wrapper in
+## Observability
+
+The example binaries share observability helpers under
 `examples/support/observability.rs`.
 
-- `command_start` and `command_finish` are emitted for every example binary.
-- Tracing fields are stable across examples:
-  `repo`, `command`, `run_id`, `git_sha`, `latency_ms`, `success`,
-  `error_category`.
-- Sentry is opt-in only. If `SENTRY_DSN` is unset or blank, the wrappers do
-  not initialize a client and do not introduce a network dependency.
-- Only safe diagnostics are attached to Sentry scope:
-  `repo`, `command`, `git_sha`, `model_slug`, `telemetry_source`,
-  `heartbeat_enabled`, `validation_status`, and `error_category`.
-- Absolute checkpoint paths, DSNs, and generated artifact paths are not added
-  to Sentry tags or extras by the wrappers.
+- `command_start` and `command_finish` tracing events are emitted for every
+  example command.
+- Sentry is opt-in only. If `SENTRY_DSN` is unset or blank, the examples remain
+  local/offline.
+- The wrappers attach only safe diagnostic fields such as `repo`, `command`,
+  `git_sha`, `model_slug`, `telemetry_source`, `heartbeat_enabled`,
+  `validation_status`, and `error_category`.
+- Absolute checkpoint paths and artifact paths are not attached as Sentry tags
+  by the wrappers.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,9 +128,13 @@ For each run it writes artifacts including:
 - `latent_telemetry.csv`
 - `run_manifest.json`
 - `summary.json`
-- `snn_gpu_routing_telemetry.csv`
 
-The GPU routing telemetry CSV schema is:
+`snn_gpu_routing_telemetry.csv` is conditional: it is produced only by GPU
+routing paths that append telemetry rows. The normal
+`examples/saaq_latent_calibration.rs` loop uses `Model::tick_gpu_temporal`, so
+this CSV is not created in standard validation runs.
+
+When emitted, the GPU routing telemetry CSV schema is:
 
 ```text
 token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
@@ -154,7 +158,9 @@ CWD-relative filename `snn_gpu_routing_telemetry.csv`.
 Implications:
 
 - `examples/saaq_latent_calibration.rs` sets the path explicitly into the run
-  directory, so its routing telemetry stays per-run.
+  directory, so any routing telemetry emitted by a writing path stays per-run.
+- The same runner currently advances the GPU loop through
+  `Model::tick_gpu_temporal`, which does not append routing CSV rows on its own.
 - Other call sites may still rely on the legacy fallback when they do not set
   the path explicitly.
 

--- a/docs/MODULE_STATUS.md
+++ b/docs/MODULE_STATUS.md
@@ -8,18 +8,18 @@ Status legend: `reference` · `stabilizing` · `proven` · `frozen`
 
 | Module | Status | Target `rmems` crate | Notes |
 |--------|--------|----------------------|-------|
-| `src/model/core.rs` | reference | `rmems-model` | Orchestration layer; still entangled with `Model::forward_gpu_temporal` CWD write. Gated on Stage E of the reference-repo cleanup. |
-| `src/model/temporal.rs` | stabilizing | `rmems-model` | GPU temporal loop is tight and proven; needs its routing-CSV path made explicit before freezing. |
-| `src/model/telemetry_io.rs` | stabilizing | `rmems-model` | Pure helper, ready to move once the caller stops passing a CWD-relative path. |
-| `src/moe/mod.rs` | stabilizing | `rmems-moe` | Host entry for `OlmoeRouter`; surface is clean. Pending full matrix. |
-| `src/moe/checkpoint.rs` | reference | `rmems-moe` | Pre-existing WIP in the parser is patched. Needs a proper test battery before promotion. |
-| `src/moe/adapter.rs` | stabilizing | `rmems-moe` | Five-family support validated on the author's machine; needs CI matrix. |
-| `src/moe/routing.rs` | stabilizing | `rmems-moe` | Stateless math. Low-risk promotion candidate. |
-| `src/projector.rs` | stabilizing | `rmems-projector` | `ProjectionMode` surface frozen; SpikingTernary path is the live one. |
-| `src/funnel.rs` | reference | `rmems-funnel` | GIF hidden layer still shared between CPU and GPU callers. |
-| `src/telemetry.rs` | stabilizing | `rmems-telemetry` | Schema frozen (`timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w`). |
-| `src/latent.rs` | stabilizing | `rmems-latent` | Dual-SAAQ emission is working; needs a REPEAT_COUNT=2 determinism check to graduate. |
-| `src/gpu/*` | reference | `rmems-gpu` | Kernel sources and cust wrappers. Promotion blocked on build.rs portability. |
+| `src/model/core.rs` | reference | `rmems-model` | Orchestration layer still couples runtime behavior, artifact wiring, and GGUF-backed routing. Not yet ready to promote as an isolated surface. |
+| `src/model/temporal.rs` | stabilizing | `rmems-model` | GPU temporal loop is tight and proven. Legacy fallback to a CWD-relative routing CSV still exists when `ModelConfig::gpu_routing_telemetry_path` is unset, so callers must keep the sink explicit. |
+| `src/model/telemetry_io.rs` | stabilizing | `rmems-model` | Pure helper. Public behavior is stable; promotion depends mainly on the surrounding runtime/API cleanup. |
+| `src/moe/mod.rs` | stabilizing | `rmems-moe` | Host entry for `OlmoeRouter`; surface is clean. Pending full model-family validation matrix. |
+| `src/moe/checkpoint.rs` | reference | `rmems-moe` | GGUF parser/mmap/dequant layer works, but still needs a broader parser and format test battery before promotion. |
+| `src/moe/adapter.rs` | stabilizing | `rmems-moe` | Five-family adapter resolution is implemented; needs broader validation coverage. |
+| `src/moe/routing.rs` | stabilizing | `rmems-moe` | Stateless routing math. Low-risk promotion candidate. |
+| `src/projector.rs` | stabilizing | `rmems-projector` | `ProjectionMode` surface is stable; `SpikingTernary` remains the live research path. |
+| `src/funnel.rs` | reference | `rmems-funnel` | CPU GIF hidden layer is still shared with the broader runtime and validation path. |
+| `src/telemetry.rs` | stabilizing | `rmems-telemetry` | Telemetry encoding surface is small and stable. `TelemetrySnapshot` now includes heartbeat fields in addition to physical telemetry channels. |
+| `src/latent.rs` | stabilizing | `rmems-latent` | Dual-SAAQ emission is in place. Determinism and campaign validation remain the main graduation gate. |
+| `src/gpu/*` | reference | `rmems-gpu` | Kernel sources and cust wrappers remain coupled to the reference repo build/runtime assumptions. Promotion is still blocked on portability and validation breadth. |
 | `examples/support/config.rs` | reference | n/a | Intentionally stays here — it is the env-truth surface for the reference repo only. |
 
 ## Known blockers
@@ -27,8 +27,9 @@ Status legend: `reference` · `stabilizing` · `proven` · `frozen`
 - **Machine-local discovery root.** `examples/support/mod.rs` walks
   `$HOME/Downloads/SNN_Quantization`. Fine for the reference repo; must
   not be copied into any `rmems` crate.
-- **`GPU_ROUTING_TELEMETRY_PATH` CWD default.** Stage E of the cleanup
-  makes this configurable via `ModelConfig`; freezing `src/model/*` is
-  blocked until that lands.
-- **`build.rs` fatbin compilation.** Assumes nvcc + sm_120 targets on the
-  author's box. `gpu-stub` feature covers the CI / non-CUDA case.
+- **Legacy routing-CSV fallback.** The runtime now supports
+  `ModelConfig::gpu_routing_telemetry_path`, but any caller that leaves it
+  unset still falls back to the CWD-relative filename
+  `snn_gpu_routing_telemetry.csv`.
+- **`build.rs` fatbin compilation.** Assumes nvcc + `sm_120` targets on the
+  author's box. `gpu-stub` covers the CI / non-CUDA case.

--- a/docs/RUN_PROFILES.md
+++ b/docs/RUN_PROFILES.md
@@ -32,9 +32,14 @@ configured output root. Each run directory contains:
 - `latent_telemetry.csv`
 - `run_manifest.json`
 - `summary.json`
-- `snn_gpu_routing_telemetry.csv`
 
-The GPU routing telemetry CSV schema is:
+`snn_gpu_routing_telemetry.csv` is conditional: it is produced only by GPU
+routing paths that append telemetry rows (for example
+`Model::forward_gpu_temporal`). The normal `saaq_latent_calibration` loop uses
+`Model::tick_gpu_temporal`, so this CSV is not created in standard validation
+runs.
+
+When emitted, the GPU routing telemetry CSV schema is:
 
 ```text
 token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction

--- a/docs/RUN_PROFILES.md
+++ b/docs/RUN_PROFILES.md
@@ -20,8 +20,42 @@ not been blessed and should be considered experimental.
 | Heartbeat ON only | synthetic | on | 1.5 | `HEARTBEAT_MATRIX=on just saaq` |
 | Legacy rule parity | synthetic | both | 1.0 | `SAAQ_RULE=legacy just saaq` |
 
-Dual-SAAQ columns (`saaq_delta_q_*_v1_0` / `_v1_5`) are emitted regardless of
-`SAAQ_RULE`; the env var only picks which rule fills the legacy columns.
+Dual-SAAQ columns are emitted regardless of `SAAQ_RULE`; the env var only
+selects which rule fills the legacy compatibility columns.
+
+### Validation outputs
+
+`examples/saaq_latent_calibration.rs` writes a per-run directory under the
+configured output root. Each run directory contains:
+
+- `tick_telemetry.txt`
+- `latent_telemetry.csv`
+- `run_manifest.json`
+- `summary.json`
+- `snn_gpu_routing_telemetry.csv`
+
+The GPU routing telemetry CSV schema is:
+
+```text
+token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
+```
+
+The latent telemetry CSV includes both SAAQ trajectories via
+`SnnDualLatentCalibrator`:
+
+- legacy / primary compatibility columns
+- explicit legacy trajectory columns
+- explicit v1.5 trajectory columns
+
+### Operational notes
+
+- `TICKS=0` with `TELEMETRY_SOURCE=csv` uses the full CSV row count so corpus
+  runs cover exactly one telemetry loop.
+- When `TICKS > csv_row_count`, the runner warns about wraparound contamination.
+- `STRICT_REPEAT_CHECK=true` enables repeat-to-repeat comparison in the
+  validation workflow.
+- `run_manifest.json` stamps the actual telemetry source label, including
+  `synthetic_fallback` when CSV replay degrades.
 
 ## GPU smoke test
 
@@ -29,11 +63,21 @@ Dual-SAAQ columns (`saaq_delta_q_*_v1_0` / `_v1_5`) are emitted regardless of
 |---------|---------|
 | 10k GPU ticks, real checkpoint | `GGUF_CHECKPOINT_PATH=... just smoke` |
 
+This example is the direct GPU-temporal smoke path. It is the correct entrypoint
+for validating resident synapse upload, GIF weighted temporal stepping, and the
+on-device best-walker reduction.
+
 ## CSV replay
 
 | Profile | Command |
 |---------|---------|
 | Ingest canonical telemetry CSV | `just replay /path/to/telemetry.csv` |
+
+Canonical CSV schema consumed by replay and validation:
+
+```text
+timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w
+```
 
 ## Telemetry bridge demo
 
@@ -57,3 +101,19 @@ up to five MoE families under `$HOME/Downloads/SNN_Quantization/`:
 This discovery root is a machine-local convention on the author's Fedora
 box. CI and contributor machines should set `GGUF_CHECKPOINT_PATH`
 explicitly.
+
+## Supported routing/model surfaces reflected in code
+
+Routing modes:
+
+- `StubUniform`
+- `DenseSim`
+- `SpikingSim`
+
+Model families supported by the GGUF adapter layer:
+
+- `Olmoe`
+- `Qwen3Moe`
+- `Gemma4`
+- `DeepSeek2`
+- `LlamaMoe`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,49 @@
 //! # corinth-canal
 //!
-//! Standalone SNN-logic quantization crate focused on the projector and OlmoeRouter
-//! routing path. The telemetry/SNN front-end is a deterministic in-repo stub
-//! that generates repeatable spikes without requiring external services.
+//! `corinth-canal` is the single-crate reference implementation for the `rmems`
+//! SNN-logic quantization line.
 //!
-//! ## Architecture
+//! The crate keeps the full telemetry -> spiking -> projector -> router path in
+//! one repository so the research loop can be exercised end to end before proven
+//! components are promoted into separate `rmems-*` crates.
+//!
+//! ## Runtime pipeline
 //!
 //! ```text
 //! TelemetrySnapshot
 //!        │
-//!        ▼  deterministic dummy spike generator
-//! spike_train + membrane_potentials
+//!        ▼  TelemetryEncoder (CPU) / project_snapshot_current (GPU)
+//! ternary telemetry events (+1 / 0 / -1 per channel)
+//!        │
+//!        ▼  SignedSplitBankBridge (CPU) / GPU input_spikes buffer
+//! input spike train
+//!        │
+//!        ▼  SparseGifHiddenLayer (CPU) / gif_step_weighted_tick (GPU)
+//! hidden spike train + membrane potentials
 //!        │
 //!        ▼  Projector
 //! dense embedding [EMBEDDING_DIM = 2048]
 //!        │
 //!        ▼  OlmoeRouter
-//! expert_weights + selected_experts + hidden
+//! expert_weights + selected_experts + routed hidden state
+//!        │
+//!        ▼  SAAQ latent calibration / telemetry export
 //! ```
+//!
+//! ## Model loading
+//!
+//! The routing bridge is GGUF-backed and custom to this repository.
+//! `OlmoeRouter` parses GGUF checkpoints in-repo, resolves a supported model
+//! family, extracts routing tensors and token embeddings, and selects a GPU
+//! synapse source from one of:
+//!
+//! - real `F16`
+//! - dequantized `Q8_0`
+//! - dequantized `Q5_K`
+//! - synthetic fallback
+//!
+//! Supported families in code today are `Olmoe`, `Qwen3Moe`, `Gemma4`,
+//! `DeepSeek2`, and `LlamaMoe`.
 //!
 //! ## Quick start
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,19 @@
 //!
 //! ## Quick start
 //!
+//! The `model` module is available when the `cuda` feature is enabled (the
+//! default feature set).
+//!
 //! ```no_run
+//! # #[cfg(feature = "cuda")] {
 //! use corinth_canal::model::{Model, ModelConfig};
-//! use corinth_canal::telemetry::TelemetrySnapshot;
+//! use corinth_canal::TelemetrySnapshot;
 //!
 //! let mut model = Model::new(ModelConfig::default()).unwrap();
 //! let output = model.forward(&TelemetrySnapshot::default()).unwrap();
 //!
 //! println!("Selected experts: {:?}", output.selected_experts);
+//! # }
 //! ```
 
 pub mod error;


### PR DESCRIPTION
## **User description**
## Summary

This PR aligns the top-level and architecture documentation with the current `corinth-canal` implementation and documents the repository’s agent/executor setup in `AGENTS.md`.

It also removes the `.gitignore` rule that prevented `AGENTS.md` from being tracked in-repo.

## What changed

- updated `src/lib.rs` crate docs to reflect the actual runtime pipeline
- updated `README.md` to match the current single-crate architecture and validation flow
- updated `docs/ARCHITECTURE.md` with current CPU/GPU paths, GGUF-backed routing, and artifact behavior
- updated `docs/MODULE_STATUS.md` to reflect the current routing-telemetry path behavior
- updated `docs/RUN_PROFILES.md` to document current validation outputs and supported routing/model surfaces
- added agent/executor tooling guidance to `AGENTS.md`
- removed `AGENTS.md` from `.gitignore` so it stays tracked

## Implementation details now reflected in docs

### Runtime flow

`TelemetrySnapshot -> TelemetryEncoder / GPU snapshot projection -> ternary events -> SignedSplitBankBridge / GPU input_spikes -> SparseGifHiddenLayer / GPU GIF temporal loop -> Projector -> OlmoeRouter -> SAAQ calibration / telemetry export`

### GGUF-backed routing/model-loading surface

The docs now reflect the custom in-repo GGUF-backed routing bridge and the currently supported model families:

- `Olmoe`
- `Qwen3Moe`
- `Gemma4`
- `DeepSeek2`
- `LlamaMoe`

They also document the GPU synapse source cascade:

- real `F16`
- dequantized `Q8_0`
- dequantized `Q5_K`
- synthetic fallback

### Routing and projection modes

Routing modes:
- `StubUniform`
- `DenseSim`
- `SpikingSim`

Projection modes:
- `RateSum`
- `TemporalHistogram`
- `MembraneSnapshot`
- `SpikingTernary`

### Validation outputs

The docs now explicitly call out the validation artifacts and routing telemetry schema:

- `tick_telemetry.txt`
- `latent_telemetry.csv`
- `run_manifest.json`
- `summary.json`
- `snn_gpu_routing_telemetry.csv`

GPU routing telemetry CSV schema:

```text
token_idx,best_score,best_walker,spike_count,mean_adaptation,active_fraction
```

The docs also reflect that dual SAAQ emission exists in latent telemetry output.

## Agent / executor tooling now documented

`AGENTS.md` now documents:

- Codex as the primary executor
- Hermes Agents and GitHub Copilot as part of the memory-agent backbone
- approved fallback executors:
  - Opencode
  - Kilo
  - Cline
  - Gemini CLI
- experimental tooling:
  - Goose Agent
  - OpenClaw
  - Blocks
- optional integrations / evaluated tooling referenced only at a high level:
  - Google APIs
  - NVIDIA NIM
  - OpenRouter
  - Grok APIs
  - CodeHawk (currently available via 30-day free trial)
  - IBM bob (potential evaluated tooling; needs verification before being documented as enabled)

The doc language also states that:
- local/offline behavior must remain safe when optional APIs are unset
- docs/examples must not include secrets, tokens, DSNs, private telemetry, or local absolute paths

## Validation

- ran `cargo check`

## Notes

- This PR is docs-only plus `.gitignore` cleanup for `AGENTS.md` tracking.
- The goal here is to make the repo’s public docs match the current implementation without changing runtime behavior.

Closes #49
Closes #50

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only plus a `.gitignore` tweak to start tracking `AGENTS.md`; no runtime logic is modified.
> 
> **Overview**
> Updates repository documentation to match the current end-to-end pipeline (*telemetry → spiking → projector → GGUF-backed routing → SAAQ artifacts*), including clarified CPU vs GPU paths, supported model families/modes, and the validation outputs/CSV schemas.
> 
> Adds a new tracked `AGENTS.md` describing approved agent/executor tooling and safety rules, and removes the `.gitignore` entry that previously excluded it. Also refreshes crate-level docs in `src/lib.rs` and streamlines `README.md`/`docs/*` to reflect the current single-crate scope and workflow expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b319d8014f324d57e62277cc189adc7d7310f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Align the docs with the current single-crate runtime and validation flow**

### What Changed
- Updated the crate and top-level docs to describe the current end-to-end pipeline from telemetry input through spiking, projection, routing, and validation output
- Documented the GGUF-backed routing bridge, supported model families, routing modes, and projection modes now reflected in the code
- Added clear guidance for validation runs, including per-run artifacts, routing telemetry output, CSV schema, wraparound behavior, and repeat checks
- Added `AGENTS.md` with repository-specific guidance for agent tooling and kept it tracked in the repo

### Impact
`✅ Clearer validation setup`
`✅ Easier per-run artifact tracking`
`✅ Fewer mismatches between docs and runtime behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
