### PR TITLE
feat(examples): add NR telemetry verification and SAAQ formula docs

### DIFF
--- a/configs/saaq15_llama_moe_only.toml
+++ b/configs/saaq15_llama_moe_only.toml
@@ -1,4 +1,0 @@
-[[model]]
-slug = "llama_3_2_dark_champion_q5_k_m"
-family = "llama_moe"
-path = "/absolute/path/to/Llama-3.2-8X3B-MOE-Dark-Champion-GGUF/L3.2-8X3B-MOE-Dark-Champion-Inst-18.4B-uncen-ablit_D_AU-q5_k_m.gguf"

--- a/docs/SAAQ_FORMULA_COMPARISON.md
+++ b/docs/SAAQ_FORMULA_COMPARISON.md
@@ -8,6 +8,11 @@ Formula provenance was cross-checked against the external
 `corinth-canal` latent telemetry for SymbolicRegression.jl discovery and
 paired-run validation; it does not define simulator runtime math.
 
+An older checked-in raw-telemetry artifact from
+`outputs/20260414_194227_v2pNMk/hall_of_fame.csv` (and its identical `.bak`
+copy) was also inspected. That artifact predates the latent SAAQ 1.0 / 1.5
+rules below and comes from `SAAQ_discovery.jl`, not `SAAQ_latent_discovery.jl`.
+
 ## SAAQ 1.0 — `LegacyV1_0`
 
 **Config name:** `saaq_v1_0` (env `SAAQ_RULE=legacy` or `SAAQ_RULE=saaq_v1_0`)
@@ -117,6 +122,56 @@ as follows:
 - `SAAQ_discovery.jl` is an older raw-telemetry discovery harness. Its
   `ideal_compression_y = (gpu_power_w + cpu_package_power_w) / 400.0` target is
   not one of the SAAQ 1.0 or SAAQ 1.5 latent update formulas.
+
+## Earlier Raw Discovery Artifact
+
+The older `Surrogate_Viz.jl` artifact at
+`outputs/20260414_194227_v2pNMk/hall_of_fame.csv` uses the feature order from
+`SAAQ_discovery.jl`:
+
+- `x1 = gpu_temp_c`
+- `x2 = gpu_power_w`
+- `x3 = cpu_package_power_w`
+- `x4 = snn_firing_rate = gpu_temp_c / 100.0`
+
+Its target is:
+
+```
+ideal_compression_y = (gpu_power_w + cpu_package_power_w) / 400.0
+```
+
+The first non-constant discovered formula in that artifact is:
+
+```
+x2 / 280.9163511387151
+```
+
+which is simply:
+
+```
+gpu_power_w / 280.9163511387151
+```
+
+The best low-loss expression in that same hall-of-fame is:
+
+```
+((x2 / 203.92689231637638) - ((x2 - x3) / 407.26879801609624)) * 1.02021806662029
+```
+
+This numerically reduces to approximately:
+
+```
+0.00250 * gpu_power_w + 0.00251 * cpu_package_power_w
+```
+
+which is effectively a rediscovery of:
+
+```
+(gpu_power_w + cpu_package_power_w) / 400.0
+```
+
+This artifact is useful provenance for the earliest surrogate-discovery stage,
+but it is not the source of the later latent `LegacyV1_0` runtime formula.
 
 ## Caveats
 

--- a/docs/SAAQ_FORMULA_COMPARISON.md
+++ b/docs/SAAQ_FORMULA_COMPARISON.md
@@ -92,8 +92,8 @@ rounding (`0.0573`, `0.496`).
 
 When using the SAAQ calibration example (`saaq_latent_calibration`), the run
 manifest (`run_manifest.json`) includes the `saaq_rule` field set to either
