### PR TITLE
feat(observability): export traces to New Relic via OpenTelemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,9 +43,13 @@ AGENTOS_JSON_TRACING=0
 # OTLP/HTTP. Leave blank to keep examples fully local/offline.
 NR_INSERT_KEY=
 
-# Optional New Relic OTLP traces endpoint. Defaults to
-# `https://otlp.nr-data.net/v1/traces`.
+# Optional generic New Relic OTLP endpoint. The OpenTelemetry SDK appends the
+# signal path when this base endpoint is used. Defaults to New Relic's trace
+# endpoint when both OTLP endpoint vars are blank.
 OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# Optional trace-specific OTLP endpoint. Use this when passing a full traces URL.
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=
 
 # Optional OpenTelemetry service name. Defaults to `corinth-canal`.
 OTEL_SERVICE_NAME=

--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,8 @@ AGENTOS_JSON_TRACING=0
 # OTLP/HTTP. Leave blank to keep examples fully local/offline.
 NR_INSERT_KEY=
 
-# Optional New Relic OTLP endpoint. Defaults to `https://otlp.nr-data.net`.
+# Optional New Relic OTLP traces endpoint. Defaults to
+# `https://otlp.nr-data.net/v1/traces`.
 OTEL_EXPORTER_OTLP_ENDPOINT=
 
 # Optional OpenTelemetry service name. Defaults to `corinth-canal`.

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,31 @@ AGENTOS_GIT_SHA=
 AGENTOS_JSON_TRACING=0
 
 # ---------------------------------------------------------------------------
+# New Relic OpenTelemetry telemetry
+# ---------------------------------------------------------------------------
+
+# New Relic ingest license key. When set, `init_tracing()` automatically
+# wires a `tracing-opentelemetry` layer that exports spans to New Relic via
+# OTLP/HTTP. Leave blank to keep examples fully local/offline.
+NR_INSERT_KEY=
+
+# Optional New Relic OTLP endpoint. Defaults to `https://otlp.nr-data.net`.
+OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# Optional OpenTelemetry service name. Defaults to `corinth-canal`.
+OTEL_SERVICE_NAME=
+
+# Optional New Relic account ID. Used by the NR verification helpers in
+# examples/support/observability.rs; not required for OTLP export itself.
+NR_ACCOUNT_ID=
+
+# Optional New Relic query key. Used by verification helpers only.
+NR_QUERY_KEY=
+
+# Optional New Relic app name. Used by verification helpers only.
+NEW_RELIC_APP_NAME=
+
+# ---------------------------------------------------------------------------
 # Checkpoint + embedding tooling
 # ---------------------------------------------------------------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +63,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -117,6 +150,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -131,6 +166,25 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -158,12 +212,16 @@ dependencies = [
  "dotenvy",
  "libc",
  "memmap2",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "sentry",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -260,6 +318,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,10 +425,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "futures-sink"
@@ -374,6 +472,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -388,8 +487,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -399,9 +500,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -732,10 +835,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -790,6 +961,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -951,6 +1128,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1223,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1018,6 +1271,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1123,12 +1455,16 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1159,6 +1495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1528,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1194,13 +1537,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1208,6 +1591,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1218,6 +1602,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1419,6 +1812,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +2007,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +2198,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,12 +2500,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 sentry = { version = "0.48.1", default-features = false, features = ["backtrace", "panic", "anyhow", "transport"] }
 opentelemetry = "0.32.0"
 opentelemetry_sdk = "0.32.0"
-opentelemetry-otlp = { version = "0.32.0", features = ["http-proto", "reqwest-client", "reqwest-rustls"] }
+opentelemetry-otlp = { version = "0.32.0", features = ["http-proto", "reqwest-blocking-client", "reqwest-rustls"] }
 tracing-opentelemetry = "0.33.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ memmap2 = "0.9"
 libc = "0.2"
 serde_json = "1.0"
 sentry = { version = "0.48.1", default-features = false, features = ["backtrace", "panic", "anyhow", "transport"] }
