### PR TITLE
Add Safetensors checkpoint manifest inspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ Thumbs.db
 # Debug
 *.log
 
+# Coverage reports
+lcov.info
+*.profraw
+*.profdata
+coverage/
+
 # Agent notes
 
 # Local Kilo planning scratch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,45 @@
 version = 4
 
 [[package]]
+name = "abscissa_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd87587023faadfc7f6e93b1ad45074b72f1f6d22c1e0f19333a952446ab1c1"
+dependencies = [
+ "abscissa_derive",
+ "arc-swap",
+ "backtrace",
+ "canonical-path",
+ "clap",
+ "color-eyre",
+ "fs-err",
+ "once_cell",
+ "regex",
+ "secrecy",
+ "semver",
+ "serde",
+ "termcolor",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
+ "wait-timeout",
+]
+
+[[package]]
+name = "abscissa_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da54f552dccbdec19736d713720dd88af932a82eb02ca0f22410de5d31ad726"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +66,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,16 +137,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auditable-extract"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44371e9f9759dea49c42b6c6fe4c64ea216ee2af325a4524a7180823e00d3e7a"
+dependencies = [
+ "binfarce",
+ "wasmparser",
+]
+
+[[package]]
+name = "auditable-info"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c692b37b578433ebc75db30941a7ff137c381a204beb2429a30b7587d4d4dff3"
+dependencies = [
+ "auditable-extract",
+ "auditable-serde",
+ "miniz_oxide",
+ "serde_json",
+]
+
+[[package]]
+name = "auditable-serde"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d026218ae25ba5c72834245412dd1338f6d270d2c5109ee03a4badec288d4056"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -81,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "binfarce"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18464ccbb85e5dede30d70cc7676dc9950a0fb7dbf595a43d765be9123c616a2"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +275,36 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -105,10 +319,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
+name = "canonical-path"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
+
+[[package]]
+name = "cargo-audit"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4e27b0ab2d116c87c29db159ad42565cdcdccf77eb62ef0486ddd017a02da6"
+dependencies = [
+ "abscissa_core",
+ "cargo-lock",
+ "clap",
+ "display-error-chain",
+ "home",
+ "rustsec",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "cargo-llvm-cov"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb60793c145d8ef09b5cfa49c2f2890b93bde5a13885a9369654ca87dddfe7f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo-config2",
+ "duct",
+ "fs-err",
+ "glob",
+ "lcov2cobertura",
+ "lexopt",
+ "opener",
+ "regex",
+ "rustc-demangle",
+ "ruzstd",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "shell-escape",
+ "tar",
+ "termcolor",
+ "walkdir",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
+dependencies = [
+ "petgraph",
+ "semver",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
+]
 
 [[package]]
 name = "cc"
@@ -117,6 +417,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -131,6 +433,110 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "core-foundation"
@@ -153,18 +559,83 @@ name = "corinth-canal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo-audit",
+ "cargo-llvm-cov",
  "cc",
  "cust",
  "dotenvy",
+ "fmt",
  "libc",
  "memmap2",
  "sentry",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -214,6 +685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cvss"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fb220d3ce1b565af39cee5b89e47fd8dd1dab162900ee4363c8ee4169ee8a2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,7 +720,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "display-error-chain"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc2146e86bc19f52f4c064a64782f05f139ca464ed72937301631e73f8d6cf5"
 
 [[package]]
 name = "displaydoc"
@@ -260,6 +757,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "duct"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "shared_child",
+ "shared_thread",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,10 +806,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -297,10 +857,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09904adae26440d46daeacb5ed7922fee69d43ebf84d31e078cd49652cecd718"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -325,6 +919,21 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -376,14 +985,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -393,9 +1014,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -403,6 +1026,776 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gix"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3428a03ace494ae40308bd3df0b37e7eb7403e24389f27abdff30abf2b5adf17"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50ce5433eaa46187349e59089eea71b0397caa71991b2fa3e124120426d7d15"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e72da5a1c35c9a129be0c60ab9968779981ca50835dd98650ecd8b0ea4d721e"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e516efaac951ed21115b11d5514b120c26ccb493d0c0b9ea6cc10edf4fdf44"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2962172c6f78731e2b7773bf762f7b8d1746a342a4c0a8914a612206e1295953"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dda2e4d5a61d4a16a780f61f2b7e9406ad1f8da97c35c09ef501f3fdf74de0"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a153dd4f5789fdf242e19e3f7105f2a114df198570225976fe4a108bac9dee4"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ef04ac6b0b9cb75b02afaab4045eafb7b59be41815fbfaaa184a2280af2146"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12553b32d1da25671f31c0b084bf1e5cb6d5ef529254d04ec33cdc890bd7f687"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bcd367b2c5dbf6bec9ce02ca59eab179fc82cf39f15ec83549ee25c255c99f"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-object",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950b027b861c6863ddf1b075672ec1ef2006b95c4d12284fc1ec4cdb1ab6639e"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dffc9ca4dfa4f519a3d2cf1c038919160544923577ac60f45bcb602a24d82c6"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7240442915cdd74e1f889566695ce0d0c23c7185b13318a1232ce646af0d18ad"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ced05d2d7b13bff08b2f7eb4e47cfeaf00b974c2ddce08377c4fe1f706b3eb"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31c6b3664efe5916c539c50e610f9958f2993faf8e29fa5a40fb80b6ac8486a"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dff6d49869f16b8900da7c27b886a45cbf641b1e45aab355d012afe4266b7f"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f705c977d90ace597049252ae1d7fec907edc0fa7616cc91bf5508d0f4006"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d59882d2fdab5e609b0c452a6ef9a3bd12ef6b694be4f82ab8f126ad0969864"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c44db57ebbbeaad9972c2a60662142660427a1f0a7529314d53fefb4fedad24"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f4cc23f55ca7c190bf243f1a4e2139d4522022f724fb0dfc06c93f65a01ef6"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4806f1ebf969cd54d178ccd975911ef1829aeccea0b27630e63c9d26c8347d7f"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f20837b0c70b65f6ac77886be033de3b69d5879f99128b47c42665ab0a17c2"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ce400a770a7952e45267803192cc2d1fe0afa08e2c08dde32e04c7908c6e61"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c719cf7d669439e1fca735bd1c4de54d43c5d30e8883fd6063c4924b213d70c9"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a50b30aa0c6e6de43c723359c5809a96275a3aa92d323ef7f58b1cdd60f16"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189386b5da5285216cc0ede89eff5a943d5261fc794241ee6ec5360b77df15ad"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1840fe723c6264ee596e5a179e1b9a2df59351f09bae9cea570a472a790bc0"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1064c7ffa5a915014a6a5b71fbc5299462ae655348bed23e083b4a735076c3"
+dependencies = [
+ "base64",
+ "bstr",
+ "gix-command",
+ "gix-credentials",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f8b53b4c56b01c43a4491c4edfe2ce66c654eb86232205172ceb1650d21c55"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9895abc7654cbd8e102d6a765d3bdfa1567fcd5d2849b8e3d3da6405d64913c9"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "glam"
@@ -439,16 +1832,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -653,6 +2100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,13 +2127,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -690,10 +2159,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -708,10 +2283,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lcov2cobertura"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf5d75e3487295500b5426ad473805696126915b3e647ecdd5b9597a17766c6a"
+dependencies = [
+ "anyhow",
+ "quick-xml",
+ "regex",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "lexopt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"
@@ -738,10 +2340,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -750,6 +2367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -768,12 +2396,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -808,6 +2443,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -860,6 +2504,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opener"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fa337e0cf13357c13ef1dc108df1333eb192f75fc170bea03fcf1fd404c2ee"
+dependencies = [
+ "bstr",
+ "normpath",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +2564,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +2618,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +2640,30 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "platforms"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -960,6 +2696,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quitters"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88ccde7d84d2115b250b5cba923973fc42fe23ad42d9d63bb129d956a6db014"
+dependencies = [
+ "once_cell",
+ "regex",
+ "semver",
 ]
 
 [[package]]
@@ -1007,6 +2828,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +2893,7 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1056,15 +2907,20 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1095,6 +2951,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc-stable-hash"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +2990,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1130,13 +2999,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1144,9 +3053,36 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rustsec"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b4fa3512c10790d18e6cfdadc34fa753cc27cb2826d70c427baa9a69bbf11f3"
+dependencies = [
+ "auditable-info",
+ "auditable-serde",
+ "binfarce",
+ "cargo-lock",
+ "cvss",
+ "fs-err",
+ "gix",
+ "home",
+ "once_cell",
+ "platforms",
+ "quitters",
+ "semver",
+ "serde",
+ "tame-index",
+ "thiserror 2.0.18",
+ "time",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -1156,12 +3092,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1192,6 +3159,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sentry"
@@ -1340,6 +3311,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,10 +3350,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "shared_thread"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1365,6 +3416,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "socket2"
@@ -1381,6 +3442,18 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1431,6 +3504,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tame-index"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51563c6639245219c077420e0a207e99b5e82e2e6bb78fd4898d42028ea7dde"
+dependencies = [
+ "camino",
+ "crossbeam-channel",
+ "http",
+ "libc",
+ "memchr",
+ "rayon",
+ "reqwest",
+ "rustc-stable-hash",
+ "semver",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml-span",
+ "twox-hash",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +3549,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1534,6 +3651,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,9 +3719,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml-span"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22ba417d437b5fa5dcba6c27dbd6c14f38845315b724d89fed73b7a426451b7"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -1602,6 +3771,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,10 +3796,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1620,6 +3816,18 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower"
@@ -1642,12 +3850,17 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1747,10 +3960,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "untrusted"
@@ -1813,6 +4062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +4100,31 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rustc_version",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1927,10 +4207,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1946,6 +4245,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,7 +4287,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1975,14 +4314,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1992,10 +4348,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2004,10 +4372,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2016,10 +4396,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2028,10 +4420,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2041,6 +4445,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -2053,6 +4463,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"
@@ -2156,6 +4576,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,45 +3,6 @@
 version = 4
 
 [[package]]
-name = "abscissa_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd87587023faadfc7f6e93b1ad45074b72f1f6d22c1e0f19333a952446ab1c1"
-dependencies = [
- "abscissa_derive",
- "arc-swap",
- "backtrace",
- "canonical-path",
- "clap",
- "color-eyre",
- "fs-err",
- "once_cell",
- "regex",
- "secrecy",
- "semver",
- "serde",
- "termcolor",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
- "wait-timeout",
-]
-
-[[package]]
-name = "abscissa_derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da54f552dccbdec19736d713720dd88af932a82eb02ca0f22410de5d31ad726"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,62 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,99 +42,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "async-compression"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
-dependencies = [
- "compression-codecs",
- "compression-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auditable-extract"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44371e9f9759dea49c42b6c6fe4c64ea216ee2af325a4524a7180823e00d3e7a"
-dependencies = [
- "binfarce",
- "wasmparser",
-]
-
-[[package]]
-name = "auditable-info"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c692b37b578433ebc75db30941a7ff137c381a204beb2429a30b7587d4d4dff3"
-dependencies = [
- "auditable-extract",
- "auditable-serde",
- "miniz_oxide",
- "serde_json",
-]
-
-[[package]]
-name = "auditable-serde"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d026218ae25ba5c72834245412dd1338f6d270d2c5109ee03a4badec288d4056"
-dependencies = [
- "semver",
- "serde",
- "serde_json",
- "topological-sort",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "backtrace"
@@ -259,12 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "binfarce"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18464ccbb85e5dede30d70cc7676dc9950a0fb7dbf595a43d765be9123c616a2"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,36 +91,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -319,106 +105,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-
-[[package]]
-name = "canonical-path"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
-
-[[package]]
-name = "cargo-audit"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4e27b0ab2d116c87c29db159ad42565cdcdccf77eb62ef0486ddd017a02da6"
-dependencies = [
- "abscissa_core",
- "cargo-lock",
- "clap",
- "display-error-chain",
- "home",
- "rustsec",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "cargo-config2"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
-dependencies = [
- "serde",
- "serde_derive",
- "toml 1.1.2+spec-1.1.0",
-]
-
-[[package]]
-name = "cargo-llvm-cov"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb60793c145d8ef09b5cfa49c2f2890b93bde5a13885a9369654ca87dddfe7f"
-dependencies = [
- "anyhow",
- "camino",
- "cargo-config2",
- "duct",
- "fs-err",
- "glob",
- "lcov2cobertura",
- "lexopt",
- "opener",
- "regex",
- "rustc-demangle",
- "ruzstd",
- "serde",
- "serde_derive",
- "serde_json",
- "shell-escape",
- "tar",
- "termcolor",
- "walkdir",
-]
-
-[[package]]
-name = "cargo-lock"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
-dependencies = [
- "petgraph",
- "semver",
- "serde",
- "toml 0.9.12+spec-1.1.0",
- "url",
-]
-
-[[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -433,110 +131,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clru"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
-]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "compression-codecs"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
-dependencies = [
- "compression-core",
- "flate2",
- "memchr",
-]
-
-[[package]]
-name = "compression-core"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "core-foundation"
@@ -559,83 +153,18 @@ name = "corinth-canal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cargo-audit",
- "cargo-llvm-cov",
  "cc",
  "cust",
  "dotenvy",
- "fmt",
  "libc",
  "memmap2",
  "sentry",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -685,15 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cvss"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fb220d3ce1b565af39cee5b89e47fd8dd1dab162900ee4363c8ee4169ee8a2"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,24 +240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "display-error-chain"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc2146e86bc19f52f4c064a64782f05f139ca464ed72937301631e73f8d6cf5"
 
 [[package]]
 name = "displaydoc"
@@ -757,39 +260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "duct"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
-dependencies = [
- "libc",
- "os_pipe",
- "shared_child",
- "shared_thread",
-]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,40 +276,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -857,28 +297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09904adae26440d46daeacb5ed7922fee69d43ebf84d31e078cd49652cecd718"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,12 +307,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -919,21 +331,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -985,26 +382,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1014,11 +399,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1026,776 +422,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "gix"
-version = "0.78.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3428a03ace494ae40308bd3df0b37e7eb7403e24389f27abdff30abf2b5adf17"
-dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-pathspec",
- "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
- "gix-sec",
- "gix-shallow",
- "gix-submodule",
- "gix-tempfile",
- "gix-trace",
- "gix-transport",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree",
- "gix-worktree-state",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50ce5433eaa46187349e59089eea71b0397caa71991b2fa3e124120426d7d15"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-utils",
- "itoa",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e72da5a1c35c9a129be0c60ab9968779981ca50835dd98650ecd8b0ea4d721e"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e516efaac951ed21115b11d5514b120c26ccb493d0c0b9ea6cc10edf4fdf44"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2962172c6f78731e2b7773bf762f7b8d1746a342a4c0a8914a612206e1295953"
-dependencies = [
- "bstr",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "shell-words",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dda2e4d5a61d4a16a780f61f2b7e9406ad1f8da97c35c09ef501f3fdf74de0"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-error",
- "gix-hash",
- "memmap2",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a153dd4f5789fdf242e19e3f7105f2a114df198570225976fe4a108bac9dee4"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "memchr",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-path",
- "libc",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-credentials"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ef04ac6b0b9cb75b02afaab4045eafb7b59be41815fbfaaa184a2280af2146"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-config-value",
- "gix-date",
- "gix-path",
- "gix-prompt",
- "gix-sec",
- "gix-trace",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12553b32d1da25671f31c0b084bf1e5cb6d5ef529254d04ec33cdc890bd7f687"
-dependencies = [
- "bstr",
- "gix-error",
- "itoa",
- "jiff",
- "smallvec",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bcd367b2c5dbf6bec9ce02ca59eab179fc82cf39f15ec83549ee25c255c99f"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-object",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950b027b861c6863ddf1b075672ec1ef2006b95c4d12284fc1ec4cdb1ab6639e"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dffc9ca4dfa4f519a3d2cf1c038919160544923577ac60f45bcb602a24d82c6"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
-dependencies = [
- "bytes",
- "crc32fast",
- "crossbeam-channel",
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "once_cell",
- "parking_lot",
- "prodash",
- "thiserror 2.0.18",
- "walkdir",
- "zlib-rs",
-]
-
-[[package]]
-name = "gix-filter"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7240442915cdd74e1f889566695ce0d0c23c7185b13318a1232ce646af0d18ad"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
- "gix-packetline",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "gix-utils",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ced05d2d7b13bff08b2f7eb4e47cfeaf00b974c2ddce08377c4fe1f706b3eb"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
-dependencies = [
- "gix-hash",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-trace",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31c6b3664efe5916c539c50e610f9958f2993faf8e29fa5a40fb80b6ac8486a"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "gix-utils",
- "gix-validate",
- "hashbrown 0.16.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-lock"
-version = "21.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-negotiate"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dff6d49869f16b8900da7c27b886a45cbf641b1e45aab355d012afe4266b7f"
-dependencies = [
- "bitflags 2.11.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f705c977d90ace597049252ae1d7fec907edc0fa7616cc91bf5508d0f4006"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-path",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.75.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d59882d2fdab5e609b0c452a6ef9a3bd12ef6b694be4f82ab8f126ad0969864"
-dependencies = [
- "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c44db57ebbbeaad9972c2a60662142660427a1f0a7529314d53fefb4fedad24"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-error",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "memmap2",
- "parking_lot",
- "smallvec",
- "thiserror 2.0.18",
- "uluru",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pathspec"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f4cc23f55ca7c190bf243f1a4e2139d4522022f724fb0dfc06c93f65a01ef6"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
- "gix-path",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-prompt"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4806f1ebf969cd54d178ccd975911ef1829aeccea0b27630e63c9d26c8347d7f"
-dependencies = [
- "gix-command",
- "gix-config-value",
- "parking_lot",
- "rustix",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f20837b0c70b65f6ac77886be033de3b69d5879f99128b47c42665ab0a17c2"
-dependencies = [
- "bstr",
- "gix-credentials",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-ref",
- "gix-refspec",
- "gix-revwalk",
- "gix-shallow",
- "gix-trace",
- "gix-transport",
- "gix-utils",
- "maybe-async",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
-dependencies = [
- "bstr",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ce400a770a7952e45267803192cc2d1fe0afa08e2c08dde32e04c7908c6e61"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-glob",
- "gix-hash",
- "gix-revision",
- "gix-validate",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c719cf7d669439e1fca735bd1c4de54d43c5d30e8883fd6063c4924b213d70c9"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "gix-trace",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a50b30aa0c6e6de43c723359c5809a96275a3aa92d323ef7f58b1cdd60f16"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
-dependencies = [
- "bitflags 2.11.1",
- "gix-path",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-shallow"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189386b5da5285216cc0ede89eff5a943d5261fc794241ee6ec5360b77df15ad"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-lock",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db1840fe723c6264ee596e5a179e1b9a2df59351f09bae9cea570a472a790bc0"
-dependencies = [
- "bstr",
- "gix-config",
- "gix-path",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "21.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
-dependencies = [
- "gix-fs",
- "libc",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
-
-[[package]]
-name = "gix-transport"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1064c7ffa5a915014a6a5b71fbc5299462ae655348bed23e083b4a735076c3"
-dependencies = [
- "base64",
- "bstr",
- "gix-command",
- "gix-credentials",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
- "reqwest",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f8b53b4c56b01c43a4491c4edfe2ce66c654eb86232205172ceb1650d21c55"
-dependencies = [
- "bitflags 2.11.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
-dependencies = [
- "bstr",
- "gix-path",
- "percent-encoding",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
-dependencies = [
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-validate",
-]
-
-[[package]]
-name = "gix-worktree-state"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9895abc7654cbd8e102d6a765d3bdfa1567fcd5d2849b8e3d3da6405d64913c9"
-dependencies = [
- "bstr",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-worktree",
- "io-close",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "glam"
@@ -1832,49 +458,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1887,15 +483,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "http"
@@ -2100,10 +687,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -2127,29 +714,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "io-close"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
-dependencies = [
- "libc",
- "winapi",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2159,116 +732,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2283,43 +750,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lcov2cobertura"
-version = "1.0.9"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5d75e3487295500b5426ad473805696126915b3e647ecdd5b9597a17766c6a"
-dependencies = [
- "anyhow",
- "quick-xml",
- "regex",
- "rustc-demangle",
-]
-
-[[package]]
-name = "lexopt"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2340,25 +786,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2367,17 +798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
-]
-
-[[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2396,19 +816,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2446,15 +859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normpath"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2504,27 +908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "opener"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fa337e0cf13357c13ef1dc108df1333eb192f75fc170bea03fcf1fd404c2ee"
-dependencies = [
- "bstr",
- "normpath",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -2553,53 +940,14 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -2618,18 +966,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
- "serde",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,30 +976,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "platforms"
-version = "3.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -2690,97 +1002,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prodash"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "quitters"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88ccde7d84d2115b250b5cba923973fc42fe23ad42d9d63bb129d956a6db014"
-dependencies = [
- "once_cell",
- "regex",
- "semver",
 ]
 
 [[package]]
@@ -2797,6 +1034,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2825,35 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2893,7 +1107,6 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2907,20 +1120,15 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2951,18 +1159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc-stable-hash"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,7 +1186,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2999,53 +1194,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3053,36 +1208,9 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
-]
-
-[[package]]
-name = "rustsec"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4fa3512c10790d18e6cfdadc34fa753cc27cb2826d70c427baa9a69bbf11f3"
-dependencies = [
- "auditable-info",
- "auditable-serde",
- "binfarce",
- "cargo-lock",
- "cvss",
- "fs-err",
- "gix",
- "home",
- "once_cell",
- "platforms",
- "quitters",
- "semver",
- "serde",
- "tame-index",
- "thiserror 2.0.18",
- "time",
- "toml 0.9.12+spec-1.1.0",
- "url",
 ]
 
 [[package]]
@@ -3092,43 +1220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ruzstd"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "serde",
- "zeroize",
 ]
 
 [[package]]
@@ -3159,16 +1256,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "sentry"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93b3e19f45495ddd41d8222a152c48c84f6ba45abe9c69e2527e9cdea29bb5b"
+checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -3185,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fafe70e622ded2d3b75dc7889ecb5391b4c22d850b5a36e81af4615cbe687f2"
+checksum = "6b8bb4a03e7cf5562ea7ff658b2a254c06d2e09b2ec7383dfd5fc7025d40227b"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -3196,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84c325ace9ca2388e510fe7d6672b5d60cd8b3bd0eb4bb4ee8314c323cd686"
+checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
 dependencies = [
  "backtrace",
  "regex",
@@ -3207,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f5abf20c42cb1593ec1638976e2647da55f79bccac956444c1707b6cce259a"
+checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
 dependencies = [
  "rand",
  "sentry-types",
@@ -3220,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0260dcb52562b6a79ae7702312a26dba94b79fb5baee7301087529e5ca4e872e"
+checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3230,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c035f3a0a8671ae1a231c5b457abb68b71acba2bf3054dab2a09a9d4ea487e"
+checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
 dependencies = [
  "bitflags 2.11.1",
  "sentry-backtrace",
@@ -3243,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d8e81058ec155992191f61c7b29bfa7b2cf12012131e7cdc0678020898a7c9"
+checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
 dependencies = [
  "debugid",
  "hex",
@@ -3311,36 +1404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest",
- "sha1",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,60 +1413,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "shared_thread"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
-
-[[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3416,16 +1429,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
-dependencies = [
- "borsh",
- "serde_core",
-]
 
 [[package]]
 name = "socket2"
@@ -3442,18 +1445,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -3504,60 +1495,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tame-index"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51563c6639245219c077420e0a207e99b5e82e2e6bb78fd4898d42028ea7dde"
-dependencies = [
- "camino",
- "crossbeam-channel",
- "http",
- "libc",
- "memchr",
- "rayon",
- "reqwest",
- "rustc-stable-hash",
- "semver",
- "serde",
- "serde_json",
- "smol_str",
- "thiserror 2.0.18",
- "tokio",
- "toml-span",
- "twox-hash",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -3651,21 +1598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,46 +1651,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml-span"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22ba417d437b5fa5dcba6c27dbd6c14f38845315b724d89fed73b7a426451b7"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -3771,24 +1666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,19 +1673,10 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -3816,18 +1684,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
-name = "topological-sort"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower"
@@ -3846,21 +1702,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "async-compression",
  "bitflags 2.11.1",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3960,46 +1811,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "uluru"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "unicode-bom"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -4062,12 +1883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,31 +1918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,7 +1938,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4207,12 +2006,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.207.0"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4220,16 +2044,6 @@ name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4245,37 +2059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,16 +2070,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4314,31 +2088,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4348,22 +2105,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4372,22 +2117,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4396,22 +2129,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4420,22 +2141,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4447,10 +2156,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "1.0.3"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -4459,20 +2171,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "yoke"
@@ -4519,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4576,12 +2357,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ memmap2 = "0.9"
 libc = "0.2"
 serde_json = "1.0"
 sentry = { version = "0.48.1", default-features = false, features = ["backtrace", "panic", "anyhow", "transport"] }
-fmt = "0.1.0"
-cargo-llvm-cov = "0.8.7"
-cargo-audit = "0.22.1"
 
 [dev-dependencies]
 dotenvy = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ memmap2 = "0.9"
 libc = "0.2"
 serde_json = "1.0"
 sentry = { version = "0.48.1", default-features = false, features = ["backtrace", "panic", "anyhow", "transport"] }
+fmt = "0.1.0"
+cargo-llvm-cov = "0.8.7"
+cargo-audit = "0.22.1"
 
 [dev-dependencies]
 dotenvy = "0.15"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,6 +107,7 @@ Instrumented launch sites:
 | `src/moe/checkpoint.rs` | GGUF parse, mmap, tensor slicing, dequantization helpers |
 | `src/moe/adapter.rs` | Model-family adapter resolution and tensor selection |
 | `src/moe/routing.rs` | Router math (gate scores, resampling, normalization, top-k) |
+| `src/moe/safetensors.rs` | Safetensors header inspection and deterministic manifest generation |
 | `src/projector.rs` | `ProjectionMode` spike-to-embedding projection |
 | `src/funnel.rs` | Telemetry funnel, signed split banks, GIF hidden layer |
 | `src/telemetry.rs` | `TelemetryEncoder` and `TelemetrySnapshot` bridge |
@@ -116,7 +117,9 @@ Instrumented launch sites:
 
 ## Model loading and routing bridge
 
-The model-loading interface is custom and GGUF-backed.
+The runtime model-loading interface is custom and GGUF-backed. Safetensors are
+supported as an inspection/import surface for checkpoint anatomy manifests; they
+do not replace GGUF-backed routing in the current runtime path.
 
 Important nuance: the adapter chooses the GPU synapse path from the selected
 tensor's actual `ggml_type`, not from the checkpoint filename or the GGUF-wide
@@ -136,6 +139,17 @@ path when `blk.0.attn_q.weight` is stored as `Q8_0` inside the GGUF.
   - dequantized `Q8_0`
   - dequantized `Q5_K`
   - synthetic fallback
+
+`moe::safetensors`:
+
+- reads only Safetensors headers, not tensor payload bytes
+- accepts a `.safetensors` file, a Hugging Face `.safetensors.index.json`, or a
+  directory containing either an index or direct shards
+- records tensor names, dtypes, shapes, byte sizes, data offsets, and shard paths
+  relative to the inspected root
+- labels recognizable MoE router and expert candidates from tensor names and
+  simple rank-2 router-shape heuristics
+- emits deterministic JSON for experiment setup without creating a project
 
 When the selected tensor is dequantized and not already square, the GPU
 temporal path resamples it to the neuron grid instead of rejecting the

--- a/docs/RUN_PROFILES.md
+++ b/docs/RUN_PROFILES.md
@@ -98,6 +98,24 @@ actual `ggml_type` of `blk.0.attn_q.weight`, not on the filename suffix.
 The example also writes `<output_root>/synapse_diagnostic.json` for a structured
 record of the same fields.
 
+## Safetensors manifest
+
+| Profile | Command |
+|---------|---------|
+| Inspect a Safetensors checkpoint or shard directory | `cargo run --example safetensors_manifest --no-default-features -- <checkpoint-or-dir> artifacts/safetensors_manifest.json` |
+
+Use Safetensors manifests when the goal is checkpoint anatomy: tensor names,
+dtypes, shapes, byte sizes, source shards, and recognizable MoE router/expert
+candidates. The manifest generator reads only Safetensors headers plus optional
+Hugging Face `.safetensors.index.json` metadata; it does not create a project,
+run activation tracing, or load tensor payload bytes.
+
+Use GGUF when the goal is current `corinth-canal` runtime routing. The
+`OlmoeRouter` path remains GGUF-backed for token embedding extraction, routing
+tensor access, and GPU synapse-source selection. Safetensors support is a setup
+and inspection adapter for experiment preparation, not a replacement for the
+runtime GGUF bridge.
+
 ## CSV replay
 
 | Profile | Command |

--- a/examples/safetensors_manifest.rs
+++ b/examples/safetensors_manifest.rs
@@ -1,0 +1,49 @@
+//! Generate a deterministic JSON manifest from Safetensors checkpoint headers.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --example safetensors_manifest --no-default-features -- <checkpoint-or-dir> <output.json>
+//! ```
+
+use corinth_canal::moe::safetensors::write_safetensors_manifest;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args_os().skip(1);
+    let checkpoint_path = args.next().map(PathBuf::from).ok_or_else(|| {
+        "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>"
+            .to_string()
+    })?;
+    let output_path = args.next().map(PathBuf::from).ok_or_else(|| {
+        "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>"
+            .to_string()
+    })?;
+    if args.next().is_some() {
+        return Err(
+            "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>"
+                .into(),
+        );
+    }
+
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let manifest = write_safetensors_manifest(&checkpoint_path, &output_path)?;
+    println!(
+        "wrote {} tensors from {} shard(s) to {}",
+        manifest.checkpoint.tensor_count,
+        manifest.checkpoint.shard_count,
+        output_path.display()
+    );
+    println!(
+        "router_candidates={} expert_candidates={}",
+        manifest.candidates.router_tensors.len(),
+        manifest.candidates.expert_tensors.len()
+    );
+
+    Ok(())
+}

--- a/examples/safetensors_manifest.rs
+++ b/examples/safetensors_manifest.rs
@@ -7,7 +7,7 @@
 //! ```
 
 use corinth_canal::moe::safetensors::write_safetensors_manifest;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const USAGE: &str =
     "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>";
@@ -26,11 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err(USAGE.into());
     }
 
-    if let Some(parent) = output_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
-    }
+    create_output_parent_dir(&output_path)?;
 
     let manifest = write_safetensors_manifest(&checkpoint_path, &output_path)?;
     println!(
@@ -45,5 +41,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         manifest.candidates.expert_tensors.len()
     );
 
+    Ok(())
+}
+
+fn create_output_parent_dir(output_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(parent) = output_path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(parent)?;
     Ok(())
 }

--- a/examples/safetensors_manifest.rs
+++ b/examples/safetensors_manifest.rs
@@ -9,27 +9,27 @@
 use corinth_canal::moe::safetensors::write_safetensors_manifest;
 use std::path::PathBuf;
 
+const USAGE: &str =
+    "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = std::env::args_os().skip(1);
-    let checkpoint_path = args.next().map(PathBuf::from).ok_or_else(|| {
-        "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>"
-            .to_string()
-    })?;
-    let output_path = args.next().map(PathBuf::from).ok_or_else(|| {
-        "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>"
-            .to_string()
-    })?;
+    let checkpoint_path = args
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(|| USAGE.to_string())?;
+    let output_path = args
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(|| USAGE.to_string())?;
     if args.next().is_some() {
-        return Err(
-            "usage: safetensors_manifest <checkpoint.safetensors|index.json|directory> <output.json>"
-                .into(),
-        );
+        return Err(USAGE.into());
     }
 
-    if let Some(parent) = output_path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        std::fs::create_dir_all(parent)?;
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
 
     let manifest = write_safetensors_manifest(&checkpoint_path, &output_path)?;

--- a/examples/safetensors_manifest.rs
+++ b/examples/safetensors_manifest.rs
@@ -26,10 +26,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err(USAGE.into());
     }
 
-    if let Some(parent) = output_path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        std::fs::create_dir_all(parent)?;
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
 
     let manifest = write_safetensors_manifest(&checkpoint_path, &output_path)?;

--- a/examples/safetensors_manifest.rs
+++ b/examples/safetensors_manifest.rs
@@ -26,10 +26,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err(USAGE.into());
     }
 
-    if let Some(parent) = output_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
     }
 
     let manifest = write_safetensors_manifest(&checkpoint_path, &output_path)?;

--- a/src/gpu/wrappers/accelerator.rs
+++ b/src/gpu/wrappers/accelerator.rs
@@ -366,7 +366,7 @@ impl GpuAccelerator {
 
         let f16_weights = match state.weights_f16.as_mut() {
             Some(weights_f16) => weights_f16,
-            None => {
+            _ => {
                 state.weights_f16 = Some(GpuBuffer::<u16>::alloc(expected)?);
                 state
                     .weights_f16

--- a/src/gpu/wrappers/kernel.rs
+++ b/src/gpu/wrappers/kernel.rs
@@ -149,7 +149,8 @@ impl KernelModule {
             )));
         }
 
-        match Module::from_fatbin(bytes, &[]) {
+        let empty_opts: &[cust::module::ModuleJitOption] = &[];
+        match Module::from_fatbin(bytes, empty_opts) {
             Ok(module) => Ok(module),
             Err(e) => {
                 let (error_log, info_log) = capture_jit_log_split(bytes);

--- a/src/gpu/wrappers/kernel.rs
+++ b/src/gpu/wrappers/kernel.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "cuda")]
 // ════════════════════════════════════════════════════════════════════
 //  gpu/kernel.rs — Fatbin Module Loading and Kernel Management
 //
@@ -20,7 +21,7 @@
 use super::error::{GpuError, GpuResult};
 use super::sentry_capture::{LaunchContext, LaunchType, capture_launch_failure};
 use cust::function::Function;
-use cust::module::Module;
+use cust::module::{Module, ModuleJitOption};
 use cust::sys as cuda;
 use std::collections::HashMap;
 use std::ffi::c_void;
@@ -149,8 +150,8 @@ impl KernelModule {
             )));
         }
 
-        let empty_opts: &[cust::module::ModuleJitOption] = &[];
-        match Module::from_fatbin(bytes, empty_opts) {
+        let options = Vec::<ModuleJitOption>::new();
+        match Module::from_fatbin(bytes, &options) {
             Ok(module) => Ok(module),
             Err(e) => {
                 let (error_log, info_log) = capture_jit_log_split(bytes);

--- a/src/gpu/wrappers/sentry_capture.rs
+++ b/src/gpu/wrappers/sentry_capture.rs
@@ -164,7 +164,8 @@ pub fn capture_launch_failure(
             scope.set_fingerprint(Some(&[context.kernel_name.as_str(), error_category]));
         },
         || {
-            sentry::capture_message(&event_message, sentry::Level::Error);
+            let msg = event_message.as_str();
+            sentry::capture_message(msg, sentry::Level::Error);
         },
     );
 }

--- a/src/moe/checkpoint.rs
+++ b/src/moe/checkpoint.rs
@@ -758,7 +758,7 @@ fn quantization_label(file_type: Option<u32>) -> String {
         Some(0) => "F32".into(),
         Some(1) => "F16".into(),
         Some(other) => format!("GGUF({other})"),
-        None => "GGUF".into(),
+        _ => "GGUF".into(),
     }
 }
 

--- a/src/moe/mod.rs
+++ b/src/moe/mod.rs
@@ -4,10 +4,12 @@
 //! - `moe/checkpoint.rs` for GGUF parsing + mapped tensor access
 //! - `moe/adapter.rs` for model-family detection and tensor selection
 //! - `moe/routing.rs` for routing math and embedding resampling
+//! - `moe/safetensors.rs` for Safetensors header inspection and manifests
 
 mod adapter;
 mod checkpoint;
 mod routing;
+pub mod safetensors;
 
 use self::adapter::{ModelAdapter, SynapseSource, resolve_adapter};
 use self::checkpoint::{

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -75,7 +75,7 @@ pub fn inspect_safetensors_checkpoint(path: impl AsRef<Path>) -> Result<Safetens
     }
 
     if is_safetensors_index(input) {
-        let root = input.parent().unwrap_or_else(|| Path::new("."));
+        let root = parent_or_current(input);
         return inspect_index(root, input);
     }
 
@@ -110,7 +110,7 @@ pub fn write_safetensors_manifest(
 }
 
 fn inspect_single_file(path: &Path) -> Result<SafetensorsManifest> {
-    let root = path.parent().unwrap_or_else(|| Path::new("."));
+    let root = parent_or_current(path);
     let shard = inspect_shard(path, root)?;
     Ok(build_manifest(
         "single_file",
@@ -151,6 +151,18 @@ fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> 
 
     let mut metadata = stringify_metadata("index", raw.metadata);
     metadata.insert("index_tensor_count".into(), index_tensor_count.to_string());
+    let indexed_shards = shards.iter().cloned().collect::<BTreeSet<_>>();
+    let unreferenced_shards = list_safetensors_files(root)?
+        .into_iter()
+        .filter(|path| !indexed_shards.contains(path))
+        .map(|path| relative_path(&path, root))
+        .collect::<Vec<_>>();
+    if !unreferenced_shards.is_empty() {
+        metadata.insert(
+            "index:unreferenced_shards".into(),
+            unreferenced_shards.join(","),
+        );
+    }
     let index_file = Some(relative_path(index_path, root));
     inspect_index_shards(root, index_file, shards, expected_by_shard, metadata)
 }
@@ -406,6 +418,8 @@ fn parse_header(
         });
     }
 
+    reject_overlapping_tensor_ranges(path, &tensors)?;
+
     Ok(ShardInspection { metadata, tensors })
 }
 
@@ -463,10 +477,12 @@ fn read_index(path: &Path) -> Result<RawIndex> {
 }
 
 fn find_index_file(root: &Path) -> Result<Option<PathBuf>> {
-    let mut candidates = read_dir_paths(root)?
-        .into_iter()
-        .filter(|path| is_safetensors_index(path))
-        .collect::<Vec<_>>();
+    let mut candidates = Vec::new();
+    for path in read_dir_paths(root)? {
+        if is_safetensors_index(&path) && is_regular_file(&path)? {
+            candidates.push(path);
+        }
+    }
     candidates.sort();
     if candidates.len() > 1 {
         let names = candidates
@@ -483,13 +499,57 @@ fn find_index_file(root: &Path) -> Result<Option<PathBuf>> {
 }
 
 fn list_safetensors_files(root: &Path) -> Result<Vec<PathBuf>> {
-    let mut shards = read_dir_paths(root)?
-        .into_iter()
-        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some(SAFETENSORS_EXTENSION))
-        .map(|path| validate_path_stays_under_root(root, &path).map(|()| path))
-        .collect::<Result<Vec<_>>>()?;
+    let mut shards = Vec::new();
+    for path in read_dir_paths(root)? {
+        if path.extension().and_then(|ext| ext.to_str()) != Some(SAFETENSORS_EXTENSION) {
+            continue;
+        }
+        if !is_regular_file(&path)? {
+            continue;
+        }
+        validate_path_stays_under_root(root, &path)?;
+        shards.push(path);
+    }
     shards.sort();
     Ok(shards)
+}
+
+fn is_regular_file(path: &Path) -> Result<bool> {
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file())
+        .map_err(|e| model_load(path, e.to_string()))
+}
+
+fn reject_overlapping_tensor_ranges(
+    path: &Path,
+    tensors: &[SafetensorsTensorRecord],
+) -> Result<()> {
+    let mut ranges = tensors
+        .iter()
+        .map(|tensor| {
+            (
+                tensor.data_offsets[0],
+                tensor.data_offsets[1],
+                tensor.name.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|(start, end, name)| (*start, *end, *name));
+
+    let mut previous: Option<(usize, usize, &str)> = None;
+    for (start, end, name) in ranges {
+        if let Some((_, previous_end, previous_name)) = previous
+            && start < previous_end
+        {
+            return Err(model_load(
+                path,
+                format!("tensor '{name}' data range overlaps tensor '{previous_name}'"),
+            ));
+        }
+        previous = Some((start, end, name));
+    }
+
+    Ok(())
 }
 
 fn read_dir_paths(root: &Path) -> Result<Vec<PathBuf>> {
@@ -563,7 +623,7 @@ fn reject_output_checkpoint_conflict(
     let root = if input_metadata.is_dir() {
         checkpoint_path
     } else {
-        checkpoint_path.parent().unwrap_or_else(|| Path::new("."))
+        parent_or_current(checkpoint_path)
     };
 
     let mut checkpoint_files = BTreeSet::new();
@@ -601,7 +661,7 @@ fn canonical_existing_or_parent(path: &Path) -> Result<PathBuf> {
     if path.exists() {
         return fs::canonicalize(path).map_err(|e| model_load(path, e.to_string()));
     }
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent = parent_or_current(path);
     let file_name = path.file_name().ok_or_else(|| {
         model_load(
             path,
@@ -622,6 +682,12 @@ fn validate_path_stays_under_root(root: &Path, path: &Path) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn parent_or_current(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
 }
 
 fn is_safetensors_index(path: &Path) -> bool {
@@ -911,6 +977,11 @@ mod tests {
             }"#,
             131_072,
         );
+        write_safetensors(
+            &dir.join("unused.safetensors"),
+            r#"{"unused.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
         let index = dir.join("model.safetensors.index.json");
         fs::write(
             &index,
@@ -921,6 +992,14 @@ mod tests {
         let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
         assert_eq!(manifest.checkpoint.tensor_count, 1);
         assert_eq!(manifest.tensors[0].name, "a.router.weight");
+        assert_eq!(
+            manifest
+                .checkpoint
+                .metadata
+                .get("index:unreferenced_shards")
+                .map(String::as_str),
+            Some("unused.safetensors")
+        );
 
         fs::write(
             &index,
@@ -943,6 +1022,48 @@ mod tests {
 
         let err = inspect_safetensors_checkpoint(&path).unwrap_err();
         assert!(err.to_string().contains("byte size mismatch"));
+    }
+
+    #[test]
+    fn rejects_overlapping_tensor_ranges() {
+        let dir = temp_dir("overlap");
+        let path = dir.join("bad.safetensors");
+        write_safetensors(
+            &path,
+            r#"{
+                "a.weight": {"dtype": "F16", "shape": [4], "data_offsets": [0, 8]},
+                "b.weight": {"dtype": "F16", "shape": [4], "data_offsets": [4, 12]}
+            }"#,
+            12,
+        );
+
+        let err = inspect_safetensors_checkpoint(&path).unwrap_err();
+        assert!(err.to_string().contains("data range overlaps"));
+    }
+
+    #[test]
+    fn directory_scan_ignores_non_file_safetensors_entries() {
+        let dir = temp_dir("non-file-entry");
+        fs::create_dir(dir.join("scratch.safetensors")).unwrap();
+        write_safetensors(
+            &dir.join("model.safetensors"),
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+
+        let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
+        assert_eq!(manifest.checkpoint.shard_count, 1);
+        assert_eq!(manifest.checkpoint.tensor_count, 1);
+        assert_eq!(manifest.tensors[0].source_shard, "model.safetensors");
+    }
+
+    #[test]
+    fn bare_paths_resolve_parent_as_current_directory() {
+        assert_eq!(
+            parent_or_current(Path::new("model.safetensors")),
+            Path::new(".")
+        );
+        assert!(canonical_existing_or_parent(Path::new("manifest.json")).is_ok());
     }
 
     #[test]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -444,9 +444,8 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<&'static str> {
         labels.push("possible_moe_router_shape");
     }
 
-    let has_expert_context = lower.contains("experts")
-        || lower.contains(".expert")
-        || lower.contains("/expert");
+    let has_expert_context =
+        lower.contains("experts") || lower.contains(".expert") || lower.contains("/expert");
     let expert_weight_name = lower.contains("gate_proj")
         || lower.contains("up_proj")
         || lower.contains("down_proj")

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1310,7 +1310,7 @@ mod tests {
             manifest
                 .checkpoint
                 .metadata
-                .get("index:unreferenced_shards")
+                .get(INDEX_UNREFERENCED_SHARDS_KEY)
                 .map(String::as_str),
             Some(r#"["unused.safetensors"]"#)
         );

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -446,8 +446,7 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<&'static str> {
 
     let has_expert_context = lower.contains("experts")
         || lower.contains(".expert")
-        || lower.contains("/expert")
-        || lower.contains("block_sparse_moe.experts");
+        || lower.contains("/expert");
     let expert_weight_name = lower.contains("gate_proj")
         || lower.contains("up_proj")
         || lower.contains("down_proj")

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -20,6 +20,9 @@ use std::path::{Component, Path, PathBuf};
 const SAFETENSORS_EXTENSION: &str = "safetensors";
 const MAX_HEADER_BYTES: usize = 64 * 1024 * 1024;
 const MAX_INDEX_BYTES: u64 = 64 * 1024 * 1024;
+/// Unambiguous boundary between shard relative path and logical metadata key in
+/// `shard:*` manifest keys (avoids ambiguity when the logical key contains `:`).
+const SHARD_METADATA_KEY_SEP: char = '\u{001e}';
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SafetensorsManifest {
@@ -165,10 +168,13 @@ fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> 
         .map(|path| relative_path(&path, root))
         .collect::<Vec<_>>();
     if !unreferenced_shards.is_empty() {
-        metadata.insert(
-            "index:unreferenced_shards".into(),
-            unreferenced_shards.join(","),
-        );
+        let encoded = serde_json::to_string(&unreferenced_shards).map_err(|e| {
+            model_load(
+                index_path,
+                format!("serialize index:unreferenced_shards list: {e}"),
+            )
+        })?;
+        metadata.insert("index:unreferenced_shards".into(), encoded);
     }
     let index_file = Some(relative_path(index_path, root));
     inspect_index_shards(root, index_file, shards, expected_by_shard, metadata)
@@ -626,13 +632,27 @@ fn dtype_size_bytes(dtype: &str) -> Option<usize> {
     }
 }
 
+fn shard_metadata_namespaced_key(shard_path: &str, key: &str) -> String {
+    format!("shard:{shard_path}{SHARD_METADATA_KEY_SEP}{key}")
+}
+
+fn namespaced_shard_metadata_logical_key(namespaced: &str) -> Option<&str> {
+    let rest = namespaced.strip_prefix("shard:")?;
+    if let Some((_, logical_key)) = rest.split_once(SHARD_METADATA_KEY_SEP) {
+        return Some(logical_key);
+    }
+    // Legacy keys used `shard:{path}:{key}` with a single `:` separator; this
+    // remains ambiguous when `key` contains `:`, so prefer new keys above.
+    rest.rsplit_once(':').map(|(_, logical_key)| logical_key)
+}
+
 fn merge_shard_metadata(
     metadata: &mut BTreeMap<String, String>,
     shard_path: &str,
     shard_metadata: BTreeMap<String, String>,
 ) {
     for (key, value) in shard_metadata {
-        let namespaced_key = format!("shard:{shard_path}:{key}");
+        let namespaced_key = shard_metadata_namespaced_key(shard_path, &key);
         match metadata.get(&key) {
             None => {
                 if !has_shard_metadata_key(metadata, &key) {
@@ -652,12 +672,20 @@ fn merge_shard_metadata(
 }
 
 fn has_shard_metadata_key(metadata: &BTreeMap<String, String>, key: &str) -> bool {
-    metadata.keys().any(|existing| {
-        existing
-            .strip_prefix("shard:")
-            .and_then(|rest| rest.rsplit_once(':'))
-            .is_some_and(|(_, shard_key)| shard_key == key)
-    })
+    metadata
+        .keys()
+        .any(|existing| namespaced_shard_metadata_logical_key(existing).is_some_and(|k| k == key))
+}
+
+fn parse_unreferenced_shards_metadata(encoded: &str) -> Vec<String> {
+    if let Ok(paths) = serde_json::from_str::<Vec<String>>(encoded) {
+        return paths;
+    }
+    encoded
+        .split(',')
+        .filter(|shard| !shard.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 fn reject_output_checkpoint_conflict(
@@ -689,10 +717,7 @@ fn reject_output_checkpoint_conflict(
         .metadata
         .get("index:unreferenced_shards")
     {
-        for shard in unreferenced_shards
-            .split(',')
-            .filter(|shard| !shard.is_empty())
-        {
+        for shard in parse_unreferenced_shards_metadata(unreferenced_shards) {
             checkpoint_files.insert(root.join(shard));
         }
     }
@@ -1206,7 +1231,7 @@ mod tests {
                 .metadata
                 .get("index:unreferenced_shards")
                 .map(String::as_str),
-            Some("unused.safetensors")
+            Some(r#"["unused.safetensors"]"#)
         );
 
         fs::write(
@@ -1348,7 +1373,7 @@ mod tests {
             manifest
                 .checkpoint
                 .metadata
-                .get("shard:a.safetensors:format")
+                .get(&shard_metadata_namespaced_key("a.safetensors", "format"))
                 .map(String::as_str),
             Some("pt")
         );
@@ -1356,10 +1381,61 @@ mod tests {
             manifest
                 .checkpoint
                 .metadata
-                .get("shard:b.safetensors:format")
+                .get(&shard_metadata_namespaced_key("b.safetensors", "format"))
                 .map(String::as_str),
             Some("np")
         );
+    }
+
+    #[test]
+    fn colon_in_metadata_logical_key_conflict_does_not_restore_base_key() {
+        let mut metadata = BTreeMap::new();
+        let mut first = BTreeMap::new();
+        first.insert("my:key".to_string(), "a".to_string());
+        merge_shard_metadata(&mut metadata, "x.safetensors", first);
+
+        let mut second = BTreeMap::new();
+        second.insert("my:key".to_string(), "b".to_string());
+        merge_shard_metadata(&mut metadata, "y.safetensors", second);
+
+        assert!(!metadata.contains_key("my:key"));
+
+        let mut third = BTreeMap::new();
+        third.insert("my:key".to_string(), "c".to_string());
+        merge_shard_metadata(&mut metadata, "z.safetensors", third);
+
+        assert!(!metadata.contains_key("my:key"));
+        assert_eq!(
+            metadata
+                .get(&shard_metadata_namespaced_key("z.safetensors", "my:key"))
+                .map(String::as_str),
+            Some("c")
+        );
+    }
+
+    #[test]
+    fn rejects_manifest_output_that_overwrites_unreferenced_index_shard_with_comma_in_name() {
+        let dir = temp_dir("output-unreferenced-comma");
+        let main_shard = dir.join("model-00001-of-00001.safetensors");
+        write_safetensors(
+            &main_shard,
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+        let unreferenced = dir.join("a,b.safetensors");
+        write_safetensors(
+            &unreferenced,
+            r#"{"b.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{"weight_map": {"a.weight": "model-00001-of-00001.safetensors"}}"#,
+        )
+        .unwrap();
+
+        let err = write_safetensors_manifest(&dir, &unreferenced).unwrap_err();
+        assert!(err.to_string().contains("must not overwrite"));
     }
 
     #[test]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -771,10 +771,15 @@ fn paths_refer_to_same_file(left: &Path, right: &Path) -> std::io::Result<bool> 
 
     #[cfg(windows)]
     {
-        Ok(
-            left_meta.volume_serial_number() == right_meta.volume_serial_number()
-                && left_meta.file_index() == right_meta.file_index(),
-        )
+        match (
+            left_meta.volume_serial_number(),
+            right_meta.volume_serial_number(),
+            left_meta.file_index(),
+            right_meta.file_index(),
+        ) {
+            (Some(vl), Some(vr), Some(il), Some(ir)) => Ok(vl == vr && il == ir),
+            _ => Ok(fs::canonicalize(left)? == fs::canonicalize(right)?),
+        }
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -547,7 +547,7 @@ format!("tensor data offset {} does not fit in usize", tensor.data_offsets[0]),
     let mut previous_name: Option<&str> = None;
     for (start, end, name) in ranges {
         if start < expected_start {
-            return Err(model_load(
+format!("tensor data offset {} does not fit in usize", tensor.data_offsets[1]),
                 path,
                 format!(
                     "tensor '{name}' data range overlaps tensor '{}'",

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -543,7 +543,7 @@ fn reject_tensor_data_ranges(
         .collect::<Vec<_>>();
     ranges.sort_by_key(|(start, end, name)| (*start, *end, *name));
 
-    let mut expected_start = 0usize;
+format!("tensor data offset {} does not fit in usize", tensor.data_offsets[0]),
     let mut previous_name: Option<&str> = None;
     for (start, end, name) in ranges {
         if start < expected_start {

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -20,6 +20,7 @@ use std::path::{Component, Path, PathBuf};
 const SAFETENSORS_EXTENSION: &str = "safetensors";
 const MAX_HEADER_BYTES: usize = 64 * 1024 * 1024;
 const MAX_INDEX_BYTES: u64 = 64 * 1024 * 1024;
+const INDEX_UNREFERENCED_SHARDS_KEY: &str = "index:unreferenced_shards";
 /// Unambiguous boundary between shard relative path and logical metadata key in
 /// `shard:*` manifest keys (avoids ambiguity when the logical key contains `:`).
 const SHARD_METADATA_KEY_SEP: char = '\u{001e}';
@@ -160,6 +161,7 @@ fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> 
     let shards = expected_by_shard.keys().cloned().collect::<Vec<_>>();
 
     let mut metadata = stringify_metadata("index", raw.metadata);
+    metadata.remove(INDEX_UNREFERENCED_SHARDS_KEY);
     metadata.insert("index_tensor_count".into(), index_tensor_count.to_string());
     let indexed_shards = shards.iter().cloned().collect::<BTreeSet<_>>();
     let unreferenced_shards = list_safetensors_files(root)?
@@ -171,10 +173,10 @@ fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> 
         let encoded = serde_json::to_string(&unreferenced_shards).map_err(|e| {
             model_load(
                 index_path,
-                format!("serialize index:unreferenced_shards list: {e}"),
+                format!("serialize {INDEX_UNREFERENCED_SHARDS_KEY} list: {e}"),
             )
         })?;
-        metadata.insert("index:unreferenced_shards".into(), encoded);
+        metadata.insert(INDEX_UNREFERENCED_SHARDS_KEY.into(), encoded);
     }
     let index_file = Some(relative_path(index_path, root));
     inspect_index_shards(root, index_file, shards, expected_by_shard, metadata)
@@ -715,7 +717,7 @@ fn reject_output_checkpoint_conflict(
     if let Some(unreferenced_shards) = manifest
         .checkpoint
         .metadata
-        .get("index:unreferenced_shards")
+        .get(INDEX_UNREFERENCED_SHARDS_KEY)
     {
         for shard in parse_unreferenced_shards_metadata(unreferenced_shards) {
             checkpoint_files.insert(root.join(shard));
@@ -808,12 +810,15 @@ fn is_safetensors_index(path: &Path) -> bool {
 
 fn index_shard_path(root: &Path, index_path: &Path, relative: &str) -> Result<PathBuf> {
     let relative_path = Path::new(relative);
+    let mut normalized = PathBuf::new();
     let escapes_root = relative_path.is_absolute()
-        || relative_path.components().any(|component| {
-            matches!(
-                component,
-                Component::ParentDir | Component::RootDir | Component::Prefix(_)
-            )
+        || relative_path.components().any(|component| match component {
+            Component::Normal(part) => {
+                normalized.push(part);
+                false
+            }
+            Component::CurDir => false,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => true,
         });
     if escapes_root {
         return Err(model_load(
@@ -821,7 +826,13 @@ fn index_shard_path(root: &Path, index_path: &Path, relative: &str) -> Result<Pa
             format!("index shard path '{relative}' must stay within the checkpoint directory"),
         ));
     }
-    let candidate = root.join(relative_path);
+    if normalized.as_os_str().is_empty() {
+        return Err(model_load(
+            index_path,
+            format!("index shard path '{relative}' must name a Safetensors shard"),
+        ));
+    }
+    let candidate = root.join(normalized);
     validate_path_stays_under_root(root, &candidate)?;
     Ok(candidate)
 }
@@ -1089,6 +1100,61 @@ mod tests {
         assert_eq!(manifest.tensors[0].name, "a.router.weight");
         assert_eq!(manifest.tensors[1].name, "z.weight");
         assert_eq!(manifest.candidates.router_tensors, vec!["a.router.weight"]);
+    }
+
+    #[test]
+    fn user_index_metadata_cannot_spoof_unreferenced_shards() {
+        let dir = temp_dir("reserved-index-metadata");
+        write_safetensors(
+            &dir.join("model.safetensors"),
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{
+                "metadata": {"unreferenced_shards": "spoof.safetensors"},
+                "weight_map": {"a.weight": "model.safetensors"}
+            }"#,
+        )
+        .unwrap();
+
+        let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
+        assert!(
+            !manifest
+                .checkpoint
+                .metadata
+                .contains_key(INDEX_UNREFERENCED_SHARDS_KEY)
+        );
+    }
+
+    #[test]
+    fn index_shard_paths_are_normalized_before_deduplication() {
+        let dir = temp_dir("normalized-index-paths");
+        write_safetensors(
+            &dir.join("model.safetensors"),
+            r#"{
+                "a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]},
+                "b.weight": {"dtype": "F16", "shape": [1], "data_offsets": [2, 4]}
+            }"#,
+            4,
+        );
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{
+                "weight_map": {
+                    "a.weight": "model.safetensors",
+                    "b.weight": "./model.safetensors"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
+        assert_eq!(manifest.checkpoint.shard_count, 1);
+        assert_eq!(manifest.checkpoint.tensor_count, 2);
+        assert_eq!(manifest.tensors[0].source_shard, "model.safetensors");
+        assert_eq!(manifest.tensors[1].source_shard, "model.safetensors");
     }
 
     #[test]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -543,11 +543,11 @@ fn reject_tensor_data_ranges(
         .collect::<Vec<_>>();
     ranges.sort_by_key(|(start, end, name)| (*start, *end, *name));
 
-format!("tensor data offset {} does not fit in usize", tensor.data_offsets[0]),
+    let mut expected_start = 0usize;
     let mut previous_name: Option<&str> = None;
     for (start, end, name) in ranges {
         if start < expected_start {
-format!("tensor data offset {} does not fit in usize", tensor.data_offsets[1]),
+            return Err(model_load(
                 path,
                 format!(
                     "tensor '{name}' data range overlaps tensor '{}'",

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -162,24 +162,32 @@ fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> 
 
     let mut metadata = stringify_metadata("index", raw.metadata);
     metadata.remove(INDEX_UNREFERENCED_SHARDS_KEY);
-    metadata.insert("index_tensor_count".into(), index_tensor_count.to_string());
     let indexed_shards = shards.iter().cloned().collect::<BTreeSet<_>>();
     let unreferenced_shards = list_safetensors_files(root)?
         .into_iter()
         .filter(|path| !indexed_shards.contains(path))
         .map(|path| relative_path(&path, root))
         .collect::<Vec<_>>();
-    if !unreferenced_shards.is_empty() {
-        let encoded = serde_json::to_string(&unreferenced_shards).map_err(|e| {
+    let unreferenced_shards_json = if unreferenced_shards.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&unreferenced_shards).map_err(|e| {
             model_load(
                 index_path,
                 format!("serialize {INDEX_UNREFERENCED_SHARDS_KEY} list: {e}"),
             )
-        })?;
-        metadata.insert(INDEX_UNREFERENCED_SHARDS_KEY.into(), encoded);
-    }
+        })?)
+    };
     let index_file = Some(relative_path(index_path, root));
-    inspect_index_shards(root, index_file, shards, expected_by_shard, metadata)
+    inspect_index_shards(
+        root,
+        index_file,
+        shards,
+        expected_by_shard,
+        metadata,
+        index_tensor_count,
+        unreferenced_shards_json,
+    )
 }
 
 fn inspect_index_shards(
@@ -188,6 +196,8 @@ fn inspect_index_shards(
     shards: Vec<PathBuf>,
     expected_by_shard: BTreeMap<PathBuf, BTreeSet<String>>,
     mut metadata: BTreeMap<String, String>,
+    index_tensor_count: usize,
+    unreferenced_shards_json: Option<String>,
 ) -> Result<SafetensorsManifest> {
     let mut tensors = Vec::new();
     for shard_path in &shards {
@@ -224,6 +234,11 @@ fn inspect_index_shards(
                 .into_iter()
                 .filter(|tensor| expected.contains(&tensor.name)),
         );
+    }
+
+    metadata.insert("index_tensor_count".into(), index_tensor_count.to_string());
+    if let Some(encoded) = unreferenced_shards_json {
+        metadata.insert(INDEX_UNREFERENCED_SHARDS_KEY.into(), encoded);
     }
 
     Ok(build_manifest(

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -5,8 +5,9 @@
 //! not perform activation tracing or router math.
 
 use crate::error::{HybridError, Result};
-use serde::Deserialize;
-use serde_json::Value;
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use serde_json::{Map, Number, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File};
 use std::io::Read;
@@ -63,6 +64,8 @@ struct ShardInspection {
     metadata: BTreeMap<String, String>,
     tensors: Vec<SafetensorsTensorRecord>,
 }
+
+struct NoDuplicateValue(Value);
 
 /// Inspect a Safetensors file, sharded Safetensors index, or directory of
 /// Safetensors shards and return a deterministic JSON-serializable manifest.
@@ -316,8 +319,7 @@ fn inspect_shard(path: &Path, root: &Path) -> Result<ShardInspection> {
     let mut header_bytes = vec![0u8; header_len];
     file.read_exact(&mut header_bytes)
         .map_err(|e| model_load(path, format!("read Safetensors header: {e}")))?;
-    let header: Value = serde_json::from_slice(&header_bytes)
-        .map_err(|e| model_load(path, format!("parse Safetensors header JSON: {e}")))?;
+    let header = parse_json_rejecting_duplicate_keys(&header_bytes, path, "Safetensors header")?;
     parse_header(path, root, file_len, header_len_u64, header)
 }
 
@@ -341,7 +343,7 @@ fn parse_header(
 
     for (name, value) in object {
         if name == "__metadata__" {
-            metadata.extend(stringify_value_object(value));
+            metadata.extend(parse_metadata_object(path, value)?);
             continue;
         }
 
@@ -395,16 +397,14 @@ fn parse_header(
             ));
         }
         let byte_size = end - start;
-        match expected_tensor_byte_size(&dtype, &shape, path, name)? {
-            Some(expected) if expected != byte_size => {
-                return Err(model_load(
-                    path,
-                    format!(
-                        "tensor '{name}' byte size mismatch: shape/dtype imply {expected} bytes, data_offsets span {byte_size} bytes"
-                    ),
-                ));
-            }
-            _ => {}
+        let expected = expected_tensor_byte_size(&dtype, &shape, path, name)?;
+        if expected != byte_size {
+            return Err(model_load(
+                path,
+                format!(
+                    "tensor '{name}' byte size mismatch: shape/dtype imply {expected} bytes, data_offsets span {byte_size} bytes"
+                ),
+            ));
         }
 
         tensors.push(SafetensorsTensorRecord {
@@ -418,7 +418,7 @@ fn parse_header(
         });
     }
 
-    reject_overlapping_tensor_ranges(path, &tensors)?;
+    reject_tensor_data_ranges(path, &tensors, data_len)?;
 
     Ok(ShardInspection { metadata, tensors })
 }
@@ -471,13 +471,15 @@ fn read_index(path: &Path) -> Result<RawIndex> {
         ));
     }
     let bytes = fs::read(path).map_err(|e| model_load(path, e.to_string()))?;
-    serde_json::from_slice(&bytes).map_err(|e| model_load(path, format!("parse index JSON: {e}")))
+    let value = parse_json_rejecting_duplicate_keys(&bytes, path, "Safetensors index")?;
+    serde_json::from_value(value).map_err(|e| model_load(path, format!("parse index JSON: {e}")))
 }
 
 fn find_index_file(root: &Path) -> Result<Option<PathBuf>> {
     let mut candidates = Vec::new();
     for path in read_dir_paths(root)? {
         if is_safetensors_index(&path) && is_regular_file(&path)? {
+            validate_path_stays_under_root(root, &path)?;
             candidates.push(path);
         }
     }
@@ -518,10 +520,17 @@ fn is_regular_file(path: &Path) -> Result<bool> {
         .map_err(|e| model_load(path, e.to_string()))
 }
 
-fn reject_overlapping_tensor_ranges(
+fn reject_tensor_data_ranges(
     path: &Path,
     tensors: &[SafetensorsTensorRecord],
+    data_len: u64,
 ) -> Result<()> {
+    let data_len = usize::try_from(data_len).map_err(|_| {
+        model_load(
+            path,
+            format!("Safetensors data section length {data_len} does not fit in usize"),
+        )
+    })?;
     let mut ranges = tensors
         .iter()
         .map(|tensor| {
@@ -534,17 +543,35 @@ fn reject_overlapping_tensor_ranges(
         .collect::<Vec<_>>();
     ranges.sort_by_key(|(start, end, name)| (*start, *end, *name));
 
-    let mut previous: Option<(usize, usize, &str)> = None;
+    let mut expected_start = 0usize;
+    let mut previous_name: Option<&str> = None;
     for (start, end, name) in ranges {
-        if let Some((_, previous_end, previous_name)) = previous
-            && start < previous_end
-        {
+        if start < expected_start {
             return Err(model_load(
                 path,
-                format!("tensor '{name}' data range overlaps tensor '{previous_name}'"),
+                format!(
+                    "tensor '{name}' data range overlaps tensor '{}'",
+                    previous_name.unwrap_or("<unknown>")
+                ),
             ));
         }
-        previous = Some((start, end, name));
+        if start > expected_start {
+            return Err(model_load(
+                path,
+                format!("tensor '{name}' data range leaves a gap from {expected_start} to {start}"),
+            ));
+        }
+        expected_start = end;
+        previous_name = Some(name);
+    }
+
+    if expected_start != data_len {
+        return Err(model_load(
+            path,
+            format!(
+                "Safetensors tensor data ranges end at {expected_start}, but data section is {data_len} bytes"
+            ),
+        ));
     }
 
     Ok(())
@@ -564,10 +591,13 @@ fn expected_tensor_byte_size(
     shape: &[usize],
     path: &Path,
     tensor_name: &str,
-) -> Result<Option<usize>> {
-    let Some(element_size) = dtype_size_bytes(dtype) else {
-        return Ok(None);
-    };
+) -> Result<usize> {
+    let element_size = dtype_size_bytes(dtype).ok_or_else(|| {
+        model_load(
+            path,
+            format!("tensor '{tensor_name}' has unsupported Safetensors dtype '{dtype}'"),
+        )
+    })?;
     let elements = shape.iter().try_fold(1usize, |acc, dim| {
         acc.checked_mul(*dim).ok_or_else(|| {
             model_load(
@@ -578,7 +608,6 @@ fn expected_tensor_byte_size(
     })?;
     elements
         .checked_mul(element_size)
-        .map(Some)
         .ok_or_else(|| model_load(path, format!("tensor '{tensor_name}' byte size overflow")))
 }
 
@@ -598,16 +627,30 @@ fn merge_shard_metadata(
     shard_metadata: BTreeMap<String, String>,
 ) {
     for (key, value) in shard_metadata {
+        let namespaced_key = format!("shard:{shard_path}:{key}");
         match metadata.get(&key) {
             None => {
-                metadata.insert(key, value);
+                if !has_shard_metadata_key(metadata, &key) {
+                    metadata.insert(key.clone(), value.clone());
+                }
+                metadata.insert(namespaced_key, value);
             }
-            Some(existing) if existing == &value => {}
+            Some(existing) if existing == &value => {
+                metadata.insert(namespaced_key, value);
+            }
             Some(_) => {
-                metadata.insert(format!("shard:{shard_path}:{key}"), value);
+                metadata.remove(&key);
+                metadata.insert(namespaced_key, value);
             }
         }
     }
+}
+
+fn has_shard_metadata_key(metadata: &BTreeMap<String, String>, key: &str) -> bool {
+    let suffix = format!(":{key}");
+    metadata
+        .keys()
+        .any(|existing| existing.starts_with("shard:") && existing.ends_with(&suffix))
 }
 
 fn reject_output_checkpoint_conflict(
@@ -721,16 +764,31 @@ fn stringify_metadata(prefix: &str, metadata: BTreeMap<String, Value>) -> BTreeM
         .collect()
 }
 
-fn stringify_value_object(value: &Value) -> BTreeMap<String, String> {
-    value
-        .as_object()
-        .map(|object| {
-            object
-                .iter()
-                .map(|(key, value)| (key.clone(), stringify_json_value(value)))
-                .collect()
+fn parse_json_rejecting_duplicate_keys(bytes: &[u8], path: &Path, context: &str) -> Result<Value> {
+    serde_json::from_slice::<NoDuplicateValue>(bytes)
+        .map(|value| value.0)
+        .map_err(|e| model_load(path, format!("parse {context} JSON: {e}")))
+}
+
+fn parse_metadata_object(path: &Path, value: &Value) -> Result<BTreeMap<String, String>> {
+    let object = value.as_object().ok_or_else(|| {
+        model_load(
+            path,
+            "Safetensors __metadata__ must be a JSON object of strings".into(),
+        )
+    })?;
+    object
+        .iter()
+        .map(|(key, value)| {
+            let value = value.as_str().ok_or_else(|| {
+                model_load(
+                    path,
+                    format!("Safetensors __metadata__ key '{key}' must be a string"),
+                )
+            })?;
+            Ok((key.clone(), value.to_string()))
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 fn stringify_json_value(value: &Value) -> String {
@@ -738,6 +796,91 @@ fn stringify_json_value(value: &Value) -> String {
         .as_str()
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| value.to_string())
+}
+
+impl<'de> Deserialize<'de> for NoDuplicateValue {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(NoDuplicateValueVisitor)
+    }
+}
+
+struct NoDuplicateValueVisitor;
+
+impl<'de> Visitor<'de> for NoDuplicateValueVisitor {
+    type Value = NoDuplicateValue;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("valid JSON without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> std::result::Result<Self::Value, E> {
+        Ok(NoDuplicateValue(Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E> {
+        Ok(NoDuplicateValue(Value::Number(Number::from(value))))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E> {
+        Ok(NoDuplicateValue(Value::Number(Number::from(value))))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> std::result::Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let number = Number::from_f64(value).ok_or_else(|| E::custom("invalid JSON number"))?;
+        Ok(NoDuplicateValue(Value::Number(number)))
+    }
+
+    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(NoDuplicateValue(Value::String(value.to_string())))
+    }
+
+    fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E> {
+        Ok(NoDuplicateValue(Value::String(value)))
+    }
+
+    fn visit_none<E>(self) -> std::result::Result<Self::Value, E> {
+        Ok(NoDuplicateValue(Value::Null))
+    }
+
+    fn visit_unit<E>(self) -> std::result::Result<Self::Value, E> {
+        Ok(NoDuplicateValue(Value::Null))
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = seq.next_element::<NoDuplicateValue>()? {
+            values.push(value.0);
+        }
+        Ok(NoDuplicateValue(Value::Array(values)))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut seen = BTreeSet::new();
+        let mut object = Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if !seen.insert(key.clone()) {
+                return Err(de::Error::custom(format!("duplicate JSON key '{key}'")));
+            }
+            let value = map.next_value::<NoDuplicateValue>()?;
+            object.insert(key, value.0);
+        }
+        Ok(NoDuplicateValue(Value::Object(object)))
+    }
 }
 
 fn relative_path(path: &Path, root: &Path) -> String {
@@ -945,6 +1088,29 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn rejects_directory_index_that_escapes_via_symlink() {
+        let dir = temp_dir("index-symlink");
+        let outside = temp_dir("outside-index");
+        fs::write(
+            outside.join("external.safetensors.index.json"),
+            r#"{"weight_map": {}}"#,
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(
+            outside.join("external.safetensors.index.json"),
+            dir.join("model.safetensors.index.json"),
+        )
+        .unwrap();
+
+        let err = inspect_safetensors_checkpoint(&dir).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must stay within the checkpoint directory")
+        );
+    }
+
     #[test]
     fn rejects_multiple_directory_indexes() {
         let dir = temp_dir("multiple-indexes");
@@ -1023,6 +1189,54 @@ mod tests {
     }
 
     #[test]
+    fn rejects_unknown_safetensors_dtype() {
+        let dir = temp_dir("unknown-dtype");
+        let path = dir.join("bad.safetensors");
+        write_safetensors(
+            &path,
+            r#"{"bad.weight": {"dtype": "F128", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+
+        let err = inspect_safetensors_checkpoint(&path).unwrap_err();
+        assert!(err.to_string().contains("unsupported Safetensors dtype"));
+    }
+
+    #[test]
+    fn rejects_duplicate_header_keys() {
+        let dir = temp_dir("duplicate-keys");
+        let path = dir.join("bad.safetensors");
+        write_safetensors(
+            &path,
+            r#"{
+                "dup.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]},
+                "dup.weight": {"dtype": "F16", "shape": [1], "data_offsets": [2, 4]}
+            }"#,
+            4,
+        );
+
+        let err = inspect_safetensors_checkpoint(&path).unwrap_err();
+        assert!(err.to_string().contains("duplicate JSON key"));
+    }
+
+    #[test]
+    fn rejects_non_string_metadata_values() {
+        let dir = temp_dir("metadata-values");
+        let path = dir.join("bad.safetensors");
+        write_safetensors(
+            &path,
+            r#"{
+                "__metadata__": {"format": 1},
+                "a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}
+            }"#,
+            2,
+        );
+
+        let err = inspect_safetensors_checkpoint(&path).unwrap_err();
+        assert!(err.to_string().contains("must be a string"));
+    }
+
+    #[test]
     fn rejects_overlapping_tensor_ranges() {
         let dir = temp_dir("overlap");
         let path = dir.join("bad.safetensors");
@@ -1037,6 +1251,71 @@ mod tests {
 
         let err = inspect_safetensors_checkpoint(&path).unwrap_err();
         assert!(err.to_string().contains("data range overlaps"));
+    }
+
+    #[test]
+    fn rejects_tensor_data_gaps_and_trailing_bytes() {
+        let dir = temp_dir("data-gaps");
+        let gap_path = dir.join("gap.safetensors");
+        write_safetensors(
+            &gap_path,
+            r#"{
+                "a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]},
+                "b.weight": {"dtype": "F16", "shape": [1], "data_offsets": [4, 6]}
+            }"#,
+            6,
+        );
+        let err = inspect_safetensors_checkpoint(&gap_path).unwrap_err();
+        assert!(err.to_string().contains("leaves a gap"));
+
+        let trailing_path = dir.join("trailing.safetensors");
+        write_safetensors(
+            &trailing_path,
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            4,
+        );
+        let err = inspect_safetensors_checkpoint(&trailing_path).unwrap_err();
+        assert!(err.to_string().contains("data section is 4 bytes"));
+    }
+
+    #[test]
+    fn conflicting_shard_metadata_is_only_namespaced() {
+        let dir = temp_dir("metadata-conflict");
+        write_safetensors(
+            &dir.join("a.safetensors"),
+            r#"{
+                "__metadata__": {"format": "pt"},
+                "a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}
+            }"#,
+            2,
+        );
+        write_safetensors(
+            &dir.join("b.safetensors"),
+            r#"{
+                "__metadata__": {"format": "np"},
+                "b.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}
+            }"#,
+            2,
+        );
+
+        let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
+        assert!(!manifest.checkpoint.metadata.contains_key("format"));
+        assert_eq!(
+            manifest
+                .checkpoint
+                .metadata
+                .get("shard:a.safetensors:format")
+                .map(String::as_str),
+            Some("pt")
+        );
+        assert_eq!(
+            manifest
+                .checkpoint
+                .metadata
+                .get("shard:b.safetensors:format")
+                .map(String::as_str),
+            Some("np")
+        );
     }
 
     #[test]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -641,7 +641,7 @@ fn dtype_size_bytes(dtype: &str) -> Option<usize> {
     match dtype {
         "C128" => Some(16),
         "F64" | "I64" | "U64" | "C64" => Some(8),
-        "F32" | "I32" | "U32" => Some(4),
+        "F32" | "TF32" | "I32" | "U32" => Some(4),
         "F16" | "BF16" | "I16" | "U16" => Some(2),
         "F8_E5M2" | "F8_E4M3" | "F8_E8M0" | "I8" | "U8" | "BOOL" => Some(1),
         _ => None,

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -11,6 +11,10 @@ use serde_json::{Map, Number, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File};
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+#[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
 use std::path::{Component, Path, PathBuf};
 
 const SAFETENSORS_EXTENSION: &str = "safetensors";
@@ -613,10 +617,11 @@ fn expected_tensor_byte_size(
 
 fn dtype_size_bytes(dtype: &str) -> Option<usize> {
     match dtype {
-        "F64" | "I64" | "U64" => Some(8),
+        "C128" => Some(16),
+        "F64" | "I64" | "U64" | "C64" => Some(8),
         "F32" | "I32" | "U32" => Some(4),
         "F16" | "BF16" | "I16" | "U16" => Some(2),
-        "F8_E5M2" | "F8_E4M3" | "I8" | "U8" | "BOOL" => Some(1),
+        "F8_E5M2" | "F8_E4M3" | "F8_E8M0" | "I8" | "U8" | "BOOL" => Some(1),
         _ => None,
     }
 }
@@ -647,10 +652,12 @@ fn merge_shard_metadata(
 }
 
 fn has_shard_metadata_key(metadata: &BTreeMap<String, String>, key: &str) -> bool {
-    let suffix = format!(":{key}");
-    metadata
-        .keys()
-        .any(|existing| existing.starts_with("shard:") && existing.ends_with(&suffix))
+    metadata.keys().any(|existing| {
+        existing
+            .strip_prefix("shard:")
+            .and_then(|rest| rest.rsplit_once(':'))
+            .is_some_and(|(_, shard_key)| shard_key == key)
+    })
 }
 
 fn reject_output_checkpoint_conflict(
@@ -677,16 +684,26 @@ fn reject_output_checkpoint_conflict(
     for tensor in &manifest.tensors {
         checkpoint_files.insert(root.join(&tensor.source_shard));
     }
+    if let Some(unreferenced_shards) = manifest
+        .checkpoint
+        .metadata
+        .get("index:unreferenced_shards")
+    {
+        for shard in unreferenced_shards
+            .split(',')
+            .filter(|shard| !shard.is_empty())
+        {
+            checkpoint_files.insert(root.join(shard));
+        }
+    }
 
     for checkpoint_file in checkpoint_files {
-        if checkpoint_file.exists()
-            && fs::canonicalize(&checkpoint_file).map_err(|e| {
-                model_load(
-                    &checkpoint_file,
-                    format!("canonicalize checkpoint file for output conflict check: {e}"),
-                )
-            })? == output
-        {
+        if paths_refer_to_same_file(&checkpoint_file, &output).map_err(|e| {
+            model_load(
+                &checkpoint_file,
+                format!("compare checkpoint/output file identity: {e}"),
+            )
+        })? {
             return Err(model_load(
                 output_path,
                 "manifest output path must not overwrite a Safetensors checkpoint or index file"
@@ -696,6 +713,33 @@ fn reject_output_checkpoint_conflict(
     }
 
     Ok(())
+}
+
+fn paths_refer_to_same_file(left: &Path, right: &Path) -> std::io::Result<bool> {
+    if !left.exists() || !right.exists() {
+        return Ok(false);
+    }
+
+    let left_meta = fs::metadata(left)?;
+    let right_meta = fs::metadata(right)?;
+
+    #[cfg(unix)]
+    {
+        Ok(left_meta.dev() == right_meta.dev() && left_meta.ino() == right_meta.ino())
+    }
+
+    #[cfg(windows)]
+    {
+        Ok(
+            left_meta.volume_serial_number() == right_meta.volume_serial_number()
+                && left_meta.file_index() == right_meta.file_index(),
+        )
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        Ok(fs::canonicalize(left)? == fs::canonicalize(right)?)
+    }
 }
 
 fn canonical_existing_or_parent(path: &Path) -> Result<PathBuf> {
@@ -1319,6 +1363,20 @@ mod tests {
     }
 
     #[test]
+    fn shard_metadata_key_detection_uses_exact_key_match() {
+        let mut metadata = BTreeMap::new();
+        let mut first = BTreeMap::new();
+        first.insert("xfoo".to_string(), "1".to_string());
+        merge_shard_metadata(&mut metadata, "a.safetensors", first);
+
+        let mut second = BTreeMap::new();
+        second.insert("foo".to_string(), "2".to_string());
+        merge_shard_metadata(&mut metadata, "b.safetensors", second);
+
+        assert_eq!(metadata.get("foo").map(String::as_str), Some("2"));
+    }
+
+    #[test]
     fn directory_scan_ignores_non_file_safetensors_entries() {
         let dir = temp_dir("non-file-entry");
         fs::create_dir(dir.join("scratch.safetensors")).unwrap();
@@ -1355,6 +1413,48 @@ mod tests {
 
         let err = write_safetensors_manifest(&path, &path).unwrap_err();
         assert!(err.to_string().contains("must not overwrite"));
+    }
+
+    #[test]
+    fn rejects_manifest_output_that_overwrites_unreferenced_index_shard() {
+        let dir = temp_dir("output-unreferenced");
+        let main_shard = dir.join("model-00001-of-00001.safetensors");
+        write_safetensors(
+            &main_shard,
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+        let unreferenced = dir.join("unused.safetensors");
+        write_safetensors(
+            &unreferenced,
+            r#"{"b.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{"weight_map": {"a.weight": "model-00001-of-00001.safetensors"}}"#,
+        )
+        .unwrap();
+
+        let err = write_safetensors_manifest(&dir, &unreferenced).unwrap_err();
+        assert!(err.to_string().contains("must not overwrite"));
+    }
+
+    #[test]
+    fn accepts_current_additional_safetensors_dtypes() {
+        let dir = temp_dir("extra-dtypes");
+        let path = dir.join("model.safetensors");
+        write_safetensors(
+            &path,
+            r#"{
+                "a.weight": {"dtype": "F8_E8M0", "shape": [4], "data_offsets": [0, 4]},
+                "b.weight": {"dtype": "C64", "shape": [2], "data_offsets": [4, 20]}
+            }"#,
+            20,
+        );
+
+        let manifest = inspect_safetensors_checkpoint(&path).unwrap();
+        assert_eq!(manifest.checkpoint.tensor_count, 2);
     }
 
     #[test]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -359,7 +359,6 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<String> {
 
     let router_name = lower.contains("router")
         || lower.contains("gate_inp")
-        || lower.contains("ffn_gate_inp")
         || lower.ends_with(".gate.weight")
         || lower.ends_with("/gate/weight");
     let router_shape = shape.len() == 2
@@ -374,7 +373,6 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<String> {
     }
 
     let expert_name = lower.contains("expert")
-        || lower.contains("block_sparse_moe.experts")
         || lower.contains("gate_proj")
         || lower.contains("up_proj")
         || lower.contains("down_proj")

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1,0 +1,622 @@
+//! Safetensors checkpoint inspection and deterministic manifest generation.
+//!
+//! This module reads only Safetensors headers and optional Hugging Face shard
+//! index metadata. It does not read tensor payload bytes into memory and does
+//! not perform activation tracing or router math.
+
+use crate::error::{HybridError, Result};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+const SAFETENSORS_EXTENSION: &str = "safetensors";
+const MAX_HEADER_BYTES: usize = 256 * 1024 * 1024;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SafetensorsManifest {
+    pub manifest_version: u32,
+    pub format: &'static str,
+    pub checkpoint: SafetensorsCheckpointSource,
+    pub tensors: Vec<SafetensorsTensorRecord>,
+    pub candidates: SafetensorsCandidateSummary,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SafetensorsCheckpointSource {
+    pub input_kind: String,
+    pub index_file: Option<String>,
+    pub shard_count: usize,
+    pub tensor_count: usize,
+    pub metadata: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SafetensorsTensorRecord {
+    pub name: String,
+    pub dtype: String,
+    pub shape: Vec<usize>,
+    pub byte_size: usize,
+    pub source_shard: String,
+    pub data_offsets: [usize; 2],
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SafetensorsCandidateSummary {
+    pub router_tensors: Vec<String>,
+    pub expert_tensors: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawIndex {
+    #[serde(default)]
+    metadata: BTreeMap<String, Value>,
+    weight_map: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct ShardInspection {
+    metadata: BTreeMap<String, String>,
+    tensors: Vec<SafetensorsTensorRecord>,
+}
+
+/// Inspect a Safetensors file, sharded Safetensors index, or directory of
+/// Safetensors shards and return a deterministic JSON-serializable manifest.
+pub fn inspect_safetensors_checkpoint(path: impl AsRef<Path>) -> Result<SafetensorsManifest> {
+    let input = path.as_ref();
+    let metadata = fs::metadata(input).map_err(|e| model_load(input, e.to_string()))?;
+
+    if metadata.is_dir() {
+        return inspect_directory(input);
+    }
+
+    if is_safetensors_index(input) {
+        let root = input.parent().unwrap_or_else(|| Path::new("."));
+        return inspect_index(root, input);
+    }
+
+    if input.extension().and_then(|ext| ext.to_str()) == Some(SAFETENSORS_EXTENSION) {
+        return inspect_single_file(input);
+    }
+
+    Err(HybridError::UnsupportedFormat(format!(
+        "expected .safetensors file, .safetensors.index.json file, or directory, got '{}'",
+        input.display()
+    )))
+}
+
+/// Write a deterministic pretty-printed Safetensors manifest to `output_path`.
+pub fn write_safetensors_manifest(
+    checkpoint_path: impl AsRef<Path>,
+    output_path: impl AsRef<Path>,
+) -> Result<SafetensorsManifest> {
+    let manifest = inspect_safetensors_checkpoint(checkpoint_path)?;
+    let json = serde_json::to_string_pretty(&manifest).map_err(|e| HybridError::ModelLoad {
+        path: output_path.as_ref().display().to_string(),
+        reason: format!("serialize Safetensors manifest: {e}"),
+    })?;
+    fs::write(output_path.as_ref(), json).map_err(|e| HybridError::ModelLoad {
+        path: output_path.as_ref().display().to_string(),
+        reason: e.to_string(),
+    })?;
+    Ok(manifest)
+}
+
+fn inspect_single_file(path: &Path) -> Result<SafetensorsManifest> {
+    let root = path.parent().unwrap_or_else(|| Path::new("."));
+    let shard = inspect_shard(path, root)?;
+    Ok(build_manifest(
+        "single_file",
+        None,
+        vec![path.to_path_buf()],
+        shard.metadata,
+        shard.tensors,
+    ))
+}
+
+fn inspect_directory(root: &Path) -> Result<SafetensorsManifest> {
+    if let Some(index_path) = find_index_file(root)? {
+        return inspect_index(root, &index_path);
+    }
+
+    let shards = list_safetensors_files(root)?;
+    if shards.is_empty() {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "no .safetensors files found in '{}'",
+            root.display()
+        )));
+    }
+    inspect_shards("directory", root, None, shards)
+}
+
+fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> {
+    let raw = read_index(index_path)?;
+    let shards = raw
+        .weight_map
+        .values()
+        .map(|relative| index_shard_path(root, index_path, relative))
+        .collect::<Result<BTreeSet<_>>>()?
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    let mut metadata = stringify_metadata(raw.metadata);
+    metadata.insert(
+        "index_tensor_count".into(),
+        raw.weight_map.len().to_string(),
+    );
+    let index_file = Some(relative_path(index_path, root));
+    inspect_shards("hf_index", root, index_file, shards).map(|mut manifest| {
+        manifest.checkpoint.metadata.extend(metadata);
+        manifest
+    })
+}
+
+fn inspect_shards(
+    input_kind: &str,
+    root: &Path,
+    index_file: Option<String>,
+    shards: Vec<PathBuf>,
+) -> Result<SafetensorsManifest> {
+    let mut metadata = BTreeMap::new();
+    let mut tensors = Vec::new();
+
+    for shard_path in &shards {
+        let shard = inspect_shard(shard_path, root)?;
+        metadata.extend(shard.metadata);
+        tensors.extend(shard.tensors);
+    }
+
+    Ok(build_manifest(
+        input_kind, index_file, shards, metadata, tensors,
+    ))
+}
+
+fn build_manifest(
+    input_kind: &str,
+    index_file: Option<String>,
+    shards: Vec<PathBuf>,
+    metadata: BTreeMap<String, String>,
+    mut tensors: Vec<SafetensorsTensorRecord>,
+) -> SafetensorsManifest {
+    tensors.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.source_shard.cmp(&right.source_shard))
+    });
+    let router_tensors = tensors
+        .iter()
+        .filter(|tensor| {
+            tensor
+                .labels
+                .iter()
+                .any(|label| label == "moe_router_candidate")
+        })
+        .map(|tensor| tensor.name.clone())
+        .collect();
+    let expert_tensors = tensors
+        .iter()
+        .filter(|tensor| {
+            tensor
+                .labels
+                .iter()
+                .any(|label| label == "moe_expert_candidate")
+        })
+        .map(|tensor| tensor.name.clone())
+        .collect();
+
+    SafetensorsManifest {
+        manifest_version: 1,
+        format: "safetensors",
+        checkpoint: SafetensorsCheckpointSource {
+            input_kind: input_kind.to_string(),
+            index_file,
+            shard_count: shards.len(),
+            tensor_count: tensors.len(),
+            metadata,
+        },
+        tensors,
+        candidates: SafetensorsCandidateSummary {
+            router_tensors,
+            expert_tensors,
+        },
+    }
+}
+
+fn inspect_shard(path: &Path, root: &Path) -> Result<ShardInspection> {
+    let mut file = File::open(path).map_err(|e| model_load(path, e.to_string()))?;
+    let file_len = file
+        .metadata()
+        .map_err(|e| model_load(path, e.to_string()))?
+        .len();
+    let mut len_bytes = [0u8; 8];
+    file.read_exact(&mut len_bytes)
+        .map_err(|e| model_load(path, format!("read Safetensors header length: {e}")))?;
+    let header_len_u64 = u64::from_le_bytes(len_bytes);
+    let header_len = usize::try_from(header_len_u64).map_err(|_| {
+        model_load(
+            path,
+            format!("Safetensors header length {header_len_u64} does not fit in usize"),
+        )
+    })?;
+    if header_len > MAX_HEADER_BYTES {
+        return Err(model_load(
+            path,
+            format!("Safetensors header length {header_len} exceeds limit {MAX_HEADER_BYTES}"),
+        ));
+    }
+    if 8u64
+        .checked_add(header_len_u64)
+        .is_none_or(|end| end > file_len)
+    {
+        return Err(model_load(
+            path,
+            "Safetensors header extends beyond file".into(),
+        ));
+    }
+
+    let mut header_bytes = vec![0u8; header_len];
+    file.read_exact(&mut header_bytes)
+        .map_err(|e| model_load(path, format!("read Safetensors header: {e}")))?;
+    let header: Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| model_load(path, format!("parse Safetensors header JSON: {e}")))?;
+    parse_header(path, root, file_len, header_len_u64, header)
+}
+
+fn parse_header(
+    path: &Path,
+    root: &Path,
+    file_len: u64,
+    header_len: u64,
+    header: Value,
+) -> Result<ShardInspection> {
+    let object = header
+        .as_object()
+        .ok_or_else(|| model_load(path, "Safetensors header must be a JSON object".to_string()))?;
+    let data_len = file_len
+        .checked_sub(8)
+        .and_then(|len| len.checked_sub(header_len))
+        .ok_or_else(|| model_load(path, "Safetensors data range underflow".into()))?;
+    let source_shard = relative_path(path, root);
+    let mut metadata = BTreeMap::new();
+    let mut tensors = Vec::new();
+
+    for (name, value) in object {
+        if name == "__metadata__" {
+            metadata.extend(stringify_value_object(value));
+            continue;
+        }
+
+        let tensor = value.as_object().ok_or_else(|| {
+            model_load(path, format!("tensor '{name}' metadata must be an object"))
+        })?;
+        let dtype = tensor
+            .get("dtype")
+            .and_then(Value::as_str)
+            .ok_or_else(|| model_load(path, format!("tensor '{name}' is missing dtype")))?
+            .to_string();
+        let shape = tensor
+            .get("shape")
+            .and_then(Value::as_array)
+            .ok_or_else(|| model_load(path, format!("tensor '{name}' is missing shape")))?
+            .iter()
+            .map(|dim| {
+                dim.as_u64()
+                    .and_then(|v| usize::try_from(v).ok())
+                    .ok_or_else(|| model_load(path, format!("tensor '{name}' has invalid shape")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let offsets = tensor
+            .get("data_offsets")
+            .and_then(Value::as_array)
+            .ok_or_else(|| model_load(path, format!("tensor '{name}' is missing data_offsets")))?;
+        if offsets.len() != 2 {
+            return Err(model_load(
+                path,
+                format!("tensor '{name}' data_offsets must have length 2"),
+            ));
+        }
+        let start = offsets[0]
+            .as_u64()
+            .and_then(|v| usize::try_from(v).ok())
+            .ok_or_else(|| model_load(path, format!("tensor '{name}' has invalid start offset")))?;
+        let end = offsets[1]
+            .as_u64()
+            .and_then(|v| usize::try_from(v).ok())
+            .ok_or_else(|| model_load(path, format!("tensor '{name}' has invalid end offset")))?;
+        if start > end {
+            return Err(model_load(
+                path,
+                format!("tensor '{name}' data_offsets are reversed"),
+            ));
+        }
+        if u64::try_from(end).map_or(true, |end| end > data_len) {
+            return Err(model_load(
+                path,
+                format!("tensor '{name}' extends beyond Safetensors data section"),
+            ));
+        }
+
+        tensors.push(SafetensorsTensorRecord {
+            name: name.clone(),
+            dtype,
+            shape: shape.clone(),
+            byte_size: end - start,
+            source_shard: source_shard.clone(),
+            data_offsets: [start, end],
+            labels: classify_tensor(name, &shape),
+        });
+    }
+
+    Ok(ShardInspection { metadata, tensors })
+}
+
+fn classify_tensor(name: &str, shape: &[usize]) -> Vec<String> {
+    let lower = name.to_ascii_lowercase();
+    let mut labels = Vec::new();
+
+    let router_name = lower.contains("router")
+        || lower.contains("gate_inp")
+        || lower.contains("ffn_gate_inp")
+        || lower.ends_with(".gate.weight")
+        || lower.ends_with("/gate/weight");
+    let router_shape = shape.len() == 2
+        && shape
+            .iter()
+            .copied()
+            .min()
+            .is_some_and(|v| (2..=512).contains(&v))
+        && shape.iter().copied().max().is_some_and(|v| v >= 512);
+    if router_name || router_shape {
+        labels.push("moe_router_candidate".to_string());
+    }
+
+    let expert_name = lower.contains("expert")
+        || lower.contains("block_sparse_moe")
+        || lower.contains("gate_proj")
+        || lower.contains("up_proj")
+        || lower.contains("down_proj")
+        || lower.contains(".w1.")
+        || lower.contains(".w2.")
+        || lower.contains(".w3.");
+    if expert_name {
+        labels.push("moe_expert_candidate".to_string());
+    }
+
+    labels
+}
+
+fn read_index(path: &Path) -> Result<RawIndex> {
+    let bytes = fs::read(path).map_err(|e| model_load(path, e.to_string()))?;
+    serde_json::from_slice(&bytes).map_err(|e| model_load(path, format!("parse index JSON: {e}")))
+}
+
+fn find_index_file(root: &Path) -> Result<Option<PathBuf>> {
+    let mut candidates = fs::read_dir(root)
+        .map_err(|e| model_load(root, e.to_string()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| is_safetensors_index(path))
+        .collect::<Vec<_>>();
+    candidates.sort();
+    Ok(candidates.into_iter().next())
+}
+
+fn list_safetensors_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut shards = fs::read_dir(root)
+        .map_err(|e| model_load(root, e.to_string()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some(SAFETENSORS_EXTENSION))
+        .collect::<Vec<_>>();
+    shards.sort();
+    Ok(shards)
+}
+
+fn is_safetensors_index(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".safetensors.index.json"))
+}
+
+fn index_shard_path(root: &Path, index_path: &Path, relative: &str) -> Result<PathBuf> {
+    let relative_path = Path::new(relative);
+    let escapes_root = relative_path.is_absolute()
+        || relative_path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        });
+    if escapes_root {
+        return Err(model_load(
+            index_path,
+            format!("index shard path '{relative}' must stay within the checkpoint directory"),
+        ));
+    }
+    Ok(root.join(relative_path))
+}
+
+fn stringify_metadata(metadata: BTreeMap<String, Value>) -> BTreeMap<String, String> {
+    metadata
+        .into_iter()
+        .map(|(key, value)| (key, stringify_json_value(&value)))
+        .collect()
+}
+
+fn stringify_value_object(value: &Value) -> BTreeMap<String, String> {
+    value
+        .as_object()
+        .map(|object| {
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), stringify_json_value(value)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn stringify_json_value(value: &Value) -> String {
+    value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn relative_path(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn model_load(path: &Path, reason: String) -> HybridError {
+    HybridError::ModelLoad {
+        path: path.display().to_string(),
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "corinth-safetensors-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_safetensors(path: &Path, header: &str, data_len: usize) {
+        let mut file = File::create(path).unwrap();
+        file.write_all(&(header.len() as u64).to_le_bytes())
+            .unwrap();
+        file.write_all(header.as_bytes()).unwrap();
+        file.write_all(&vec![0u8; data_len]).unwrap();
+    }
+
+    #[test]
+    fn parses_single_file_manifest_and_labels_candidates() {
+        let dir = temp_dir("single");
+        let path = dir.join("model.safetensors");
+        write_safetensors(
+            &path,
+            r#"{
+                "__metadata__": {"format": "pt"},
+                "model.layers.0.mlp.gate.weight": {"dtype": "F32", "shape": [64, 2048], "data_offsets": [0, 524288]},
+                "model.layers.0.mlp.experts.0.w1.weight": {"dtype": "F16", "shape": [2048, 4096], "data_offsets": [524288, 17301504]}
+            }"#,
+            17_301_504,
+        );
+
+        let manifest = inspect_safetensors_checkpoint(&path).unwrap();
+        assert_eq!(manifest.checkpoint.input_kind, "single_file");
+        assert_eq!(manifest.checkpoint.shard_count, 1);
+        assert_eq!(manifest.checkpoint.tensor_count, 2);
+        assert_eq!(manifest.checkpoint.metadata.get("format").unwrap(), "pt");
+        assert_eq!(
+            manifest.tensors[0].name,
+            "model.layers.0.mlp.experts.0.w1.weight"
+        );
+        assert_eq!(manifest.tensors[0].source_shard, "model.safetensors");
+        assert_eq!(manifest.candidates.router_tensors.len(), 1);
+        assert_eq!(manifest.candidates.expert_tensors.len(), 1);
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn reads_hugging_face_index_and_orders_deterministically() {
+        let dir = temp_dir("index");
+        let shard_a = dir.join("model-00001-of-00002.safetensors");
+        let shard_b = dir.join("model-00002-of-00002.safetensors");
+        write_safetensors(
+            &shard_b,
+            r#"{"z.weight": {"dtype": "F16", "shape": [2, 2], "data_offsets": [0, 8]}}"#,
+            8,
+        );
+        write_safetensors(
+            &shard_a,
+            r#"{"a.router.weight": {"dtype": "F32", "shape": [8, 2048], "data_offsets": [0, 65536]}}"#,
+            65_536,
+        );
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{
+                "metadata": {"total_size": 65544},
+                "weight_map": {
+                    "z.weight": "model-00002-of-00002.safetensors",
+                    "a.router.weight": "model-00001-of-00002.safetensors"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
+        assert_eq!(manifest.checkpoint.input_kind, "hf_index");
+        assert_eq!(
+            manifest.checkpoint.index_file.as_deref(),
+            Some("model.safetensors.index.json")
+        );
+        assert_eq!(manifest.checkpoint.shard_count, 2);
+        assert_eq!(
+            manifest.checkpoint.metadata.get("total_size").unwrap(),
+            "65544"
+        );
+        assert_eq!(manifest.tensors[0].name, "a.router.weight");
+        assert_eq!(manifest.tensors[1].name, "z.weight");
+        assert_eq!(manifest.candidates.router_tensors, vec!["a.router.weight"]);
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_tensor_offsets_beyond_data_section() {
+        let dir = temp_dir("bounds");
+        let path = dir.join("bad.safetensors");
+        write_safetensors(
+            &path,
+            r#"{"bad.weight": {"dtype": "F16", "shape": [4], "data_offsets": [0, 16]}}"#,
+            8,
+        );
+
+        let err = inspect_safetensors_checkpoint(&path).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("extends beyond Safetensors data section")
+        );
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_index_shard_paths_that_escape_checkpoint_directory() {
+        let dir = temp_dir("escape");
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{
+                "weight_map": {
+                    "a.weight": "../outside.safetensors"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = inspect_safetensors_checkpoint(&dir).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must stay within the checkpoint directory")
+        );
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -465,11 +465,6 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<&'static str> {
             .min()
             .is_some_and(|v| (2..=512).contains(&v))
         && shape.iter().copied().max().is_some_and(|v| v >= 512);
-    if router_name {
-        labels.push("moe_router_candidate");
-    } else if router_shape {
-        labels.push("possible_moe_router_shape");
-    }
 
     let has_expert_context =
         lower.contains("experts") || lower.contains(".expert") || lower.contains("/expert");
@@ -482,6 +477,10 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<&'static str> {
     let expert_name = has_expert_context && expert_weight_name;
     if expert_name {
         labels.push("moe_expert_candidate");
+    } else if router_name {
+        labels.push("moe_router_candidate");
+    } else if router_shape {
+        labels.push("possible_moe_router_shape");
     }
 
     labels

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -374,7 +374,7 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<String> {
     }
 
     let expert_name = lower.contains("expert")
-        || lower.contains("block_sparse_moe")
+        || lower.contains("block_sparse_moe.experts")
         || lower.contains("gate_proj")
         || lower.contains("up_proj")
         || lower.contains("down_proj")

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -13,7 +13,8 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 const SAFETENSORS_EXTENSION: &str = "safetensors";
-const MAX_HEADER_BYTES: usize = 256 * 1024 * 1024;
+const MAX_HEADER_BYTES: usize = 64 * 1024 * 1024;
+const MAX_INDEX_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SafetensorsManifest {
@@ -41,7 +42,7 @@ pub struct SafetensorsTensorRecord {
     pub byte_size: usize,
     pub source_shard: String,
     pub data_offsets: [usize; 2],
-    pub labels: Vec<String>,
+    pub labels: Vec<&'static str>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -93,13 +94,16 @@ pub fn write_safetensors_manifest(
     checkpoint_path: impl AsRef<Path>,
     output_path: impl AsRef<Path>,
 ) -> Result<SafetensorsManifest> {
+    let checkpoint_path = checkpoint_path.as_ref();
+    let output_path = output_path.as_ref();
     let manifest = inspect_safetensors_checkpoint(checkpoint_path)?;
+    reject_output_checkpoint_conflict(checkpoint_path, output_path, &manifest)?;
     let json = serde_json::to_string_pretty(&manifest).map_err(|e| HybridError::ModelLoad {
-        path: output_path.as_ref().display().to_string(),
+        path: output_path.display().to_string(),
         reason: format!("serialize Safetensors manifest: {e}"),
     })?;
-    fs::write(output_path.as_ref(), json).map_err(|e| HybridError::ModelLoad {
-        path: output_path.as_ref().display().to_string(),
+    fs::write(output_path, json).map_err(|e| HybridError::ModelLoad {
+        path: output_path.display().to_string(),
         reason: e.to_string(),
     })?;
     Ok(manifest)
@@ -134,24 +138,70 @@ fn inspect_directory(root: &Path) -> Result<SafetensorsManifest> {
 
 fn inspect_index(root: &Path, index_path: &Path) -> Result<SafetensorsManifest> {
     let raw = read_index(index_path)?;
-    let shards = raw
-        .weight_map
-        .values()
-        .map(|relative| index_shard_path(root, index_path, relative))
-        .collect::<Result<BTreeSet<_>>>()?
-        .into_iter()
-        .collect::<Vec<_>>();
+    let index_tensor_count = raw.weight_map.len();
+    let mut expected_by_shard: BTreeMap<PathBuf, BTreeSet<String>> = BTreeMap::new();
+    for (tensor_name, relative) in raw.weight_map {
+        let shard_path = index_shard_path(root, index_path, &relative)?;
+        expected_by_shard
+            .entry(shard_path)
+            .or_default()
+            .insert(tensor_name);
+    }
+    let shards = expected_by_shard.keys().cloned().collect::<Vec<_>>();
 
-    let mut metadata = stringify_metadata(raw.metadata);
-    metadata.insert(
-        "index_tensor_count".into(),
-        raw.weight_map.len().to_string(),
-    );
+    let mut metadata = stringify_metadata("index", raw.metadata);
+    metadata.insert("index_tensor_count".into(), index_tensor_count.to_string());
     let index_file = Some(relative_path(index_path, root));
-    inspect_shards("hf_index", root, index_file, shards).map(|mut manifest| {
-        manifest.checkpoint.metadata.extend(metadata);
-        manifest
-    })
+    inspect_index_shards(root, index_file, shards, expected_by_shard, metadata)
+}
+
+fn inspect_index_shards(
+    root: &Path,
+    index_file: Option<String>,
+    shards: Vec<PathBuf>,
+    expected_by_shard: BTreeMap<PathBuf, BTreeSet<String>>,
+    mut metadata: BTreeMap<String, String>,
+) -> Result<SafetensorsManifest> {
+    let mut tensors = Vec::new();
+    for shard_path in &shards {
+        let expected = expected_by_shard.get(shard_path).ok_or_else(|| {
+            model_load(
+                shard_path,
+                "internal error: index shard has no expected tensor set".into(),
+            )
+        })?;
+        let shard = inspect_shard(shard_path, root)?;
+        merge_shard_metadata(
+            &mut metadata,
+            &relative_path(shard_path, root),
+            shard.metadata,
+        );
+
+        let found = shard
+            .tensors
+            .iter()
+            .map(|tensor| tensor.name.clone())
+            .collect::<BTreeSet<_>>();
+        if let Some(missing) = expected.difference(&found).next() {
+            return Err(model_load(
+                shard_path,
+                format!(
+                    "index maps tensor '{missing}' to this shard, but the shard header does not contain it"
+                ),
+            ));
+        }
+
+        tensors.extend(
+            shard
+                .tensors
+                .into_iter()
+                .filter(|tensor| expected.contains(&tensor.name)),
+        );
+    }
+
+    Ok(build_manifest(
+        "hf_index", index_file, shards, metadata, tensors,
+    ))
 }
 
 fn inspect_shards(
@@ -165,7 +215,11 @@ fn inspect_shards(
 
     for shard_path in &shards {
         let shard = inspect_shard(shard_path, root)?;
-        metadata.extend(shard.metadata);
+        merge_shard_metadata(
+            &mut metadata,
+            &relative_path(shard_path, root),
+            shard.metadata,
+        );
         tensors.extend(shard.tensors);
     }
 
@@ -188,22 +242,12 @@ fn build_manifest(
     });
     let router_tensors = tensors
         .iter()
-        .filter(|tensor| {
-            tensor
-                .labels
-                .iter()
-                .any(|label| label == "moe_router_candidate")
-        })
+        .filter(|tensor| tensor.labels.contains(&"moe_router_candidate"))
         .map(|tensor| tensor.name.clone())
         .collect();
     let expert_tensors = tensors
         .iter()
-        .filter(|tensor| {
-            tensor
-                .labels
-                .iter()
-                .any(|label| label == "moe_expert_candidate")
-        })
+        .filter(|tensor| tensor.labels.contains(&"moe_expert_candidate"))
         .map(|tensor| tensor.name.clone())
         .collect();
 
@@ -332,18 +376,30 @@ fn parse_header(
                 format!("tensor '{name}' data_offsets are reversed"),
             ));
         }
-        if u64::try_from(end).map_or(true, |end| end > data_len) {
+        if end as u64 > data_len {
             return Err(model_load(
                 path,
                 format!("tensor '{name}' extends beyond Safetensors data section"),
             ));
+        }
+        let byte_size = end - start;
+        match expected_tensor_byte_size(&dtype, &shape, path, name)? {
+            Some(expected) if expected != byte_size => {
+                return Err(model_load(
+                    path,
+                    format!(
+                        "tensor '{name}' byte size mismatch: shape/dtype imply {expected} bytes, data_offsets span {byte_size} bytes"
+                    ),
+                ));
+            }
+            _ => {}
         }
 
         tensors.push(SafetensorsTensorRecord {
             name: name.clone(),
             dtype,
             shape: shape.clone(),
-            byte_size: end - start,
+            byte_size,
             source_shard: source_shard.clone(),
             data_offsets: [start, end],
             labels: classify_tensor(name, &shape),
@@ -353,7 +409,7 @@ fn parse_header(
     Ok(ShardInspection { metadata, tensors })
 }
 
-fn classify_tensor(name: &str, shape: &[usize]) -> Vec<String> {
+fn classify_tensor(name: &str, shape: &[usize]) -> Vec<&'static str> {
     let lower = name.to_ascii_lowercase();
     let mut labels = Vec::new();
 
@@ -368,47 +424,204 @@ fn classify_tensor(name: &str, shape: &[usize]) -> Vec<String> {
             .min()
             .is_some_and(|v| (2..=512).contains(&v))
         && shape.iter().copied().max().is_some_and(|v| v >= 512);
-    if router_name || router_shape {
-        labels.push("moe_router_candidate".to_string());
+    if router_name {
+        labels.push("moe_router_candidate");
+    } else if router_shape {
+        labels.push("possible_moe_router_shape");
     }
 
-    let expert_name = lower.contains("expert")
-        || lower.contains("gate_proj")
+    let has_expert_context = lower.contains("experts")
+        || lower.contains(".expert")
+        || lower.contains("/expert")
+        || lower.contains("block_sparse_moe.experts");
+    let expert_weight_name = lower.contains("gate_proj")
         || lower.contains("up_proj")
         || lower.contains("down_proj")
         || lower.contains(".w1.")
         || lower.contains(".w2.")
         || lower.contains(".w3.");
+    let expert_name = has_expert_context && expert_weight_name;
     if expert_name {
-        labels.push("moe_expert_candidate".to_string());
+        labels.push("moe_expert_candidate");
     }
 
     labels
 }
 
 fn read_index(path: &Path) -> Result<RawIndex> {
+    let len = fs::metadata(path)
+        .map_err(|e| model_load(path, e.to_string()))?
+        .len();
+    if len > MAX_INDEX_BYTES {
+        return Err(model_load(
+            path,
+            format!("Safetensors index is {len} bytes, exceeding limit {MAX_INDEX_BYTES}"),
+        ));
+    }
     let bytes = fs::read(path).map_err(|e| model_load(path, e.to_string()))?;
     serde_json::from_slice(&bytes).map_err(|e| model_load(path, format!("parse index JSON: {e}")))
 }
 
 fn find_index_file(root: &Path) -> Result<Option<PathBuf>> {
-    let mut candidates = fs::read_dir(root)
-        .map_err(|e| model_load(root, e.to_string()))?
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+    let mut candidates = read_dir_paths(root)?
+        .into_iter()
         .filter(|path| is_safetensors_index(path))
         .collect::<Vec<_>>();
     candidates.sort();
-    Ok(candidates.into_iter().next())
+    if candidates.len() > 1 {
+        let names = candidates
+            .iter()
+            .map(|path| relative_path(path, root))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(HybridError::UnsupportedFormat(format!(
+            "multiple Safetensors index files found in '{}': {names}; pass the intended index file explicitly",
+            root.display()
+        )));
+    }
+    Ok(candidates.pop())
 }
 
 fn list_safetensors_files(root: &Path) -> Result<Vec<PathBuf>> {
-    let mut shards = fs::read_dir(root)
-        .map_err(|e| model_load(root, e.to_string()))?
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+    let mut shards = read_dir_paths(root)?
+        .into_iter()
         .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some(SAFETENSORS_EXTENSION))
-        .collect::<Vec<_>>();
+        .map(|path| validate_path_stays_under_root(root, &path).map(|()| path))
+        .collect::<Result<Vec<_>>>()?;
     shards.sort();
     Ok(shards)
+}
+
+fn read_dir_paths(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(root).map_err(|e| model_load(root, e.to_string()))? {
+        let entry = entry.map_err(|e| model_load(root, format!("read directory entry: {e}")))?;
+        paths.push(entry.path());
+    }
+    Ok(paths)
+}
+
+fn expected_tensor_byte_size(
+    dtype: &str,
+    shape: &[usize],
+    path: &Path,
+    tensor_name: &str,
+) -> Result<Option<usize>> {
+    let Some(element_size) = dtype_size_bytes(dtype) else {
+        return Ok(None);
+    };
+    let elements = shape.iter().try_fold(1usize, |acc, dim| {
+        acc.checked_mul(*dim).ok_or_else(|| {
+            model_load(
+                path,
+                format!("tensor '{tensor_name}' shape element count overflow"),
+            )
+        })
+    })?;
+    elements
+        .checked_mul(element_size)
+        .map(Some)
+        .ok_or_else(|| model_load(path, format!("tensor '{tensor_name}' byte size overflow")))
+}
+
+fn dtype_size_bytes(dtype: &str) -> Option<usize> {
+    match dtype {
+        "F64" | "I64" | "U64" => Some(8),
+        "F32" | "I32" | "U32" => Some(4),
+        "F16" | "BF16" | "I16" | "U16" => Some(2),
+        "F8_E5M2" | "F8_E4M3" | "I8" | "U8" | "BOOL" => Some(1),
+        _ => None,
+    }
+}
+
+fn merge_shard_metadata(
+    metadata: &mut BTreeMap<String, String>,
+    shard_path: &str,
+    shard_metadata: BTreeMap<String, String>,
+) {
+    for (key, value) in shard_metadata {
+        match metadata.get(&key) {
+            None => {
+                metadata.insert(key, value);
+            }
+            Some(existing) if existing == &value => {}
+            Some(_) => {
+                metadata.insert(format!("shard:{shard_path}:{key}"), value);
+            }
+        }
+    }
+}
+
+fn reject_output_checkpoint_conflict(
+    checkpoint_path: &Path,
+    output_path: &Path,
+    manifest: &SafetensorsManifest,
+) -> Result<()> {
+    let output = canonical_existing_or_parent(output_path)?;
+    let input_metadata = fs::metadata(checkpoint_path)
+        .map_err(|e| model_load(checkpoint_path, format!("stat checkpoint input: {e}")))?;
+    let root = if input_metadata.is_dir() {
+        checkpoint_path
+    } else {
+        checkpoint_path.parent().unwrap_or_else(|| Path::new("."))
+    };
+
+    let mut checkpoint_files = BTreeSet::new();
+    if input_metadata.is_file() {
+        checkpoint_files.insert(checkpoint_path.to_path_buf());
+    }
+    if let Some(index_file) = &manifest.checkpoint.index_file {
+        checkpoint_files.insert(root.join(index_file));
+    }
+    for tensor in &manifest.tensors {
+        checkpoint_files.insert(root.join(&tensor.source_shard));
+    }
+
+    for checkpoint_file in checkpoint_files {
+        if checkpoint_file.exists()
+            && fs::canonicalize(&checkpoint_file).map_err(|e| {
+                model_load(
+                    &checkpoint_file,
+                    format!("canonicalize checkpoint file for output conflict check: {e}"),
+                )
+            })? == output
+        {
+            return Err(model_load(
+                output_path,
+                "manifest output path must not overwrite a Safetensors checkpoint or index file"
+                    .into(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn canonical_existing_or_parent(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        return fs::canonicalize(path).map_err(|e| model_load(path, e.to_string()));
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        model_load(
+            path,
+            "manifest output path must include a file name".to_string(),
+        )
+    })?;
+    let parent = fs::canonicalize(parent).map_err(|e| model_load(parent, e.to_string()))?;
+    Ok(parent.join(file_name))
+}
+
+fn validate_path_stays_under_root(root: &Path, path: &Path) -> Result<()> {
+    let canonical_root = fs::canonicalize(root).map_err(|e| model_load(root, e.to_string()))?;
+    let canonical_path = fs::canonicalize(path).map_err(|e| model_load(path, e.to_string()))?;
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(model_load(
+            path,
+            "Safetensors shard path must stay within the checkpoint directory".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn is_safetensors_index(path: &Path) -> bool {
@@ -432,13 +645,15 @@ fn index_shard_path(root: &Path, index_path: &Path, relative: &str) -> Result<Pa
             format!("index shard path '{relative}' must stay within the checkpoint directory"),
         ));
     }
-    Ok(root.join(relative_path))
+    let candidate = root.join(relative_path);
+    validate_path_stays_under_root(root, &candidate)?;
+    Ok(candidate)
 }
 
-fn stringify_metadata(metadata: BTreeMap<String, Value>) -> BTreeMap<String, String> {
+fn stringify_metadata(prefix: &str, metadata: BTreeMap<String, Value>) -> BTreeMap<String, String> {
     metadata
         .into_iter()
-        .map(|(key, value)| (key, stringify_json_value(&value)))
+        .map(|(key, value)| (format!("{prefix}:{key}"), stringify_json_value(&value)))
         .collect()
 }
 
@@ -479,9 +694,32 @@ fn model_load(path: &Path, reason: String) -> HybridError {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::ops::Deref;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    fn temp_dir(name: &str) -> PathBuf {
+    struct TestDir(PathBuf);
+
+    impl Deref for TestDir {
+        type Target = Path;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl AsRef<Path> for TestDir {
+        fn as_ref(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn temp_dir(name: &str) -> TestDir {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -491,7 +729,7 @@ mod tests {
             std::process::id()
         ));
         fs::create_dir_all(&path).unwrap();
-        path
+        TestDir(path)
     }
 
     fn write_safetensors(path: &Path, header: &str, data_len: usize) {
@@ -528,8 +766,6 @@ mod tests {
         assert_eq!(manifest.tensors[0].source_shard, "model.safetensors");
         assert_eq!(manifest.candidates.router_tensors.len(), 1);
         assert_eq!(manifest.candidates.expert_tensors.len(), 1);
-
-        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
@@ -567,14 +803,16 @@ mod tests {
         );
         assert_eq!(manifest.checkpoint.shard_count, 2);
         assert_eq!(
-            manifest.checkpoint.metadata.get("total_size").unwrap(),
+            manifest
+                .checkpoint
+                .metadata
+                .get("index:total_size")
+                .unwrap(),
             "65544"
         );
         assert_eq!(manifest.tensors[0].name, "a.router.weight");
         assert_eq!(manifest.tensors[1].name, "z.weight");
         assert_eq!(manifest.candidates.router_tensors, vec!["a.router.weight"]);
-
-        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
@@ -592,8 +830,6 @@ mod tests {
             err.to_string()
                 .contains("extends beyond Safetensors data section")
         );
-
-        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
@@ -614,7 +850,122 @@ mod tests {
             err.to_string()
                 .contains("must stay within the checkpoint directory")
         );
+    }
 
-        fs::remove_dir_all(dir).unwrap();
+    #[cfg(unix)]
+    #[test]
+    fn rejects_index_shard_paths_that_escape_via_symlink() {
+        let dir = temp_dir("symlink");
+        let outside = temp_dir("outside");
+        let outside_shard = outside.join("outside.safetensors");
+        write_safetensors(
+            &outside_shard,
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+        std::os::unix::fs::symlink(&outside_shard, dir.join("link.safetensors")).unwrap();
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{
+                "weight_map": {
+                    "a.weight": "link.safetensors"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = inspect_safetensors_checkpoint(&dir).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must stay within the checkpoint directory")
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_directory_indexes() {
+        let dir = temp_dir("multiple-indexes");
+        fs::write(
+            dir.join("a.safetensors.index.json"),
+            r#"{"weight_map": {}}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("b.safetensors.index.json"),
+            r#"{"weight_map": {}}"#,
+        )
+        .unwrap();
+
+        let err = inspect_safetensors_checkpoint(&dir).unwrap_err();
+        assert!(err.to_string().contains("multiple Safetensors index files"));
+    }
+
+    #[test]
+    fn hf_index_filters_extra_tensors_and_requires_mapped_tensors() {
+        let dir = temp_dir("index-filter");
+        let shard = dir.join("model-00001-of-00001.safetensors");
+        write_safetensors(
+            &shard,
+            r#"{
+                "a.router.weight": {"dtype": "F32", "shape": [8, 2048], "data_offsets": [0, 65536]},
+                "stale.router.weight": {"dtype": "F32", "shape": [8, 2048], "data_offsets": [65536, 131072]}
+            }"#,
+            131_072,
+        );
+        let index = dir.join("model.safetensors.index.json");
+        fs::write(
+            &index,
+            r#"{"weight_map": {"a.router.weight": "model-00001-of-00001.safetensors"}}"#,
+        )
+        .unwrap();
+
+        let manifest = inspect_safetensors_checkpoint(&dir).unwrap();
+        assert_eq!(manifest.checkpoint.tensor_count, 1);
+        assert_eq!(manifest.tensors[0].name, "a.router.weight");
+
+        fs::write(
+            &index,
+            r#"{"weight_map": {"missing.weight": "model-00001-of-00001.safetensors"}}"#,
+        )
+        .unwrap();
+        let err = inspect_safetensors_checkpoint(&dir).unwrap_err();
+        assert!(err.to_string().contains("does not contain it"));
+    }
+
+    #[test]
+    fn rejects_shape_dtype_byte_size_mismatch() {
+        let dir = temp_dir("byte-size");
+        let path = dir.join("bad.safetensors");
+        write_safetensors(
+            &path,
+            r#"{"bad.weight": {"dtype": "F16", "shape": [4], "data_offsets": [0, 4]}}"#,
+            4,
+        );
+
+        let err = inspect_safetensors_checkpoint(&path).unwrap_err();
+        assert!(err.to_string().contains("byte size mismatch"));
+    }
+
+    #[test]
+    fn rejects_manifest_output_that_overwrites_checkpoint_file() {
+        let dir = temp_dir("output-conflict");
+        let path = dir.join("model.safetensors");
+        write_safetensors(
+            &path,
+            r#"{"a.weight": {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]}}"#,
+            2,
+        );
+
+        let err = write_safetensors_manifest(&path, &path).unwrap_err();
+        assert!(err.to_string().contains("must not overwrite"));
+    }
+
+    #[test]
+    fn generic_dense_ffn_names_are_not_moe_expert_candidates() {
+        let labels = classify_tensor("model.layers.0.mlp.gate_proj.weight", &[4096, 2048]);
+        assert!(!labels.contains(&"moe_expert_candidate"));
+
+        let labels = classify_tensor("model.layers.0.block_sparse_moe.gate.weight", &[8, 2048]);
+        assert!(labels.contains(&"moe_router_candidate"));
+        assert!(!labels.contains(&"moe_expert_candidate"));
     }
 }

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -543,11 +543,11 @@ fn reject_tensor_data_ranges(
         .collect::<Vec<_>>();
     ranges.sort_by_key(|(start, end, name)| (*start, *end, *name));
 
-    let mut expected_start = 0usize;
+format!("tensor data offset {} does not fit in usize", tensor.data_offsets[0]),
     let mut previous_name: Option<&str> = None;
     for (start, end, name) in ranges {
         if start < expected_start {
-            return Err(model_load(
+format!("tensor data offset {} does not fit in usize", tensor.data_offsets[1]),
                 path,
                 format!(
                     "tensor '{name}' data range overlaps tensor '{}'",


### PR DESCRIPTION
## **User description**
## Summary
- add a Safetensors header-only inspection API and deterministic JSON manifest records
- detect direct shards, shard directories, and Hugging Face .safetensors.index.json files
- label recognizable MoE router/expert candidate tensors and add a no-CUDA example CLI
- document Safetensors manifest usage versus GGUF runtime routing

## Validation
- rustfmt --edition 2024 --check src/moe/mod.rs src/moe/safetensors.rs examples/safetensors_manifest.rs
- cargo check --all-targets --no-default-features
- cargo test --no-default-features --locked -- --nocapture
- cargo check --all-targets
- cargo test --lib --locked -- --nocapture
- cargo clippy --all-targets --no-default-features -- -D warnings -A dead_code
- cargo clippy --all-targets -- -D warnings -A dead_code
- cargo run --example safetensors_manifest --no-default-features -- <local-olmoe-safetensors-dir> <temp-output-json>

Manual OLMoE result: 3219 tensors, 3 shards, 16 router candidates, 3072 expert candidates. Generated output was kept outside the repository and not committed.

Closes #53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a sizeable new file-parsing surface (Safetensors + HF index) with path/canonicalization and offset validation; bugs here could cause false negatives/positives or unexpected I/O errors when inspecting checkpoints. Existing GGUF routing remains unchanged aside from small, low-risk cleanup in CUDA/Sentry wrappers and lockfile updates.
> 
> **Overview**
> Adds a new `moe::safetensors` module plus `safetensors_manifest` example to **inspect Safetensors checkpoints (single file, shard directory, or Hugging Face `.safetensors.index.json`) and emit a deterministic JSON manifest** of tensor header metadata, including heuristic labels for likely MoE router/expert tensors.
> 
> The inspector is header-only (no tensor payload reads) and includes extensive validation/guardrails (duplicate-key rejection, offset/byte-size consistency, gap/overlap checks, index↔shard consistency, root-escape prevention including symlinks, and refusing to write manifests that would overwrite checkpoint files). Docs are updated to clarify Safetensors as an inspection surface vs the existing GGUF runtime path, `.gitignore` now ignores coverage artifacts, and minor CUDA wrapper tweaks improve compatibility (`ModuleJitOption` usage) and Sentry capture calling conventions; dependency lockfile is refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9fc736c08c6f99a131bbae0a787c1c502e25b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Inspect Safetensors checkpoints and generate a deterministic manifest**

### What Changed
- Can inspect a single `.safetensors` file, a Hugging Face `.safetensors.index.json`, or a directory of shards and write a stable JSON manifest
- Manifest now lists tensor names, dtypes, shapes, byte sizes, data offsets, source shard paths, and checkpoint metadata
- Recognizes likely MoE router and expert tensors so checkpoint structure is easier to review before running a model
- Rejects malformed checkpoints and unsafe paths, including duplicate JSON keys, invalid ranges, missing tensors, and output files that would overwrite checkpoint data
- Adds a command-line example and docs for generating the manifest without loading tensor payloads

### Impact
`✅ Faster checkpoint inspection`
`✅ Clearer MoE tensor discovery`
`✅ Safer manifest generation from large Safetensors checkpoints`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