-`"saaq_v1_0"` or `"saaq_v1_5"`, making it clear which formula produced the
-results.
+`"LegacyV1_0"` or `"SaaqV1_5SqrtRate"` (the enum variant names), making it
+clear which formula produced the results.
 
 The dual calibrator (`SnnDualLatentCalibrator`) always emits **both** rule
 trajectories in the CSV output, regardless of which rule is designated primary:

--- a/docs/SAAQ_FORMULA_COMPARISON.md
+++ b/docs/SAAQ_FORMULA_COMPARISON.md
@@ -1,0 +1,132 @@
+# SAAQ 1.0 vs SAAQ 1.5 Formula Comparison
+
+This document compares the two SAAQ (Spiking Adaptive Activity Quantization) update
+rules implemented in `src/latent.rs`.
+
+Formula provenance was cross-checked against the external
+`rmems/Surrogate_Viz.jl` repository. That Julia workbench consumes
+`corinth-canal` latent telemetry for SymbolicRegression.jl discovery and
+paired-run validation; it does not define simulator runtime math.
+
+## SAAQ 1.0 — `LegacyV1_0`
+
+**Config name:** `saaq_v1_0` (env `SAAQ_RULE=legacy` or `SAAQ_RULE=saaq_v1_0`)
+
+**Formula:**
+
+```
+saaq_delta_q_target = 0.52 * delta_q_prev
+                    + 0.28 * activity_pressure
+                    + 0.12 * membrane_pressure
+                    + 0.20 * routing_entropy
+                    - 0.18
+```
+
+Where:
+- `activity_pressure = clamp(avg_pop_firing_rate_hz / 24.0, 0.0, 1.0)`
+- `membrane_pressure = clamp(membrane_dv_dt / 12.0, -1.0, 1.0)`
+- `routing_entropy = normalized_entropy(expert_weights)`
+- `delta_q_prev` = the previous tick's `saaq_delta_q_target`
+
+**Characteristics:**
+- Multi-term linear blend (AR(1) with three perceptual pressure terms and an offset)
+- Responds to both population firing rate and membrane derivative
+- Uses routing entropy from expert weights as a pressure term
+- Hardcoded coefficients: 0.52, 0.28, 0.12, 0.20, -0.18
+
+## SAAQ 1.5 — `SaaqV1_5SqrtRate`
+
+**Config name:** `saaq_v1_5` (env `SAAQ_RULE=saaq_v1_5`, or any unrecognized value; this is the **default**)
+
+**Formula:**
+
+```
+saaq_delta_q_target = 0.0573 * sqrt(max(avg_pop_firing_rate_hz, 0.0))
+                    + 0.496 * delta_q_prev
+```
+
+**Characteristics:**
+- Simpler AR(1) with sqrt-rate drive and autoregressive decay
+- Only two coefficients: 0.0573 (sqrt-rate drive) and 0.496 (autoregressive decay)
+- No membrane pressure term
+- No routing entropy term
+- No constant offset
+- Uses `sqrt(firing_rate)` which compresses high firing rates and prevents runaway
+
+**Surrogate_Viz.jl reference:** `SAAQ_latent_discovery.jl` trains symbolic
+regression over the columns `avg_pop_firing_rate_hz`, `membrane_dv_dt`,
+`routing_entropy`, and `saaq_delta_q_prev`, targeting `saaq_delta_q_target`.
+The checked-in `hall_of_fame.csv` includes the discovered expression:
+
+```
+(sqrt(avg_pop_firing_rate_hz) * 0.05727633160985141) - (saaq_delta_q_prev / -2.015263764843582)
+```
+
+This simplifies to approximately:
+
+```
+0.05727633160985141 * sqrt(avg_pop_firing_rate_hz)
++ 0.496212... * saaq_delta_q_prev
+```
+
+which matches the Rust `SaaqV1_5SqrtRate` implementation after coefficient
+rounding (`0.0573`, `0.496`).
+
+## Key differences
+
+| Aspect | SAAQ 1.0 (`LegacyV1_0`) | SAAQ 1.5 (`SaaqV1_5SqrtRate`) |
+|--------|------------------------|-------------------------------|
+| Terms | 5 (AR + 3 pressures + offset) | 2 (sqrt-rate + AR) |
+| Input signals | Firing rate, membrane ΔV/dt, routing entropy | Firing rate only |
+| Firing rate transform | Linear (divide by 24) | Square root |
+| Offset | Yes (-0.18) | No |
+| AR coefficient | 0.52 | 0.496 |
+| Default? | No | **Yes** |
+
+## Run manifest labeling
+
+When using the SAAQ calibration example (`saaq_latent_calibration`), the run
+manifest (`run_manifest.json`) includes the `saaq_rule` field set to either
+`"saaq_v1_0"` or `"saaq_v1_5"`, making it clear which formula produced the
+results.
+
+The dual calibrator (`SnnDualLatentCalibrator`) always emits **both** rule
+trajectories in the CSV output, regardless of which rule is designated primary:
+
+- `saaq_delta_q_legacy_prev` / `saaq_delta_q_legacy_target` — SAAQ 1.0
+- `saaq_delta_q_v15_prev` / `saaq_delta_q_v15_target` — SAAQ 1.5
+
+The primary rule's output also populates the legacy `saaq_delta_q_prev` /
+`saaq_delta_q_target` columns for backward compatibility.
+
+## Surrogate_Viz.jl consumers
+
+The external `Surrogate_Viz.jl` repository uses these run labels and CSV columns
+as follows:
+
+- `SAAQ_latent_discovery.jl` expects `avg_pop_firing_rate_hz`,
+  `membrane_dv_dt`, `routing_entropy`, `saaq_delta_q_prev`, and
+  `saaq_delta_q_target` for symbolic-regression discovery.
+- `src/Surrogate_Viz.jl` prefers `saaq_delta_q_v15_target` when selecting a
+  SAAQ target column, then falls back to other `saaq` + `delta` + `target`
+  columns with score penalties for `legacy` names.
+- `compare_saaq15_baseline_pair.jl` filters imported runs with
+  `rule = "SaaqV1_5SqrtRate"` and reports the detected SAAQ delta column.
+- `compare_full_lineup_saaq15.jl` uses the same `SaaqV1_5SqrtRate` rule filter
+  for full-lineup paired-run dashboards.
+- `SAAQ_discovery.jl` is an older raw-telemetry discovery harness. Its
+  `ideal_compression_y = (gpu_power_w + cpu_package_power_w) / 400.0` target is
+  not one of the SAAQ 1.0 or SAAQ 1.5 latent update formulas.
+
+## Caveats
+
+- Neither formula has been fitted to empirical neural data; coefficients are
+  hand-chosen heuristics.
+- SAAQ 1.0's membrane pressure term depends on finite-difference ΔV/dt
+  estimation, which can be noisy at small `dt`.
+- SAAQ 1.5's `sqrt(rate)` compresses high rates but may under-respond to
+  silence (near-zero firing), causing slow convergence from cold-start.
+- The `Surrogate_Viz.jl` hall-of-fame equation is discovery evidence for the
+  SAAQ 1.5 coefficients, not an independent runtime source of truth.
+- The formulas are **not** changed by this issue; comparison is documentation
+  only.

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -25,6 +25,12 @@ pub const DEFAULT_RUST_SYNTAX_PROMPT_TEXT: &str =
 
 pub const DEFAULT_ENGLISH_SNN_PROMPT_TEXT: &str = "Let's teach this MoE model about SNN.";
 