+opentelemetry = "0.32.0"
+opentelemetry_sdk = "0.32.0"
+opentelemetry-otlp = { version = "0.32.0", features = ["http-proto", "reqwest-client", "reqwest-rustls"] }
+tracing-opentelemetry = "0.33.0"
 
 [dev-dependencies]
 dotenvy = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ memmap2 = "0.9"
 libc = "0.2"
 serde_json = "1.0"
 sentry = { version = "0.48.1", default-features = false, features = ["backtrace", "panic", "anyhow", "transport"] }
-opentelemetry = "0.32.0"
-opentelemetry_sdk = "0.32.0"
-opentelemetry-otlp = { version = "0.32.0", features = ["http-proto", "reqwest-blocking-client", "reqwest-rustls"] }
-tracing-opentelemetry = "0.33.0"
 
 [dev-dependencies]
 dotenvy = "0.15"
+opentelemetry = "0.32.0"
+opentelemetry_sdk = "0.32.0"
+opentelemetry-otlp = { version = "0.32.0", features = ["http-proto", "reqwest-blocking-client", "reqwest-rustls"] }
 toml    = "0.8"
+tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [build-dependencies]

--- a/examples/support/config.rs
+++ b/examples/support/config.rs
@@ -323,7 +323,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "produced no usable entries")]
     fn safetensors_validation_rejects_empty_lineup() {
-        validate_safetensors_lineup_entries(Path::new("configs/template.toml"), &[]);
+        let entries: &[SafetensorsModelEntry] = &[];
+        validate_safetensors_lineup_entries(Path::new("configs/template.toml"), entries);
     }
 
     #[test]

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -12,9 +12,15 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use sentry::ClientInitGuard;
 use serde_json::json;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 static INIT: Once = Once::new();
 const REPO_NAME: &str = "corinth-canal";