+pub const DEFAULT_ENGLISH_EXPLANATION_PROMPT_TEXT: &str =
+    "Explain to me how Mixture of Experts models work";
+
+pub const DEFAULT_PROGRAMMING_RUST_PROMPT_TEXT: &str =
+    "Write a Rust function that parses a comma-separated list of integers into a Vec, returning a Result with a helpful error on invalid input.";
+
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ValidationModelSpec {
@@ -80,6 +86,12 @@ pub fn prompt_text_for_profile(profile: &str) -> &'static str {
         "math_logic" | "math" => DEFAULT_MATH_PROMPT_TEXT,
         "rust_syntax" | "rust" => DEFAULT_RUST_SYNTAX_PROMPT_TEXT,
         "english_snn" | "english" | "snn" => DEFAULT_ENGLISH_SNN_PROMPT_TEXT,
+        "english_explanation" | "english_moe" | "moe_explanation" => {
+            DEFAULT_ENGLISH_EXPLANATION_PROMPT_TEXT
+        }
+        "programming_rust" | "rust_parse" | "rust_programming" => {
+            DEFAULT_PROGRAMMING_RUST_PROMPT_TEXT
+        }
         _ => DEFAULT_MATH_PROMPT_TEXT,
     }
 }

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -28,8 +28,7 @@ pub const DEFAULT_ENGLISH_SNN_PROMPT_TEXT: &str = "Let's teach this MoE model ab
 pub const DEFAULT_ENGLISH_EXPLANATION_PROMPT_TEXT: &str =
     "Explain to me how Mixture of Experts models work";
 