+
+/// OpenTelemetry tracer provider guard. Kept alive for the process lifetime
+/// so the global tracer is not dropped prematurely.
+static OTEL_PROVIDER: OnceLock<opentelemetry_sdk::trace::TracerProvider> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SafeDiagnosticData<'a> {
@@ -126,14 +132,82 @@ impl OwnedDiagnosticData {
 pub fn init_tracing() {
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-        let builder = tracing_subscriber::fmt().with_env_filter(filter);
-
-        if std::env::var("AGENTOS_JSON_TRACING").as_deref() == Ok("1") {
-            builder.json().init();
+        let fmt_layer = if std::env::var("AGENTOS_JSON_TRACING").as_deref() == Ok("1") {
+            tracing_subscriber::fmt::layer().json().boxed()
         } else {
-            builder.init();
+            tracing_subscriber::fmt::layer().boxed()
+        };
+
+        let registry = tracing_subscriber::registry().with(filter).with(fmt_layer);
+
+        match init_opentelemetry_layer() {
+            Some(otel_layer) => {
+                registry.with(otel_layer).init();
+            }
+            None => {
+                registry.init();
+            }
         }
     });
+}
+
+/// Attempt to build an OpenTelemetry `tracing` layer backed by a New Relic OTLP
+/// exporter. Returns `None` when New Relic credentials are absent or invalid so
+/// the caller can fall back to plain tracing.
+fn init_opentelemetry_layer() -> Option<
+    tracing_opentelemetry::OpenTelemetryLayer<
+        tracing_subscriber::Registry,
+        opentelemetry_sdk::trace::TracerProvider,
+    >,
+> {
+    let api_key = std::env::var("NR_INSERT_KEY")
+        .ok()
+        .filter(|v| !v.trim().is_empty())?;
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "https://otlp.nr-data.net".to_owned());
+    let service_name = std::env::var("OTEL_SERVICE_NAME")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| REPO_NAME.to_owned());
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .with_headers(std::collections::HashMap::from([(
+            "api-key".to_owned(),
+            api_key,
+        )]))
+        .build()
+        .ok()?;
+
+    let resource = opentelemetry_sdk::Resource::builder()
+        .with_attribute(opentelemetry::KeyValue::new("service.name", service_name))
+        .with_attribute(opentelemetry::KeyValue::new(
+            "service.repository",
+            REPO_NAME,
+        ))
+        .build();
+
+    let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_simple_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    opentelemetry::global::set_tracer_provider(provider.clone());
+    let _ = OTEL_PROVIDER.set(provider);
+
+    Some(tracing_opentelemetry::layer().with_tracer(OTEL_PROVIDER.get()?.tracer(REPO_NAME)))
+}
+
+/// Flush any pending OpenTelemetry spans and shut down the global tracer
+/// provider. Safe to call when OTel was never initialized — it becomes a no-op.
+pub fn shutdown_opentelemetry() {
+    if let Some(provider) = OTEL_PROVIDER.get() {
+        let _ = provider.shutdown();
+    }
+    opentelemetry::global::shutdown_tracer_provider();
 }
 
 pub fn start_command(command: &'static str) -> CommandObserver {

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -73,6 +73,7 @@ pub struct CommandObserver {
     git_sha: String,
     started: Instant,
     safe_data: RefCell<OwnedDiagnosticData>,
+    span: RefCell<Option<tracing::Span>>,
 }
 
 pub trait ErrorReport {
@@ -175,24 +176,38 @@ fn init_opentelemetry_tracer() -> Option<Tracer> {
     let api_key = std::env::var("NR_INSERT_KEY")
         .ok()
         .filter(|v| !v.trim().is_empty())?;
-    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "https://otlp.nr-data.net/v1/traces".to_owned());
     let service_name = std::env::var("OTEL_SERVICE_NAME")
         .ok()
         .filter(|v| !v.trim().is_empty())
         .unwrap_or_else(|| REPO_NAME.to_owned());
 
-    let exporter = opentelemetry_otlp::SpanExporter::builder()
+    let has_generic_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .is_some();
+    let has_traces_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .is_some();
+
+    let mut exporter_builder = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
-        .with_endpoint(endpoint)
         .with_headers(std::collections::HashMap::from([(
             "api-key".to_owned(),
             api_key,
-        )]))
-        .build()
-        .ok()?;
+        )]));
+
+    if !has_generic_endpoint && !has_traces_endpoint {
+        exporter_builder = exporter_builder.with_endpoint("https://otlp.nr-data.net/v1/traces");
+    }
+
+    let exporter = match exporter_builder.build() {
+        Ok(exporter) => exporter,
+        Err(error) => {
+            eprintln!("OpenTelemetry disabled: failed to build New Relic OTLP exporter ({error})");
+            return None;
+        }
+    };
 
     let resource = opentelemetry_sdk::Resource::builder()
         .with_attribute(opentelemetry::KeyValue::new("service.name", service_name))
@@ -223,12 +238,25 @@ pub fn shutdown_opentelemetry() {
 
 pub fn start_command(command: &'static str) -> CommandObserver {
     init_tracing();
+    let run_id = run_id();
+    let git_sha = git_sha();
+    let span = tracing::info_span!(
+        "command_execution",
+        repo = REPO_NAME,
+        command,
+        run_id = %run_id,
+        git_sha = %git_sha,
+        success = tracing::field::Empty,
+        error_category = tracing::field::Empty,
+        validation_status = tracing::field::Empty,
+    );
     let observer = CommandObserver {
         command,
-        run_id: run_id(),
-        git_sha: git_sha(),
+        run_id,
+        git_sha,
         started: Instant::now(),
         safe_data: RefCell::new(OwnedDiagnosticData::default()),
+        span: RefCell::new(Some(span)),
     };
     annotate_scope(
         observer.command,
@@ -236,14 +264,18 @@ pub fn start_command(command: &'static str) -> CommandObserver {
         &observer.git_sha,
         SafeDiagnosticData::default(),
     );
-    tracing::info_span!(
-        "command_start",
-        repo = REPO_NAME,
-        command = observer.command,
-        run_id = %observer.run_id,
-        git_sha = %observer.git_sha,
-    )
-    .in_scope(|| {
+    if let Some(span) = observer.span.borrow().as_ref() {
+        span.in_scope(|| {
+            tracing::info!(
+                event = "command_start",
+                repo = REPO_NAME,
+                command = observer.command,
+                run_id = %observer.run_id,
+                git_sha = %observer.git_sha,
+                "command_start"
+            );
+        });
+    } else {
         tracing::info!(
             event = "command_start",
             repo = REPO_NAME,
@@ -252,7 +284,7 @@ pub fn start_command(command: &'static str) -> CommandObserver {
             git_sha = %observer.git_sha,
             "command_start"
         );
-    });
+    }
     observer
 }
 
@@ -472,17 +504,27 @@ impl CommandObserver {
             &self.git_sha,
             enriched.as_safe(),
         );
-        tracing::info_span!(
-            "command_finish",
-            repo = REPO_NAME,
-            command = self.command,
-            run_id = %self.run_id,
-            git_sha = %self.git_sha,
-            success = result.is_ok(),
-            error_category = resolved_category,
-            validation_status = resolved_status,
-        )
-        .in_scope(|| {
+        let span = self.span.borrow_mut().take();
+        if let Some(span) = span {
+            span.record("success", result.is_ok());
+            span.record("error_category", resolved_category);
+            span.record("validation_status", resolved_status);
+            span.in_scope(|| {
+                tracing::info!(
+                    event = "command_finish",
+                    repo = REPO_NAME,
+                    command = self.command,
+                    run_id = %self.run_id,
+                    git_sha = %self.git_sha,
+                    latency_ms = self.started.elapsed().as_millis() as u64,
+                    success = result.is_ok(),
+                    error_category = resolved_category,
+                    validation_status = resolved_status,
+                    "command_finish"
+                );
+            });
+            drop(span);
+        } else {
             tracing::info!(
                 event = "command_finish",
                 repo = REPO_NAME,
@@ -495,7 +537,7 @@ impl CommandObserver {
                 validation_status = resolved_status,
                 "command_finish"
             );
-        });
+        }
 
         if let Err(error) = result.as_ref() {
             capture_scoped_error(

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -228,11 +228,11 @@ fn init_opentelemetry_tracer() -> Option<Tracer> {
     Some(OTEL_PROVIDER.get()?.tracer(REPO_NAME))
 }
 
-/// Flush any pending OpenTelemetry spans and shut down the global tracer
-/// provider. Safe to call when OTel was never initialized — it becomes a no-op.
-pub fn shutdown_opentelemetry() {
+/// Flush any pending OpenTelemetry spans without shutting down the global
+/// provider. Safe to call when OTel was never initialized; it becomes a no-op.
+pub fn flush_opentelemetry() {
     if let Some(provider) = OTEL_PROVIDER.get() {
-        let _ = provider.shutdown();
+        let _ = provider.force_flush();
     }
 }
 
@@ -548,7 +548,7 @@ impl CommandObserver {
             );
         }
 
-        shutdown_opentelemetry();
+        flush_opentelemetry();
     }
 }
 

--- a/examples/support/observability.rs
+++ b/examples/support/observability.rs
@@ -9,6 +9,9 @@ use std::process::Command;
 use std::sync::{Once, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::trace::{SdkTracerProvider, Tracer};
 use sentry::ClientInitGuard;
 use serde_json::json;
 use tracing_subscriber::EnvFilter;
@@ -20,7 +23,7 @@ const REPO_NAME: &str = "corinth-canal";
 
 /// OpenTelemetry tracer provider guard. Kept alive for the process lifetime
 /// so the global tracer is not dropped prematurely.
-static OTEL_PROVIDER: OnceLock<opentelemetry_sdk::trace::TracerProvider> = OnceLock::new();
+static OTEL_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SafeDiagnosticData<'a> {
@@ -132,20 +135,34 @@ impl OwnedDiagnosticData {
 pub fn init_tracing() {
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-        let fmt_layer = if std::env::var("AGENTOS_JSON_TRACING").as_deref() == Ok("1") {
-            tracing_subscriber::fmt::layer().json().boxed()
-        } else {
-            tracing_subscriber::fmt::layer().boxed()
-        };
+        let json_tracing = std::env::var("AGENTOS_JSON_TRACING").as_deref() == Ok("1");
 
-        let registry = tracing_subscriber::registry().with(filter).with(fmt_layer);
-
-        match init_opentelemetry_layer() {
-            Some(otel_layer) => {
-                registry.with(otel_layer).init();
+        match (json_tracing, init_opentelemetry_tracer()) {
+            (true, Some(tracer)) => {
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(tracing_subscriber::fmt::layer().json())
+                    .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                    .init();
             }
-            None => {
-                registry.init();
+            (true, None) => {
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(tracing_subscriber::fmt::layer().json())
+                    .init();
+            }
+            (false, Some(tracer)) => {
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(tracing_subscriber::fmt::layer())
+                    .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                    .init();
+            }
+            (false, None) => {
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(tracing_subscriber::fmt::layer())
+                    .init();
             }
         }
     });
@@ -154,19 +171,14 @@ pub fn init_tracing() {
 /// Attempt to build an OpenTelemetry `tracing` layer backed by a New Relic OTLP
 /// exporter. Returns `None` when New Relic credentials are absent or invalid so
 /// the caller can fall back to plain tracing.
-fn init_opentelemetry_layer() -> Option<
-    tracing_opentelemetry::OpenTelemetryLayer<
-        tracing_subscriber::Registry,
-        opentelemetry_sdk::trace::TracerProvider,
-    >,
-> {
+fn init_opentelemetry_tracer() -> Option<Tracer> {
     let api_key = std::env::var("NR_INSERT_KEY")
         .ok()
         .filter(|v| !v.trim().is_empty())?;
     let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "https://otlp.nr-data.net".to_owned());
+        .unwrap_or_else(|| "https://otlp.nr-data.net/v1/traces".to_owned());
     let service_name = std::env::var("OTEL_SERVICE_NAME")
         .ok()
         .filter(|v| !v.trim().is_empty())
@@ -190,7 +202,7 @@ fn init_opentelemetry_layer() -> Option<
         ))
         .build();
 
-    let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_resource(resource)
         .build();
@@ -198,7 +210,7 @@ fn init_opentelemetry_layer() -> Option<
     opentelemetry::global::set_tracer_provider(provider.clone());
     let _ = OTEL_PROVIDER.set(provider);
 
-    Some(tracing_opentelemetry::layer().with_tracer(OTEL_PROVIDER.get()?.tracer(REPO_NAME)))
+    Some(OTEL_PROVIDER.get()?.tracer(REPO_NAME))
 }
 
 /// Flush any pending OpenTelemetry spans and shut down the global tracer
@@ -207,7 +219,6 @@ pub fn shutdown_opentelemetry() {
     if let Some(provider) = OTEL_PROVIDER.get() {
         let _ = provider.shutdown();
     }
-    opentelemetry::global::shutdown_tracer_provider();
 }
 
 pub fn start_command(command: &'static str) -> CommandObserver {
@@ -225,14 +236,23 @@ pub fn start_command(command: &'static str) -> CommandObserver {
         &observer.git_sha,
         SafeDiagnosticData::default(),
     );
-    tracing::info!(
-        event = "command_start",
+    tracing::info_span!(
+        "command_start",
         repo = REPO_NAME,
         command = observer.command,
         run_id = %observer.run_id,
         git_sha = %observer.git_sha,
-        "command_start"
-    );
+    )
+    .in_scope(|| {
+        tracing::info!(
+            event = "command_start",
+            repo = REPO_NAME,
+            command = observer.command,
+            run_id = %observer.run_id,
+            git_sha = %observer.git_sha,
+            "command_start"
+        );
+    });
     observer
 }
 
@@ -452,18 +472,30 @@ impl CommandObserver {
             &self.git_sha,
             enriched.as_safe(),
         );
-        tracing::info!(
-            event = "command_finish",
+        tracing::info_span!(
+            "command_finish",
             repo = REPO_NAME,
             command = self.command,
             run_id = %self.run_id,
             git_sha = %self.git_sha,
-            latency_ms = self.started.elapsed().as_millis() as u64,
             success = result.is_ok(),
             error_category = resolved_category,
             validation_status = resolved_status,
-            "command_finish"
-        );
+        )
+        .in_scope(|| {
+            tracing::info!(
+                event = "command_finish",
+                repo = REPO_NAME,
+                command = self.command,
+                run_id = %self.run_id,
+                git_sha = %self.git_sha,
+                latency_ms = self.started.elapsed().as_millis() as u64,
+                success = result.is_ok(),
+                error_category = resolved_category,
+                validation_status = resolved_status,
+                "command_finish"
+            );
+        });
 
         if let Err(error) = result.as_ref() {
             capture_scoped_error(
@@ -473,6 +505,8 @@ impl CommandObserver {
                 error.as_dyn_error(),
             );
         }
+
+        shutdown_opentelemetry();
     }
 }
 


### PR DESCRIPTION
## **User description**
## Summary
- add actual OpenTelemetry OTLP/HTTP span export to New Relic when `NR_INSERT_KEY` is present
- document New Relic OTLP environment variables in `.env.example` while keeping `.env.local` ignored for real secrets
- emit command-level `command_start` / `command_finish` spans and flush them at command finish so short-lived examples reach New Relic
- fix follow-up OTel issues found during live verification: use blocking reqwest transport, full `/v1/traces` endpoint, and current `SdkTracerProvider` APIs

## Related Issue
- Reopens/completes #73 follow-up scope: PR #86 added verification helpers only; this PR adds real New Relic telemetry emission.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --no-default-features`
- `cargo test --no-default-features`
- Live New Relic smoke run: `cargo run --example telemetry_bridge`
- New Relic NRQL verified a completed span:
  - `SELECT count(*) FROM Span FACET service.name, name, command, validation_status, success SINCE 45 minutes ago LIMIT 100`
  - returned `command_finish`, `command = telemetry_bridge`, `validation_status = completed`, `success = true`

## Secret Safety
- `.env.local` remains gitignored (`.gitignore:32`) and was not committed.
- `.env.example` contains placeholders only; no API keys or license keys are committed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export traces to New Relic via OpenTelemetry in the observability module
> - Adds `init_opentelemetry_tracer` to [observability.rs](https://github.com/rmems/corinth-canal/pull/88/files#diff-dddc32a6497c87df11f23151b1979066842e56d60945abbd354fe194018f0c65) that reads `NR_INSERT_KEY` and builds an OTLP/HTTP `SdkTracerProvider`, defaulting to New Relic endpoints when none are configured.
> - `init_tracing` now conditionally attaches a `tracing-opentelemetry` layer when a tracer is available, falling back to JSON or plain logging otherwise.
> - `CommandObserver` gains a `span` field tracking a `command_execution` span with attributes like `repo`, `run_id`, `git_sha`, and outcome fields; the span is flushed via `flush_opentelemetry` on command finish.
> - New Relic and OTLP environment variables are documented in [.env.example](https://github.com/rmems/corinth-canal/pull/88/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcefcc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


___

## **CodeAnt-AI Description**
**Send command traces to New Relic when configured**

### What Changed
- When `NR_INSERT_KEY` is set, examples now send tracing data to New Relic instead of only logging locally
- Command runs now appear as `command_start` and `command_finish` spans, with the finish span including run outcome and timing
- Spans are flushed before the process exits so short-lived commands can still show up in New Relic
- Added example environment settings for New Relic export, including the ingest key, OTLP endpoint, and service name

### Impact
`✅ Visible command traces in New Relic`
`✅ Fewer missing spans from short example runs`
`✅ Clearer command timing and success reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