-pub const DEFAULT_PROGRAMMING_RUST_PROMPT_TEXT: &str =
-    "Write a Rust function that parses a comma-separated list of integers into a Vec, returning a Result with a helpful error on invalid input.";
+pub const DEFAULT_PROGRAMMING_RUST_PROMPT_TEXT: &str = "Write a Rust function that parses a comma-separated list of integers into a Vec, returning a Result with a helpful error on invalid input.";
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -485,25 +485,29 @@ pub fn new_relic_env_status() -> Vec<(&'static str, Option<String>)> {
         .collect()
 }
 
-/// Returns `true` if at least one New Relic env var is set, indicating that
-/// the New Relic integration is configured.
+/// Minimal New Relic env vars required for ingest telemetry.
+const NR_REQUIRED: &[&str] = &["NR_INSERT_KEY", "NR_ACCOUNT_ID"];
+
+/// Returns `true` only if the minimal New Relic ingest credentials are
+/// present (both `NR_INSERT_KEY` and `NR_ACCOUNT_ID` are set and non-empty).
+/// This avoids the false-positive "configured" signal when only optional
+/// vars (e.g. `NEW_RELIC_APP_NAME`) are present.
 pub fn new_relic_is_configured() -> bool {
-    NR_ENV_VARS
-        .iter()
-        .any(|&var| {
-            std::env::var(var)
-                .ok()
-                .map(|value| value.trim().to_owned())
-                .filter(|value| !value.is_empty())
-                .is_some()
-        })
+    NR_REQUIRED.iter().all(|&var| {
+        std::env::var(var)
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .is_some()
+    })
 }
 
 /// Returns a human-readable summary of New Relic verification status, suitable
 /// for writing into experiment logs and run manifests.
 pub fn new_relic_verification_summary() -> String {
     let status = new_relic_env_status();
-    let configured = new_relic_is_configured();
+    let configured = status
+        .iter()
+        .any(|(var, value)| NR_REQUIRED.contains(var) && value.is_some());
     let mut lines = Vec::new();
     lines.push(format!("new_relic_configured: {configured}"));
     for (var, value) in &status {

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -22,6 +22,8 @@ pub struct SafeDiagnosticData<'a> {
     pub telemetry_source: Option<&'a str>,
     pub validation_status: Option<&'a str>,
     pub error_category: Option<&'a str>,
+    pub prompt_profile: Option<&'a str>,
+    pub saaq_rule: Option<&'a str>,
 }
 
 impl<'a> SafeDiagnosticData<'a> {
@@ -42,6 +44,16 @@ impl<'a> SafeDiagnosticData<'a> {
 
     pub fn with_error_category(mut self, error_category: &'a str) -> Self {
         self.error_category = Some(error_category);
+        self
+    }
+
+    pub fn with_prompt_profile(mut self, prompt_profile: &'a str) -> Self {
+        self.prompt_profile = Some(prompt_profile);
+        self
+    }
+
+    pub fn with_saaq_rule(mut self, saaq_rule: &'a str) -> Self {
+        self.saaq_rule = Some(saaq_rule);
         self
     }
 }
@@ -67,6 +79,8 @@ struct OwnedDiagnosticData {
     telemetry_source: Option<String>,
     validation_status: Option<String>,
     error_category: Option<String>,
+    prompt_profile: Option<String>,
+    saaq_rule: Option<String>,
 }
 
 impl OwnedDiagnosticData {
@@ -83,6 +97,12 @@ impl OwnedDiagnosticData {
         if let Some(error_category) = data.error_category {
             self.error_category = Some(error_category.to_owned());
         }
+        if let Some(prompt_profile) = data.prompt_profile {
+            self.prompt_profile = Some(prompt_profile.to_owned());
+        }
+        if let Some(saaq_rule) = data.saaq_rule {
+            self.saaq_rule = Some(saaq_rule.to_owned());
+        }
     }
 
     fn with_status(mut self, validation_status: &str, error_category: &str) -> Self {
@@ -97,6 +117,8 @@ impl OwnedDiagnosticData {
             telemetry_source: self.telemetry_source.as_deref(),
             validation_status: self.validation_status.as_deref(),
             error_category: self.error_category.as_deref(),
+            prompt_profile: self.prompt_profile.as_deref(),
+            saaq_rule: self.saaq_rule.as_deref(),
         }
     }
 }
@@ -422,7 +444,74 @@ fn apply_scope(
     } else {
         scope.remove_tag("error_category");
     }
+    if let Some(prompt_profile) = data.prompt_profile {
+        scope.set_tag("prompt_profile", prompt_profile);
+    } else {
+        scope.remove_tag("prompt_profile");
+    }
+    if let Some(saaq_rule) = data.saaq_rule {
+        scope.set_tag("saaq_rule", saaq_rule);
+    } else {
+        scope.remove_tag("saaq_rule");
+    }
     scope.set_extra("run_id", json!(run_id));
+}
+
+/// New Relic telemetry verification helpers.
+///
+/// These functions check whether New Relic environment variables are set and
+/// provide dry-run verification so SAAQ experiment runs can document telemetry
+/// health without requiring a live New Relic connection. All functions are
+/// safe to call when New Relic env vars are unset — they simply report the
+/// missing state.
+
+/// New Relic environment variables used by the SAAQ observability pipeline.
+pub const NR_ENV_VARS: &[&str] = &[
+    "NR_INSERT_KEY",
+    "NR_ACCOUNT_ID",
+    "NR_QUERY_KEY",
+    "NEW_RELIC_APP_NAME",
+];
+
+/// Returns a summary of which New Relic env vars are set, for telemetry
+/// verification. Never fails — missing env vars are reported as `None`.
+pub fn new_relic_env_status() -> Vec<(&'static str, Option<String>)> {
+    NR_ENV_VARS
+        .iter()
+        .map(|&var| {
+            let value = std::env::var(var).ok().filter(|v| !v.trim().is_empty());
+            (var, value.map(|v| format!("{}chars", v.len())))
+        })
+        .collect()
+}
+
+/// Returns `true` if at least one New Relic env var is set, indicating that
+/// the New Relic integration is configured.
+pub fn new_relic_is_configured() -> bool {
+    NR_ENV_VARS
+        .iter()
+        .any(|&var| std::env::var(var).as_deref().map(str::trim).filter(|s| !s.is_empty()).is_some())
+}
+
+/// Returns a human-readable summary of New Relic verification status, suitable
+/// for writing into experiment logs and run manifests.
+pub fn new_relic_verification_summary() -> String {
+    let status = new_relic_env_status();
+    let configured = new_relic_is_configured();
+    let mut lines = Vec::new();
+    lines.push(format!("new_relic_configured: {configured}"));
+    for (var, value) in &status {
+        match value {
+            Some(masked) => lines.push(format!("  {var}: set ({masked})")),
+            None => lines.push(format!("  {var}: unset")),
+        }
+    }
+    if configured {
+        lines.push("telemetry_status: new_relic_available".to_owned());
+    } else {
+        lines.push("telemetry_status: dry_run_no_new_relic".to_owned());
+    }
+    lines.join("\n")
 }
 
 pub fn error_category(status: Option<&str>, error: Option<&str>) -> &'static str {

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -490,7 +490,13 @@ pub fn new_relic_env_status() -> Vec<(&'static str, Option<String>)> {
 pub fn new_relic_is_configured() -> bool {
     NR_ENV_VARS
         .iter()
-        .any(|&var| std::env::var(var).as_deref().map(str::trim).filter(|s| !s.is_empty()).is_some())
+        .any(|&var| {
+            std::env::var(var)
+                .ok()
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+                .is_some()
+        })
 }
 
 /// Returns a human-readable summary of New Relic verification status, suitable


### PR DESCRIPTION
## **User description**
## Summary
- add two new prompt-vector profiles for English explanation and Rust programming coverage
- add safe New Relic verification helpers and include `prompt_profile` / `saaq_rule` observability tags without breaking offline runs
- document SAAQ 1.0 vs 1.5 formulas, including local `Surrogate_Viz.jl` cross-checks for both the latent v1.5 hall-of-fame equation and the earlier raw telemetry discovery artifact

## Validation
- `cargo check --all-targets --no-default-features`
- `cargo test --no-default-features`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add New Relic telemetry verification helpers and SAAQ formula comparison docs
> - Adds `new_relic_is_configured`, `new_relic_env_status`, and `new_relic_verification_summary` functions in [observability.rs](https://github.com/rmems/corinth-canal/pull/86/files#diff-dddc32a6497c87df11f23151b1979066842e56d60945abbd354fe194018f0c65) to introspect NR credential presence and produce human-readable config summaries.
> - Extends `SafeDiagnosticData` and `OwnedDiagnosticData` with `prompt_profile` and `saaq_rule` fields, propagated through merge and Sentry scope tagging.
> - Adds new prompt profiles (`english_explanation`, `programming_rust`, and aliases) in [mod.rs](https://github.com/rmems/corinth-canal/pull/86/files#diff-600930d57a86a7ada4f6bb6d0f95c05468cc7b60c3a26970c3d96ea411a9b6d2).
> - Adds [docs/SAAQ_FORMULA_COMPARISON.md](https://github.com/rmems/corinth-canal/pull/86/files#diff-fa01f5dae5e2ba14f5c53663ef2a04e039ef87639bc6515946df4ee758a1dbea) comparing SAAQ 1.0 (`LegacyV1_0`) and SAAQ 1.5 (`SaaqV1_5SqrtRate`) formulas, characteristics, and caveats.
> - Removes the `configs/saaq15_llama_moe_only.toml` config file.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e89ce19. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


___

## **CodeAnt-AI Description**
**Add new prompt profiles, telemetry checks, and SAAQ formula docs**

### What Changed
- Added two new prompt profiles for English explanations and Rust parsing tasks.
- Experiment logs and error reporting now include the prompt profile and SAAQ rule being used, along with New Relic status checks that work even when telemetry keys are missing.
- Added a comparison guide for SAAQ 1.0 and SAAQ 1.5, including the earlier raw discovery artifact and the formula cross-check notes.
- Removed a duplicate model config file that pointed to a hardcoded absolute checkpoint path.

### Impact
`✅ Clearer experiment logs`
`✅ Easier telemetry readiness checks`
`✅ Fewer invalid model config files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
