### PR TITLE
feat: add Safetensors backend, experiment output schema, and local model lineup support (#75 #76 #85)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,19 +65,43 @@ NR_QUERY_KEY=
 NEW_RELIC_APP_NAME=
 
 # ---------------------------------------------------------------------------
+# Model root configuration
+# ---------------------------------------------------------------------------
+
+# Base directory for local model checkpoints. When set, example binaries
+# resolve relative model paths against this root. Defaults to unset (paths
+# must be absolute or use compiled-in autodiscovery).
+# 
+# Recommended layout:
+#   $MODEL_ROOT/safetensors/<org>/<model>/  - HF safetensors models
+#   $MODEL_ROOT/gguf/<model>.gguf           - GGUF checkpoints
+MODEL_ROOT=
+
+# ---------------------------------------------------------------------------
 # Checkpoint + embedding tooling
 # ---------------------------------------------------------------------------
 
-# Absolute path to a GGUF checkpoint. When set, overrides model auto-discovery.
-# When unset, saaq_latent_calibration falls back to scanning
-# $HOME/Downloads/SNN_Quantization for the five validated MoE families.
-GGUF_CHECKPOINT_PATH=
+# Absolute path to a checkpoint (GGUF file or safetensors directory). When set,
+# overrides model auto-discovery. When unset, saaq_latent_calibration falls back
+# to scanning $HOME/Downloads/SNN_Quantization for validated MoE families.
+CHECKPOINT_PATH=
+
+# Absolute path to a safetensors lineup TOML file (see
+# configs/safetensors_lineup.template.toml). When set, loads safetensors models
+# for local SAAQ experiments. Takes precedence over CHECKPOINT_PATH when both
+# are set.
+SAFETENSORS_LINEUP_CONFIG=
 
 # Absolute path to the `llama-embedding` binary from llama.cpp. Used by
 # examples/support::pooled_prompt_embedding_from_llama_cpp. If the binary
 # cannot be found, the runner falls back to a deterministic text-hash
 # embedding (stamped as `text_hash_fallback` in run_manifest.json).
 LLAMA_EMBEDDING_BIN=
+
+# Local embedding backend. "ollama" (default) uses nomic-embed-text via
+# localhost. "llama_cpp" uses LLAMA_EMBEDDING_BIN. "hash" uses deterministic
+# text-hash fallback.
+EMBEDDING_BACKEND=ollama
 
 # ---------------------------------------------------------------------------
 # Telemetry source selection
@@ -102,7 +126,7 @@ PROMPT_PROFILE=math_logic
 
 # Optional model family override. One of:
 #   olmoe | qwen3moe | gemma4 | deepseek2 | llama_moe
-# Leave blank to let OlmoeRouter::probe_model infer it from the checkpoint.
+# Leave blank to let Router::probe_model infer it from the checkpoint.
 MODEL_FAMILY=
 
 # SAAQ update rule that fills the legacy latent-CSV columns.
@@ -139,7 +163,7 @@ ROUTING_MODE=spiking
 
 # Path to a TOML lineup file listing MoE checkpoints
 # (see configs/saaq15_moe_lineup.toml). When set, takes precedence over
-# GGUF_CHECKPOINT_PATH and over machine-local autodiscovery.
+# CHECKPOINT_PATH and over machine-local autodiscovery.
 # A path that cannot be read or parsed is a hard error, not a fallback.
 LINEUP_CONFIG=
 

--- a/.hermes/plans/2026-05-16_184500-corinth-canal-docs-alignment.md
+++ b/.hermes/plans/2026-05-16_184500-corinth-canal-docs-alignment.md
@@ -42,7 +42,7 @@ The current top-level flow to document is:
 `-> SignedSplitBankBridge or GPU input_spikes`
 `-> SparseGifHiddenLayer or GPU GIF temporal loop`
 `-> Projector`
-`-> OlmoeRouter`
+`-> Router`
 `-> SAAQ latent calibration / telemetry outputs`
 
 ### Model loading / routing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ TelemetrySnapshot
 -> SignedSplitBankBridge or GPU input_spikes
 -> SparseGifHiddenLayer / GPU GIF temporal loop
 -> Projector
--> OlmoeRouter
+-> Router
 -> routing telemetry / SAAQ latent calibration
 
 This repository is intentionally not split into modular crates yet. Do not

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hidden spike train + membrane state
        v  Projector
 embedding [2048]
        |
-       v  OlmoeRouter
+       v  Router
 expert_weights + selected_experts + routed hidden state
        |
        v  SAAQ latent calibration / telemetry export
@@ -47,7 +47,7 @@ for the full end-to-end loop.
 
 The model-loading interface is custom to this repository.
 
-`OlmoeRouter`:
+`Router`:
 
 - parses GGUF checkpoints in-repo
 - resolves a supported model family from checkpoint metadata
@@ -170,7 +170,7 @@ just saaq
 ### Run the GPU smoke path with a real checkpoint
 
 ```bash
-GGUF_CHECKPOINT_PATH=/path/to/model.gguf just smoke
+CHECKPOINT_PATH=/path/to/model.gguf just smoke
 ```
 
 For the full CUDA validation ladder, including host sanity checks, Compute

--- a/configs/safetensors_lineup.template.toml
+++ b/configs/safetensors_lineup.template.toml
@@ -21,6 +21,13 @@
 #
 # ── Template entries — replace /absolute/path/to with your local paths ────
 
+# ── OLMoE-1B-7B-0125-Instruct (MoE, 64 experts, 3 shards, BF16) ──
+[[model]]
+slug = "olmoe_1b_7b_0125_instruct"
+family = "olmoe"
+path = "/absolute/path/to/.models/safetensors/allenai/OLMoE-1B-7B-0125-Instruct"
+target = "local"
+
 # ── MET-55: nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16 (Dense, single shard) ──
 [[model]]
 slug = "nemotron_3_nano_4b"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ hidden spike train + membrane/adaptation state
        ▼  Projector
 embedding [EMBEDDING_DIM = 2048]
        │
-       ▼  OlmoeRouter (stub | dense | spiking sim)
+       ▼  Router (stub | dense | spiking sim)
 expert_weights + selected_experts + routed hidden state
        │
        ▼  SAAQ latent calibration / telemetry export
@@ -42,7 +42,7 @@ The CPU path is assembled from pure Rust components:
 - `SparseGifHiddenLayer` runs a 2048-neuron GIF hidden layer with adaptive
   thresholds.
 - `Projector` converts hidden activity into a 2048-dimensional embedding.
-- `OlmoeRouter` consumes the embedding and produces expert weights / selected
+- `Router` consumes the embedding and produces expert weights / selected
   experts.
 
 ### GPU path
@@ -106,7 +106,7 @@ Instrumented launch sites:
 | `src/model/core.rs` | Runtime orchestration, config validation, forward paths |
 | `src/model/temporal.rs` | GPU temporal loop (`prepare_gpu_temporal`, `tick_gpu_temporal`, `forward_gpu_temporal`) |
 | `src/model/telemetry_io.rs` | Shared CSV writer for GPU routing telemetry |
-| `src/moe/mod.rs` | `OlmoeRouter` host with routing-mode dispatch |
+| `src/moe/mod.rs` | `Router` host with routing-mode dispatch |
 | `src/moe/checkpoint.rs` | GGUF parse, mmap, tensor slicing, dequantization helpers |
 | `src/moe/adapter.rs` | Model-family adapter resolution and tensor selection |
 | `src/moe/routing.rs` | Router math (gate scores, resampling, normalization, top-k) |
@@ -130,7 +130,7 @@ quantization label. Mixed-quant checkpoints are therefore expected. For
 example, a file named `...IQ4_NL.gguf` can still drive the `dequantized-q8_0`
 path when `blk.0.attn_q.weight` is stored as `Q8_0` inside the GGUF.
 
-`OlmoeRouter`:
+`Router`:
 
 - memory-maps GGUF checkpoints in-repo
 - resolves a supported model family from GGUF metadata

--- a/docs/CUDA_VALIDATION.md
+++ b/docs/CUDA_VALIDATION.md
@@ -67,10 +67,10 @@ cargo test --workspace
 cargo check --example saaq_latent_calibration
 
 # Full default smoke: 10,000 direct GPU ticks.
-GGUF_CHECKPOINT_PATH=/path/to/model.gguf cargo run --release --example gpu_smoke_test
+CHECKPOINT_PATH=/path/to/model.gguf cargo run --release --example gpu_smoke_test
 
 # Short deterministic smoke for fast validation or sanitizer setup.
-GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=/path/to/model.gguf \
+GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=/path/to/model.gguf \
   cargo run --release --example gpu_smoke_test
 ```
 
@@ -100,17 +100,17 @@ Commands:
 ```bash
 mkdir -p artifacts/cuda-validation
 
-GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=/path/to/model.gguf \
+GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=/path/to/model.gguf \
   compute-sanitizer --tool memcheck \
   --log-file artifacts/cuda-validation/memcheck.log \
   cargo run --release --example gpu_smoke_test
 
-GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=/path/to/model.gguf \
+GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=/path/to/model.gguf \
   compute-sanitizer --tool synccheck \
   --log-file artifacts/cuda-validation/synccheck.log \
   cargo run --release --example gpu_smoke_test
 
-GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=/path/to/model.gguf \
+GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=/path/to/model.gguf \
   compute-sanitizer --tool racecheck \
   --log-file artifacts/cuda-validation/racecheck.log \
   cargo run --release --example gpu_smoke_test
@@ -136,7 +136,7 @@ Command:
 ```bash
 mkdir -p artifacts/cuda-validation
 
-GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=/path/to/model.gguf \
+GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=/path/to/model.gguf \
   nsys profile -o artifacts/cuda-validation/nsys_gpu_smoke \
   cargo run --release --example gpu_smoke_test
 ```
@@ -158,7 +158,7 @@ Command:
 ```bash
 mkdir -p artifacts/cuda-validation
 
-GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=/path/to/model.gguf \
+GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=/path/to/model.gguf \
   ncu --set full -o artifacts/cuda-validation/ncu_gpu_smoke \
   cargo run --release --example gpu_smoke_test
 ```

--- a/docs/MODULE_STATUS.md
+++ b/docs/MODULE_STATUS.md
@@ -11,7 +11,7 @@ Status legend: `reference` · `stabilizing` · `proven` · `frozen`
 | `src/model/core.rs` | reference | `rmems-model` | Orchestration layer still couples runtime behavior, artifact wiring, and GGUF-backed routing. Not yet ready to promote as an isolated surface. |
 | `src/model/temporal.rs` | stabilizing | `rmems-model` | GPU temporal loop is tight and proven. Legacy fallback to a CWD-relative routing CSV still exists when `ModelConfig::gpu_routing_telemetry_path` is unset, so callers must keep the sink explicit. |
 | `src/model/telemetry_io.rs` | stabilizing | `rmems-model` | Pure helper. Public behavior is stable; promotion depends mainly on the surrounding runtime/API cleanup. |
-| `src/moe/mod.rs` | stabilizing | `rmems-moe` | Host entry for `OlmoeRouter`; surface is clean. Pending full model-family validation matrix. |
+| `src/moe/mod.rs` | stabilizing | `rmems-moe` | Host entry for `Router`; surface is clean. Pending full model-family validation matrix. |
 | `src/moe/checkpoint.rs` | reference | `rmems-moe` | GGUF parser/mmap/dequant layer works, but still needs a broader parser and format test battery before promotion. |
 | `src/moe/adapter.rs` | stabilizing | `rmems-moe` | Five-family adapter resolution is implemented; needs broader validation coverage. |
 | `src/moe/routing.rs` | stabilizing | `rmems-moe` | Stateless routing math. Low-risk promotion candidate. |

--- a/docs/RUN_PROFILES.md
+++ b/docs/RUN_PROFILES.md
@@ -64,8 +64,8 @@ The latent telemetry CSV includes both SAAQ trajectories via
 
 | Profile | Command |
 |---------|---------|
-| 10k GPU ticks, real checkpoint | `GGUF_CHECKPOINT_PATH=... just smoke` |
-| Short deterministic GPU smoke | `GPU_SMOKE_TICKS=1 GGUF_CHECKPOINT_PATH=... cargo run --release --example gpu_smoke_test` |
+| 10k GPU ticks, real checkpoint | `CHECKPOINT_PATH=... just smoke` |
+| Short deterministic GPU smoke | `GPU_SMOKE_TICKS=1 CHECKPOINT_PATH=... cargo run --release --example gpu_smoke_test` |
 
 This example is the direct GPU-temporal smoke path. It is the correct entrypoint
 for validating resident synapse upload, GIF weighted temporal stepping, and the
@@ -152,7 +152,7 @@ Hugging Face `.safetensors.index.json` metadata; it does not create a project,
 run activation tracing, or load tensor payload bytes.
 
 Use GGUF when the goal is current `corinth-canal` runtime routing. The
-`OlmoeRouter` path remains GGUF-backed for token embedding extraction, routing
+`Router` path remains GGUF-backed for token embedding extraction, routing
 tensor access, and GPU synapse-source selection. Safetensors support is a setup
 and inspection adapter for experiment preparation, not a replacement for the
 runtime GGUF bridge.
@@ -179,7 +179,7 @@ timestamp_ms,gpu_temp_c,gpu_power_w,cpu_tctl_c,cpu_package_power_w
 
 ## Model discovery
 
-If `GGUF_CHECKPOINT_PATH` is unset, `saaq_latent_calibration` auto-discovers
+If `CHECKPOINT_PATH` is unset, `saaq_latent_calibration` auto-discovers
 up to five MoE families under `$HOME/Downloads/SNN_Quantization/`:
 
 - `olmoe-0125-gguf/OLMoE-1B-7B-0125-Instruct-F16.gguf`
@@ -189,7 +189,7 @@ up to five MoE families under `$HOME/Downloads/SNN_Quantization/`:
 - `models/Llama-3.2-8X3B-MOE-Dark-Champion-GGUF/L3.2-8X3B-MOE-Dark-Champion-Inst-18.4B-uncen-ablit_D_AU-q5_k_m.gguf`
 
 This discovery root is a machine-local convention on the author's Fedora
-box. CI and contributor machines should set `GGUF_CHECKPOINT_PATH`
+box. CI and contributor machines should set `CHECKPOINT_PATH`
 explicitly.
 
 Do not assume the filename suffix tells you which GPU synapse path will be

--- a/docs/experiments/01_semantic_latent_calibration.md
+++ b/docs/experiments/01_semantic_latent_calibration.md
@@ -16,7 +16,7 @@ I verified the bare-metal GPU temporal loop using a synthetic sine wave. The Spi
 
 ![Routing Collapse](latent_space_exploration_first_real_attempt.png)
 
-I fed real LLM embeddings from the OlmoeRouter GGUF file. The weights were safely cast from F16 to F32, but the raw, unbounded electrical pressure of the semantic vector overpowered the network's fatigue mechanics. This resulted in a 'Winner-Take-All' routing collapse where a single neuron took the entire load for 10,000 ticks.
+I fed real LLM embeddings from the Router GGUF file. The weights were safely cast from F16 to F32, but the raw, unbounded electrical pressure of the semantic vector overpowered the network's fatigue mechanics. This resulted in a 'Winner-Take-All' routing collapse where a single neuron took the entire load for 10,000 ticks.
 
 ---
 

--- a/docs/model_lineup.md
+++ b/docs/model_lineup.md
@@ -15,7 +15,7 @@ share a provider family, architecture, or deployment target.
 
 ### Batch A — Local GGUF routing targets (completed)
 
-Models that can be loaded locally via the GGUF-backed `OlmoeRouter` for SAAQ
+Models that can be loaded locally via the GGUF-backed `Router` for SAAQ
 latent calibration runs.
 
 | MET | Slug | Provider/Model | Family | Quant |

--- a/examples/csv_replay.rs
+++ b/examples/csv_replay.rs
@@ -61,7 +61,7 @@ fn run(observer: &CommandObserver) -> corinth_canal::Result<()> {
 
     let run_cfg = RunConfig::from_env();
     let mut safe = SafeDiagnosticData::default().with_telemetry_source("csv");
-    if let Some(model_slug) = observability::checkpoint_slug(&run_cfg.gguf_checkpoint_path) {
+    if let Some(model_slug) = observability::checkpoint_slug(&run_cfg.checkpoint_path) {
         safe = safe.with_model_slug(&model_slug);
         observer.annotate(safe);
     } else {
@@ -69,7 +69,7 @@ fn run(observer: &CommandObserver) -> corinth_canal::Result<()> {
     }
 
     let csv_path = &args[1];
-    let cfg = default_spiking_model_config(run_cfg.gguf_checkpoint_path.clone(), 20);
+    let cfg = default_spiking_model_config(run_cfg.checkpoint_path.clone(), 20);
 
     let mut model = Model::new_with_projector_neurons(cfg.clone(), FUNNEL_HIDDEN_NEURONS)?;
     let mut funnel = TelemetryFunnel::new(TELEMETRY_THRESHOLDS, cfg.snn_steps);

--- a/examples/gpu_smoke_test.rs
+++ b/examples/gpu_smoke_test.rs
@@ -21,16 +21,16 @@ fn run(observer: &CommandObserver) -> Result<(), Box<dyn std::error::Error>> {
     let run_cfg = RunConfig::from_env();
     let smoke_ticks = gpu_smoke_ticks();
     let mut safe = SafeDiagnosticData::default();
-    if let Some(model_slug) = observability::checkpoint_slug(&run_cfg.gguf_checkpoint_path) {
+    if let Some(model_slug) = observability::checkpoint_slug(&run_cfg.checkpoint_path) {
         safe = safe.with_model_slug(&model_slug);
         observer.annotate(safe);
     } else {
         observer.annotate(safe);
     }
-    if run_cfg.gguf_checkpoint_path.trim().is_empty() {
-        return Err(Error::other("GGUF_CHECKPOINT_PATH must point to a GGUF checkpoint").into());
+    if run_cfg.checkpoint_path.trim().is_empty() {
+        return Err(Error::other("CHECKPOINT_PATH must point to a GGUF checkpoint").into());
     }
-    let model_path = run_cfg.gguf_checkpoint_path.clone();
+    let model_path = run_cfg.checkpoint_path.clone();
     let model_label = observability::checkpoint_slug(&model_path)
         .unwrap_or_else(|| "configured_checkpoint".to_owned());
 
@@ -48,7 +48,7 @@ fn run(observer: &CommandObserver) -> Result<(), Box<dyn std::error::Error>> {
 
     if !model.router_loaded() {
         return Err(
-            Error::other("OlmoeRouter model did not load from GGUF_CHECKPOINT_PATH").into(),
+            Error::other("Router model did not load from CHECKPOINT_PATH").into(),
         );
     }
     if !accelerator.is_ready() {

--- a/examples/gpu_smoke_test.rs
+++ b/examples/gpu_smoke_test.rs
@@ -47,9 +47,7 @@ fn run(observer: &CommandObserver) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     if !model.router_loaded() {
-        return Err(
-            Error::other("Router model did not load from CHECKPOINT_PATH").into(),
-        );
+        return Err(Error::other("Router model did not load from CHECKPOINT_PATH").into());
     }
     if !accelerator.is_ready() {
         return Err(Error::other("GpuAccelerator is not ready").into());

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -5,7 +5,6 @@ use corinth_canal::{
     FunnelActivity, SaaqUpdateRule, SnnDualLatentCalibrator, SnnLatentCsvExporter,
     gpu::GpuAccelerator, model::Model,
 };
-use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Error, Write};

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use corinth_canal::{
+    ExperimentManifest, ExperimentMetrics, ExperimentSummary,
     FunnelActivity, SaaqUpdateRule, SnnDualLatentCalibrator, SnnLatentCsvExporter,
     gpu::GpuAccelerator, model::Model,
 };
@@ -16,81 +17,6 @@ use support::{
     observability::{self, CommandObserver, SafeDiagnosticData},
     prompt_embedding_for_validation, telemetry_snapshot_for_tick,
 };
-
-#[derive(Debug, Serialize)]
-struct ValidationManifest {
-    model_slug: String,
-    model_family: String,
-    architecture: String,
-    checkpoint_path: String,
-    routing_tensor_name: String,
-    synapse_source: String,
-    checkpoint_format: &'static str,
-    prompt_embedding_source: String,
-    prompt_profile: String,
-    prompt_text: String,
-    ticks: usize,
-    saaq_rule: &'static str,
-    saaq_primary_rule: &'static str,
-    saaq_dual_emit: bool,
-    validation_status: &'static str,
-    error: Option<String>,
-    telemetry_source: String,
-    telemetry_csv_path: Option<String>,
-    telemetry_row_count: Option<usize>,
-    wraparound_enabled: bool,
-    wraparound_loops: u64,
-    ticks_effective: usize,
-    run_id: String,
-    run_dir: String,
-    output_root: String,
-    repeat_idx: usize,
-    repeat_count: usize,
-    cwd_routing_csv_contaminated: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    run_tag: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    routing_mode: Option<&'static str>,
-    generated_files: Vec<String>,
-}
-
-/// Compact, stable per-run summary consumed by downstream aggregators. Lives
-/// alongside `run_manifest.json` inside every run directory.
-#[derive(Debug, Serialize)]
-struct RunSummary {
-    run_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    run_tag: Option<String>,
-    model_slug: String,
-    model_family: String,
-    telemetry_source: String,
-    repeat_idx: usize,
-    repeat_count: usize,
-    saaq_rule: &'static str,
-    validation_status: &'static str,
-    run_dir: String,
-    manifest_path: String,
-    tick_telemetry_path: String,
-    latent_telemetry_path: String,
-    metrics: RunMetrics,
-    /// `None` when strict-repeat is disabled or `repeat_count < 2`; populated
-    /// to `"matched"` / `"mismatch"` by the strict-repeat pass at the end of
-    /// `main()` only when the check actually ran.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    repeat_determinism: Option<&'static str>,
-}
-
-#[derive(Debug, Default, Serialize)]
-struct RunMetrics {
-    ticks_completed: usize,
-    latent_rows: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mean_tick_elapsed_us: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    first_timestamp_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    last_timestamp_ms: Option<u64>,
-}
 
 /// Row buffered in-memory during a sweep, flushed once at end-of-`main`
 /// into `artifacts/index.csv`. Append-only by construction: every row is
@@ -209,7 +135,7 @@ fn run_main(observer: &CommandObserver) -> Result<(), Box<dyn std::error::Error>
 
     if cfg.validation_models.is_empty() {
         return Err(Error::other(
-            "No GGUF validation models discovered. Set GGUF_CHECKPOINT_PATH or place models under ~/Downloads/SNN_Quantization.",
+            "No GGUF validation models discovered. Set CHECKPOINT_PATH or place models under ~/Downloads/SNN_Quantization.",
         )
         .into());
     }
@@ -347,7 +273,7 @@ fn run_validation(
 
     // Metrics accumulator. Populated during the tick loop; stamped into
     // summary.json at every terminal status (completed / *_failed).
-    let mut metrics = RunMetrics::default();
+    let mut metrics = ExperimentMetrics::default();
 
     let target_neurons = model.projector_mut().input_neurons();
     let (prompt_embedding, prompt_embedding_source) =
@@ -654,7 +580,7 @@ fn build_manifest(
     validation_status: &'static str,
     error: Option<String>,
     generated_files: Vec<String>,
-) -> ValidationManifest {
+) -> ExperimentManifest {
     let telemetry_row_count = ctx.resolved.row_count();
     let wraparound_enabled = telemetry_row_count
         .map(|rows| rows > 0 && ctx.ticks > rows)
@@ -668,22 +594,27 @@ fn build_manifest(
         .map(|rows| ((ctx.ticks - rows) as u64) / (rows as u64) + 1)
         .unwrap_or(0);
 
-    ValidationManifest {
+    ExperimentManifest {
+        run_id: ctx.run_id.clone(),
+        run_tag: ctx.run_tag.map(|s| s.to_owned()),
+        created_at: format!("{:?}", std::time::SystemTime::now()),
+        repo: "corinth-canal".to_owned(),
+        commit_sha: None,
         model_slug: ctx.spec.slug.clone(),
         model_family: format!("{:?}", model.router_family()),
         architecture: model.router_architecture().to_owned(),
         checkpoint_path: ctx.spec.path.clone(),
+        checkpoint_format: "gguf".to_owned(),
         routing_tensor_name: model.routing_tensor_name().to_owned(),
         synapse_source: model.synapse_source().to_owned(),
-        checkpoint_format: "gguf",
         prompt_embedding_source: prompt_embedding_source.to_owned(),
         prompt_profile: ctx.prompt_profile.to_owned(),
-        prompt_text: ctx.prompt_text.to_owned(),
+        prompt_text: Some(ctx.prompt_text.to_owned()),
         ticks: ctx.ticks,
-        saaq_rule: saaq_rule_label(saaq_rule),
-        saaq_primary_rule: saaq_rule_label(saaq_rule),
+        saaq_rule: saaq_rule_label(saaq_rule).to_owned(),
+        saaq_primary_rule: saaq_rule_label(saaq_rule).to_owned(),
         saaq_dual_emit: true,
-        validation_status,
+        validation_status: validation_status.to_owned(),
         error,
         telemetry_source: ctx.resolved.source_label.clone(),
         telemetry_csv_path: ctx
@@ -695,19 +626,11 @@ fn build_manifest(
         wraparound_enabled,
         wraparound_loops,
         ticks_effective: ctx.ticks,
-        run_id: ctx.run_id.clone(),
         run_dir: run_dir.to_string_lossy().into_owned(),
         output_root: ctx.output_root.to_string_lossy().into_owned(),
         repeat_idx: ctx.repeat_idx,
         repeat_count: ctx.repeat_count,
-        // True iff the routing CSV would land in CWD. Since Stage E this
-        // runner always sets `ModelConfig::gpu_routing_telemetry_path` to
-        // an absolute path inside `run_dir`, so CWD contamination is
-        // impossible regardless of whether `tick_gpu_temporal` or
-        // `forward_gpu_temporal` is used.
-        cwd_routing_csv_contaminated: config.gpu_routing_telemetry_path.is_none(),
-        run_tag: ctx.run_tag.map(|s| s.to_owned()),
-        routing_mode: Some(routing_mode_label(config.routing_mode)),
+        routing_mode: Some(routing_mode_label(config.routing_mode).to_owned()),
         generated_files,
     }
 }
@@ -723,7 +646,7 @@ fn routing_mode_label(mode: corinth_canal::moe::RoutingMode) -> &'static str {
 
 fn write_manifest(
     manifest_path: &PathBuf,
-    manifest: ValidationManifest,
+    manifest: ExperimentManifest,
 ) -> Result<(), Box<dyn std::error::Error>> {
     fs::write(manifest_path, serde_json::to_string_pretty(&manifest)?)?;
     Ok(())
@@ -731,7 +654,7 @@ fn write_manifest(
 
 fn write_summary(
     summary_path: &std::path::Path,
-    summary: &RunSummary,
+    summary: &ExperimentSummary,
 ) -> Result<(), Box<dyn std::error::Error>> {
     fs::write(summary_path, serde_json::to_string_pretty(summary)?)?;
     Ok(())
@@ -754,7 +677,7 @@ fn write_manifest_and_summary(
     saaq_rule: SaaqUpdateRule,
     validation_status: &'static str,
     error: Option<String>,
-    metrics: &RunMetrics,
+    metrics: &ExperimentMetrics,
     generated_files: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     write_manifest(
@@ -798,9 +721,9 @@ fn build_summary(
     latent_path: &std::path::Path,
     saaq_rule: SaaqUpdateRule,
     validation_status: &'static str,
-    metrics: &RunMetrics,
-) -> RunSummary {
-    RunSummary {
+    metrics: &ExperimentMetrics,
+) -> ExperimentSummary {
+    ExperimentSummary {
         run_id: ctx.run_id.clone(),
         run_tag: ctx.run_tag.map(|s| s.to_owned()),
         model_slug: ctx.spec.slug.clone(),
@@ -808,18 +731,19 @@ fn build_summary(
         telemetry_source: ctx.resolved.source_label.clone(),
         repeat_idx: ctx.repeat_idx,
         repeat_count: ctx.repeat_count,
-        saaq_rule: saaq_rule_label(saaq_rule),
-        validation_status,
+        saaq_rule: saaq_rule_label(saaq_rule).to_owned(),
+        validation_status: validation_status.to_owned(),
         run_dir: run_dir.to_string_lossy().into_owned(),
         manifest_path: manifest_path.to_string_lossy().into_owned(),
         tick_telemetry_path: tick_path.to_string_lossy().into_owned(),
         latent_telemetry_path: latent_path.to_string_lossy().into_owned(),
-        metrics: RunMetrics {
+        metrics: ExperimentMetrics {
             ticks_completed: metrics.ticks_completed,
             latent_rows: metrics.latent_rows,
             mean_tick_elapsed_us: metrics.mean_tick_elapsed_us,
             first_timestamp_ms: metrics.first_timestamp_ms,
             last_timestamp_ms: metrics.last_timestamp_ms,
+            ..Default::default()
         },
         repeat_determinism: None,
     }
@@ -841,7 +765,7 @@ fn pending_row_from_state(
     run_dir: &Path,
     latent_path: &Path,
     summary_path: &Path,
-    metrics: &RunMetrics,
+    metrics: &ExperimentMetrics,
     validation_status: &'static str,
 ) -> PendingIndexRow {
     PendingIndexRow {

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -1,9 +1,8 @@
 mod support;
 
 use corinth_canal::{
-    ExperimentManifest, ExperimentMetrics, ExperimentSummary,
-    FunnelActivity, SaaqUpdateRule, SnnDualLatentCalibrator, SnnLatentCsvExporter,
-    gpu::GpuAccelerator, model::Model,
+    ExperimentManifest, ExperimentMetrics, ExperimentSummary, FunnelActivity, SaaqUpdateRule,
+    SnnDualLatentCalibrator, SnnLatentCsvExporter, gpu::GpuAccelerator, model::Model,
 };
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};

--- a/examples/saaq_latent_calibration.rs
+++ b/examples/saaq_latent_calibration.rs
@@ -602,7 +602,7 @@ fn build_manifest(
         model_family: format!("{:?}", model.router_family()),
         architecture: model.router_architecture().to_owned(),
         checkpoint_path: ctx.spec.path.clone(),
-        checkpoint_format: "gguf".to_owned(),
+        checkpoint_format: config.checkpoint_format.as_str().to_owned(),
         routing_tensor_name: model.routing_tensor_name().to_owned(),
         synapse_source: model.synapse_source().to_owned(),
         prompt_embedding_source: prompt_embedding_source.to_owned(),

--- a/examples/support/config.rs
+++ b/examples/support/config.rs
@@ -169,7 +169,7 @@ fn validate_safetensors_lineup_entries(path: &Path, entries: &[SafetensorsModelE
 /// Resolve the validation-model list with the documented precedence:
 ///
 ///   1. `LINEUP_CONFIG` file (hard error if set but unparseable).
-    ///   2. `CHECKPOINT_PATH` (single-model override via the legacy path).
+///   2. `CHECKPOINT_PATH` (single-model override via the legacy path).
 ///   3. Machine-local autodiscovery under `$HOME/Downloads/SNN_Quantization`.
 fn resolve_validation_models(
     lineup_path: Option<&Path>,

--- a/examples/support/config.rs
+++ b/examples/support/config.rs
@@ -78,8 +78,12 @@ impl RunConfig {
         // when campaign provenance is added back to `ValidationManifest`,
         // re-introduce both fields together in one focused commit.
         let lineup_config_path = lineup_config_path_from_env();
-        let validation_models =
-            resolve_validation_models(lineup_config_path.as_deref(), &checkpoint_path);
+        let safetensors_lineup_path = safetensors_lineup_path_from_env();
+        let validation_models = resolve_validation_models(
+            lineup_config_path.as_deref(),
+            safetensors_lineup_path.as_deref(),
+            &checkpoint_path,
+        );
         Self {
             prompt_profile: prompt_profile.clone(),
             prompt_text,
@@ -173,6 +177,7 @@ fn validate_safetensors_lineup_entries(path: &Path, entries: &[SafetensorsModelE
 ///   3. Machine-local autodiscovery under `$HOME/Downloads/SNN_Quantization`.
 fn resolve_validation_models(
     lineup_path: Option<&Path>,
+    safetensors_lineup_path: Option<&Path>,
     checkpoint_path: &str,
 ) -> Vec<ValidationModelSpec> {
     if let Some(path) = lineup_path {
@@ -185,16 +190,33 @@ fn resolve_validation_models(
                 } else {
                     ""
                 };
-                // Hard-fail with a loud message so a typo / missing path is
-                // never silently papered over by autodiscovery.
                 panic!("LINEUP_CONFIG={path_str} could not be loaded: {err}{hint}");
             }
         }
     }
 
-    // Legacy single-model override or autodiscovery — let the existing
-    // helper keep its current contract.
-    let _ = checkpoint_path; // discover_validation_models reads it directly
+    if let Some(path) = safetensors_lineup_path {
+        match load_safetensors_lineup(path) {
+            Ok(entries) => {
+                return entries
+                    .into_iter()
+                    .map(|entry| ValidationModelSpec {
+                        slug: entry.slug,
+                        family: entry.family,
+                        path: entry.path.display().to_string(),
+                        routing_mode: None,
+                    })
+                    .collect();
+            }
+            Err(err) => {
+                let path_str = path.display().to_string();
+                panic!("SAFETENSORS_LINEUP_CONFIG={path_str} could not be loaded: {err}");
+            }
+        }
+    }
+
+    // Legacy single-model override or autodiscovery
+    let _ = checkpoint_path;
     discover_validation_models()
 }
 

--- a/examples/support/config.rs
+++ b/examples/support/config.rs
@@ -52,7 +52,7 @@ pub struct RunConfig {
     pub model_family_override: Option<ModelFamily>,
     pub saaq_rule: SaaqUpdateRule,
     pub validation_models: Vec<ValidationModelSpec>,
-    pub gguf_checkpoint_path: String,
+    pub checkpoint_path: String,
     pub routing_mode_override: Option<RoutingMode>,
     /// Free-form run tag from `RUN_TAG`. Empty / unset maps to `None` so
     /// callers can just do `if let Some(tag) = cfg.run_tag { ... }`.
@@ -71,7 +71,7 @@ impl RunConfig {
     pub fn from_env() -> Self {
         let prompt_profile = prompt_profile_slug();
         let prompt_text = prompt_text_for_profile(&prompt_profile);
-        let gguf_checkpoint_path = std::env::var("GGUF_CHECKPOINT_PATH").unwrap_or_default();
+        let checkpoint_path = std::env::var("CHECKPOINT_PATH").unwrap_or_default();
         validate_optional_lineups_from_env();
         // Local binding only — used to pick the lineup TOML below. The
         // resolved path is intentionally not stamped onto `RunConfig` yet;
@@ -79,7 +79,7 @@ impl RunConfig {
         // re-introduce both fields together in one focused commit.
         let lineup_config_path = lineup_config_path_from_env();
         let validation_models =
-            resolve_validation_models(lineup_config_path.as_deref(), &gguf_checkpoint_path);
+            resolve_validation_models(lineup_config_path.as_deref(), &checkpoint_path);
         Self {
             prompt_profile: prompt_profile.clone(),
             prompt_text,
@@ -90,7 +90,7 @@ impl RunConfig {
             model_family_override: model_family_override_from_env(),
             saaq_rule: saaq_update_rule_from_env(),
             validation_models,
-            gguf_checkpoint_path,
+            checkpoint_path,
             routing_mode_override: routing_mode_override_from_env(),
             run_tag: run_tag_from_env(),
             strict_repeat_check: strict_repeat_check_from_env(),
@@ -169,11 +169,11 @@ fn validate_safetensors_lineup_entries(path: &Path, entries: &[SafetensorsModelE
 /// Resolve the validation-model list with the documented precedence:
 ///
 ///   1. `LINEUP_CONFIG` file (hard error if set but unparseable).
-///   2. `GGUF_CHECKPOINT_PATH` (single-model override via the legacy path).
+    ///   2. `CHECKPOINT_PATH` (single-model override via the legacy path).
 ///   3. Machine-local autodiscovery under `$HOME/Downloads/SNN_Quantization`.
 fn resolve_validation_models(
     lineup_path: Option<&Path>,
-    gguf_checkpoint_path: &str,
+    checkpoint_path: &str,
 ) -> Vec<ValidationModelSpec> {
     if let Some(path) = lineup_path {
         match load_lineup_file(path) {
@@ -194,7 +194,7 @@ fn resolve_validation_models(
 
     // Legacy single-model override or autodiscovery — let the existing
     // helper keep its current contract.
-    let _ = gguf_checkpoint_path; // discover_validation_models reads it directly
+    let _ = checkpoint_path; // discover_validation_models reads it directly
     discover_validation_models()
 }
 

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -11,7 +11,7 @@ pub use lineup::{
     safetensors_lineup_path_from_env,
 };
 
-use corinth_canal::{ModelFamily, SaaqUpdateRule, moe::OlmoeRouter, moe::RoutingMode};
+use corinth_canal::{ModelFamily, SaaqUpdateRule, moe::Router, moe::RoutingMode};
 #[cfg(feature = "cuda")]
 use corinth_canal::{model::ModelConfig, projector::ProjectionMode};
 use std::io::Error;
@@ -44,15 +44,15 @@ pub struct ValidationModelSpec {
 
 #[allow(dead_code)]
 #[cfg(feature = "cuda")]
-pub fn default_spiking_model_config(gguf_checkpoint_path: String, snn_steps: usize) -> ModelConfig {
-    let probe = if gguf_checkpoint_path.trim().is_empty() {
+pub fn default_spiking_model_config(checkpoint_path: String, snn_steps: usize) -> ModelConfig {
+    let probe = if checkpoint_path.trim().is_empty() {
         None
     } else {
-        OlmoeRouter::probe_model(&gguf_checkpoint_path, None).ok()
+        Router::probe_model(&checkpoint_path, None).ok()
     };
 
     ModelConfig {
-        gguf_checkpoint_path,
+        checkpoint_path,
         model_family: probe.as_ref().map(|metadata| metadata.family),
         gpu_synapse_tensor_name: probe
             .as_ref()
@@ -269,10 +269,10 @@ pub fn pooled_prompt_embedding_from_ollama(
 }
 
 pub fn discover_validation_models() -> Vec<ValidationModelSpec> {
-    if let Ok(path) = std::env::var("GGUF_CHECKPOINT_PATH")
+    if let Ok(path) = std::env::var("CHECKPOINT_PATH")
         && !path.trim().is_empty()
     {
-        let family = OlmoeRouter::probe_model(&path, None)
+        let family = Router::probe_model(&path, None)
             .ok()
             .map(|metadata| metadata.family);
         return vec![ValidationModelSpec {

--- a/examples/synapse_diagnostic.rs
+++ b/examples/synapse_diagnostic.rs
@@ -1,7 +1,7 @@
 //! Diagnostic pass for issue #31.
 //!
 //! Loads each validation model in the configured lineup (LINEUP_CONFIG, then
-//! GGUF_CHECKPOINT_PATH, then autodiscovery — same precedence as the SAAQ
+//! CHECKPOINT_PATH, then autodiscovery — same precedence as the SAAQ
 //! runner) and prints, per model, the GGUF facts that drive the
 //! synthetic-vs-real synapse decision in
 //! `src/moe/adapter.rs::resolve_adapter`. Writes a JSON report to
@@ -17,7 +17,7 @@ use std::io::{BufWriter, Write};
 use serde::Serialize;
 
 use corinth_canal::ModelFamily;
-use corinth_canal::moe::{GpuSynapseTensorDescriptor, OlmoeRouter, RoutingMode};
+use corinth_canal::moe::{GpuSynapseTensorDescriptor, Router, RoutingMode};
 use support::config::RunConfig;
 use support::{
     ValidationModelSpec,
@@ -66,13 +66,13 @@ fn probe_one(
 
     // StubUniform routing keeps the load cheap: no gate-score precompute, no
     // membrane state, no GPU bring-up. We only need the metadata + checkpoint
-    // map that `OlmoeRouter::load_with_family_and_mode` already builds. Apply
+    // map that `Router::load_with_family_and_mode` already builds. Apply
     // the same `model_family_override.or(spec.family)` precedence as the SAAQ
     // runner (`run_validation` in `examples/saaq_latent_calibration.rs`) so
     // the diagnostic agrees with production routing on lineups that rely on
     // a global `MODEL_FAMILY` override.
     let effective_family = model_family_override.or(spec.family);
-    match OlmoeRouter::load_with_family_and_mode(
+    match Router::load_with_family_and_mode(
         &spec.path,
         0,
         0,
@@ -167,7 +167,7 @@ fn run(observer: &CommandObserver) -> Result<(), Box<dyn std::error::Error>> {
     if cfg.validation_models.is_empty() {
         eprintln!(
             "synapse_diagnostic: no validation models resolved (LINEUP_CONFIG / \
-             GGUF_CHECKPOINT_PATH / autodiscovery all returned empty)"
+             CHECKPOINT_PATH / autodiscovery all returned empty)"
         );
     }
 

--- a/examples/telemetry_bridge.rs
+++ b/examples/telemetry_bridge.rs
@@ -21,7 +21,7 @@ fn main() -> corinth_canal::Result<()> {
 fn run(observer: &CommandObserver) -> corinth_canal::Result<()> {
     let run_cfg = RunConfig::from_env();
     let mut safe = SafeDiagnosticData::default().with_telemetry_source("synthetic");
-    if let Some(model_slug) = observability::checkpoint_slug(&run_cfg.gguf_checkpoint_path) {
+    if let Some(model_slug) = observability::checkpoint_slug(&run_cfg.checkpoint_path) {
         safe = safe.with_model_slug(&model_slug);
         observer.annotate(safe);
     } else {
@@ -31,7 +31,7 @@ fn run(observer: &CommandObserver) -> corinth_canal::Result<()> {
         .routing_mode_override
         .unwrap_or(RoutingMode::SpikingSim);
 
-    let mut cfg = default_spiking_model_config(run_cfg.gguf_checkpoint_path.clone(), 20);
+    let mut cfg = default_spiking_model_config(run_cfg.checkpoint_path.clone(), 20);
     cfg.routing_mode = routing_mode;
 
     let mut model = Model::new(cfg)?;

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ test:
     cargo test
 
 # GPU smoke test — 10k direct GPU ticks against a real GGUF checkpoint.
-# Requires GGUF_CHECKPOINT_PATH in .env.local.
+# Requires CHECKPOINT_PATH in .env.local.
 smoke:
     cargo run --release --example gpu_smoke_test
 
@@ -64,7 +64,7 @@ saaq-sweep:
 bridge:
     cargo run --release --example telemetry_bridge
 
-# Probe the configured lineup (LINEUP_CONFIG / GGUF_CHECKPOINT_PATH /
+# Probe the configured lineup (LINEUP_CONFIG / CHECKPOINT_PATH /
 # autodiscovery) and print the preferred GPU synapse tensor + ggml_type per
 # model. Writes <output_root>/synapse_diagnostic.json. No SAAQ ticks and no
 # campaign side-effects (issue #31).

--- a/manifests/proven_components.toml
+++ b/manifests/proven_components.toml
@@ -30,7 +30,7 @@ last_proven_run = ""
 path            = "src/moe/mod.rs"
 status          = "stabilizing"
 target_repo     = "rmems-moe"
-owner_notes     = "OlmoeRouter host; pending full five-family matrix."
+owner_notes     = "Router host; pending full five-family matrix."
 last_proven_run = ""
 
 [[component]]

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,9 +33,9 @@ pub enum HybridError {
     #[error("input length mismatch: expected {expected}, got {got}")]
     InputLengthMismatch { expected: usize, got: usize },
 
-    /// OlmoeRouter forward pass returned an error.
-    #[error("OlmoeRouter forward pass failed: {0}")]
-    OlmoeForward(String),
+    /// Router forward pass returned an error.
+    #[error("Router forward pass failed: {0}")]
+    RouterForward(String),
 
     // ── I/O errors ────────────────────────────────────────────────────────
     #[error("I/O error: {0}")]

--- a/src/experiment/mod.rs
+++ b/src/experiment/mod.rs
@@ -1,0 +1,7 @@
+//! Experiment orchestration and output schema.
+//!
+//! This module holds the canonical data structures consumed by downstream
+//! tools (e.g. `Surrogate_Viz.jl`) and any shared experiment logic that is
+//! not tied to a specific example binary.
+
+pub mod schema;

--- a/src/experiment/schema.rs
+++ b/src/experiment/schema.rs
@@ -1,0 +1,151 @@
+//! Standardized experiment output schema for SAAQ quantization runs.
+//!
+//! This module defines the canonical JSON structures emitted by
+//! `saaq_latent_calibration` and consumed by downstream tools such as
+//! `Surrogate_Viz.jl`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Top-level manifest for a single SAAQ experiment run.
+///
+/// Emitted as `run_manifest.json` inside every run directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperimentManifest {
+    pub run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_tag: Option<String>,
+    pub created_at: String,
+    pub repo: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+
+    pub model_slug: String,
+    pub model_family: String,
+    pub architecture: String,
+    pub checkpoint_path: String,
+    pub checkpoint_format: String,
+    pub routing_tensor_name: String,
+    pub synapse_source: String,
+
+    pub prompt_embedding_source: String,
+    pub prompt_profile: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_text: Option<String>,
+
+    pub ticks: usize,
+    pub saaq_rule: String,
+    pub saaq_primary_rule: String,
+    pub saaq_dual_emit: bool,
+
+    pub telemetry_source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub telemetry_csv_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub telemetry_row_count: Option<usize>,
+
+    pub wraparound_enabled: bool,
+    pub wraparound_loops: u64,
+    pub ticks_effective: usize,
+
+    pub run_dir: String,
+    pub output_root: String,
+    pub repeat_idx: usize,
+    pub repeat_count: usize,
+
+    pub validation_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub routing_mode: Option<String>,
+
+    pub generated_files: Vec<String>,
+}
+
+/// Compact, stable per-run summary consumed by downstream aggregators.
+///
+/// Emitted as `summary.json` inside every run directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperimentSummary {
+    pub run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_tag: Option<String>,
+    pub model_slug: String,
+    pub model_family: String,
+    pub telemetry_source: String,
+    pub repeat_idx: usize,
+    pub repeat_count: usize,
+    pub saaq_rule: String,
+    pub validation_status: String,
+    pub run_dir: String,
+    pub manifest_path: String,
+    pub tick_telemetry_path: String,
+    pub latent_telemetry_path: String,
+    pub metrics: ExperimentMetrics,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repeat_determinism: Option<String>,
+}
+
+/// Quantitative metrics for a single experiment run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExperimentMetrics {
+    pub ticks_completed: usize,
+    pub latent_rows: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mean_tick_elapsed_us: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_timestamp_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_timestamp_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight_mse: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight_cosine: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_abs_error: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_output_cosine: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_output_rmse: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_top1_agreement: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_top2_set_agreement: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expert_load_delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expert_load_js_divergence: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compression_estimate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_seconds: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peak_memory_gib: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_count: Option<usize>,
+}
+
+/// Standardized warning record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperimentWarning {
+    pub category: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tensor_name: Option<String>,
+}
+
+/// Output bundle emitted by every SAAQ run.
+///
+/// This is the top-level structure that `Surrogate_Viz.jl` expects to ingest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperimentBundle {
+    pub manifest: ExperimentManifest,
+    pub summary: ExperimentSummary,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<ExperimentWarning>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub metadata: BTreeMap<String, String>,
+}

--- a/src/latent.rs
+++ b/src/latent.rs
@@ -86,7 +86,7 @@ impl SnnLatentCalibrator {
         let membrane_dv_dt = (mean_membrane - previous_mean_membrane) / dt_seconds;
 
         let expert_weights = output.expert_weights.as_deref().ok_or_else(|| {
-            HybridError::OlmoeForward("missing expert_weights in ModelOutput".into())
+            HybridError::RouterForward("missing expert_weights in ModelOutput".into())
         })?;
         let routing_entropy = normalized_entropy(expert_weights);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!        ▼  Projector
 //! dense embedding [EMBEDDING_DIM = 2048]
 //!        │
-//!        ▼  OlmoeRouter
+//!        ▼  Router
 //! expert_weights + selected_experts + routed hidden state
 //!        │
 //!        ▼  SAAQ latent calibration / telemetry export
@@ -33,7 +33,7 @@
 //! ## Model loading
 //!
 //! The routing bridge is GGUF-backed and custom to this repository.
-//! `OlmoeRouter` parses GGUF checkpoints in-repo, resolves a supported model
+//! `Router` parses GGUF checkpoints in-repo, resolves a supported model
 //! family, extracts routing tensors and token embeddings, and selects a GPU
 //! synapse source from one of:
 //!
@@ -63,6 +63,7 @@
 //! ```
 
 pub mod error;
+pub mod experiment;
 pub mod funnel;
 #[cfg(feature = "cuda")]
 pub mod gpu;
@@ -87,6 +88,11 @@ pub use telemetry::TelemetryEncoder;
 pub use types::{
     CloudModelSpec, EMBEDDING_DIM, ModelArchitectureClass, ModelFamily, ModelTarget,
     TelemetrySnapshot,
+};
+
+pub use experiment::schema::{
+    ExperimentBundle, ExperimentManifest, ExperimentMetrics, ExperimentSummary,
+    ExperimentWarning,
 };
 
 pub mod tensor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,7 @@ pub use types::{
 };
 
 pub use experiment::schema::{
-    ExperimentBundle, ExperimentManifest, ExperimentMetrics, ExperimentSummary,
-    ExperimentWarning,
+    ExperimentBundle, ExperimentManifest, ExperimentMetrics, ExperimentSummary, ExperimentWarning,
 };
 
 pub mod tensor;

--- a/src/model/core.rs
+++ b/src/model/core.rs
@@ -3,7 +3,7 @@
 use super::telemetry_io::append_gpu_routing_telemetry_row;
 use crate::error::{HybridError, Result};
 use crate::gpu::{GpuAccelerator, GpuBuffer, GpuError, GpuResult};
-use crate::moe::{GpuSynapseTensorDescriptor, OlmoeRouter};
+use crate::moe::{GpuSynapseTensorDescriptor, Router};
 use crate::projector::Projector;
 use crate::types::{
     EMBEDDING_DIM, ModelConfig, ModelFamily, ModelOutput, RoutingMode, TelemetrySnapshot,
@@ -33,7 +33,7 @@ pub(super) fn resolve_gpu_routing_telemetry_path(config: &ModelConfig) -> std::p
 pub struct Model {
     pub(super) config: ModelConfig,
     pub(super) projector: Projector,
-    pub(super) router: OlmoeRouter,
+    pub(super) router: Router,
     pub(super) global_step: i64,
 }
 
@@ -60,8 +60,8 @@ impl Model {
         }
 
         let projector = Projector::with_input_neurons(config.projection_mode, projector_neurons);
-        let router = OlmoeRouter::load_with_family_and_mode(
-            &config.gguf_checkpoint_path,
+        let router = Router::load_with_family_and_mode(
+            &config.checkpoint_path,
             config.num_experts,
             config.top_k_experts,
             config.model_family,

--- a/src/model/temporal.rs
+++ b/src/model/temporal.rs
@@ -169,15 +169,15 @@ impl Model {
             None => return Ok(false),
         };
         let fallback_signature = format!("synthetic-f32::{neuron_count}");
-        if accelerator.synapse_signature() == Some(fallback_signature.as_str()) {
-            return Ok(false);
-        }
         let signature = format!(
             "dequantized-{label}::{}::{tensor_name}",
             self.router.model_path()
         );
         if accelerator.synapse_signature() == Some(signature.as_str()) {
             return Ok(true);
+        }
+        if accelerator.synapse_signature() == Some(fallback_signature.as_str()) {
+            return Ok(false);
         }
         let weights = get_weights(&self.router, &tensor_name)
             .map_err(|e| GpuError::MemoryError(format!("{label} dequantization failed: {e}")))?;

--- a/src/model/temporal.rs
+++ b/src/model/temporal.rs
@@ -159,8 +159,8 @@ impl Model {
     fn load_dequant_synapse(
         &mut self,
         label: &str,
-        get_name: fn(&crate::moe::OlmoeRouter) -> Option<&str>,
-        get_weights: fn(&crate::moe::OlmoeRouter, &str) -> crate::error::Result<Vec<f32>>,
+        get_name: fn(&crate::moe::Router) -> Option<&str>,
+        get_weights: fn(&crate::moe::Router, &str) -> crate::error::Result<Vec<f32>>,
         accelerator: &mut GpuAccelerator,
         neuron_count: usize,
     ) -> GpuResult<bool> {

--- a/src/moe/adapter.rs
+++ b/src/moe/adapter.rs
@@ -202,12 +202,13 @@ pub(super) fn resolve_safetensors_adapter(
     let routing_tensor = "model.layers.0.mlp.gate.weight".to_owned();
 
     // Validate routing tensor exists and is rank-2
-    let routing_info = checkpoint
-        .tensor_info(&routing_tensor)
-        .ok_or_else(|| HybridError::MissingTensor {
-            name: routing_tensor.clone(),
-            path: path.to_owned(),
-        })?;
+    let routing_info =
+        checkpoint
+            .tensor_info(&routing_tensor)
+            .ok_or_else(|| HybridError::MissingTensor {
+                name: routing_tensor.clone(),
+                path: path.to_owned(),
+            })?;
     if routing_info.1.len() != 2 {
         return Err(HybridError::UnsupportedFormat(format!(
             "routing tensor '{routing_tensor}' must be rank-2 in '{path}', got dims={:?}",

--- a/src/moe/adapter.rs
+++ b/src/moe/adapter.rs
@@ -1,6 +1,7 @@
-//! Model-family adapter resolution for the GGUF router host.
+//! Model-family adapter resolution for the GGUF and Safetensors router host.
 
 use super::checkpoint::{GgufMetadata, MappedGgufCheckpoint};
+use super::safetensors::{MappedSafetensorsCheckpoint, SafetensorsMetadata};
 use super::{GGML_TYPE_F16, GGML_TYPE_F32, GGML_TYPE_Q5_K, GGML_TYPE_Q6_K, GGML_TYPE_Q8_0};
 use crate::error::{HybridError, Result};
 use crate::types::ModelFamily;
@@ -182,6 +183,100 @@ pub(super) fn resolve_adapter(
         dequant_q6_k_synapse_tensor,
         quantization: metadata.quantization().to_owned(),
     })
+}
+
+pub(super) fn resolve_safetensors_adapter(
+    metadata: &SafetensorsMetadata,
+    checkpoint: &MappedSafetensorsCheckpoint,
+    family_override: Option<ModelFamily>,
+    path: &str,
+) -> Result<ModelAdapter> {
+    let architecture = metadata.architecture.clone();
+    let family = infer_family_safetensors(&architecture, family_override, path)?;
+    let hidden_size = metadata.hidden_size;
+    let num_layers = metadata.num_layers;
+    let num_experts = metadata.num_experts;
+    let expert_used_count = metadata.expert_used_count;
+
+    let token_embedding_tensor = "model.embed_tokens.weight".to_owned();
+    let routing_tensor = "model.layers.0.mlp.gate.weight".to_owned();
+
+    // Validate routing tensor exists and is rank-2
+    let routing_info = checkpoint
+        .tensor_info(&routing_tensor)
+        .ok_or_else(|| HybridError::MissingTensor {
+            name: routing_tensor.clone(),
+            path: path.to_owned(),
+        })?;
+    if routing_info.1.len() != 2 {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "routing tensor '{routing_tensor}' must be rank-2 in '{path}', got dims={:?}",
+            routing_info.1
+        )));
+    }
+    let routing_experts = routing_info.1[0].min(routing_info.1[1]);
+    if routing_experts < num_experts {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "routing tensor '{routing_tensor}' in '{path}' only exposes {routing_experts} experts, expected at least {num_experts}"
+        )));
+    }
+
+    // Safetensors path does not yet expose real GPU synapse tensors;
+    // leave everything as synthetic fallback.
+    let preferred_gpu_synapse_tensor = None;
+    let real_gpu_synapse_tensor = None;
+    let dequant_q8_0_synapse_tensor = None;
+    let dequant_q5_k_synapse_tensor = None;
+    let dequant_q6_k_synapse_tensor = None;
+    let synapse_source = SynapseSource::SyntheticFallback;
+
+    Ok(ModelAdapter {
+        family,
+        architecture,
+        hidden_size,
+        num_layers,
+        num_experts,
+        expert_used_count,
+        token_embedding_tensor,
+        routing_tensor,
+        preferred_gpu_synapse_tensor,
+        synapse_source,
+        real_gpu_synapse_tensor,
+        dequant_q8_0_synapse_tensor,
+        dequant_q5_k_synapse_tensor,
+        dequant_q6_k_synapse_tensor,
+        quantization: "safetensors".into(),
+    })
+}
+
+fn infer_family_safetensors(
+    architecture: &str,
+    family_override: Option<ModelFamily>,
+    path: &str,
+) -> Result<ModelFamily> {
+    let inferred = match architecture {
+        "OlmoeForCausalLM" => ModelFamily::Olmoe,
+        "Qwen3MoeForCausalLM" => ModelFamily::Qwen3Moe,
+        "Gemma4ForCausalLM" => ModelFamily::Gemma4,
+        "DeepseekV2ForCausalLM" => ModelFamily::DeepSeek2,
+        "LlamaMoeForCausalLM" => ModelFamily::LlamaMoe,
+        other => {
+            return Err(HybridError::UnsupportedFormat(format!(
+                "unsupported Safetensors architecture '{other}' in '{path}'"
+            )));
+        }
+    };
+
+    if let Some(expected) = family_override
+        && expected != inferred
+    {
+        return Err(HybridError::InvalidConfig(format!(
+            "model_family override {:?} does not match Safetensors architecture '{architecture}'",
+            expected
+        )));
+    }
+
+    Ok(inferred)
 }
 
 fn infer_family(

--- a/src/moe/checkpoint.rs
+++ b/src/moe/checkpoint.rs
@@ -913,7 +913,7 @@ fn cuda_host_register(ptr: *mut c_void, len: usize, path: &str, tensor_name: &st
     })
 }
 
-fn f16_to_f32(bits: u16) -> f32 {
+pub(super) fn f16_to_f32(bits: u16) -> f32 {
     let sign = ((bits as u32) & 0x8000) << 16;
     let exp = ((bits as u32) & 0x7C00) >> 10;
     let mant = ((bits as u32) & 0x03FF) << 13;

--- a/src/moe/mod.rs
+++ b/src/moe/mod.rs
@@ -417,7 +417,11 @@ impl Router {
         path: &str,
         family_override: Option<ModelFamily>,
     ) -> Result<(RouterMetadata, CheckpointBackend, ModelAdapter)> {
-        let is_safetensors = std::path::Path::new(path).is_dir() || !path.ends_with(".gguf");
+        let is_safetensors = std::path::Path::new(path).is_dir()
+            || !std::path::Path::new(path)
+                .extension()
+                .map(|ext| ext.eq_ignore_ascii_case("gguf"))
+                .unwrap_or(false);
 
         if is_safetensors {
             let checkpoint = MappedSafetensorsCheckpoint::from_directory(path)?;

--- a/src/moe/mod.rs
+++ b/src/moe/mod.rs
@@ -1,10 +1,10 @@
-//! Public MoE router API backed by a family-aware GGUF bridge.
+//! Public MoE router API backed by a family-aware GGUF and Safetensors bridge.
 //!
 //! Private helpers live in:
 //! - `moe/checkpoint.rs` for GGUF parsing + mapped tensor access
 //! - `moe/adapter.rs` for model-family detection and tensor selection
 //! - `moe/routing.rs` for routing math and embedding resampling
-//! - `moe/safetensors.rs` for Safetensors header inspection and manifests
+//! - `moe/safetensors.rs` for Safetensors header inspection, manifests, and tensor loading
 
 mod adapter;
 mod checkpoint;
@@ -12,7 +12,7 @@ mod ggml;
 mod routing;
 pub mod safetensors;
 
-use self::adapter::{ModelAdapter, SynapseSource, resolve_adapter};
+use self::adapter::{ModelAdapter, SynapseSource, resolve_adapter, resolve_safetensors_adapter};
 use self::checkpoint::{
     MappedGgufCheckpoint, extract_named_token_embedding_from_checkpoint, probe_and_map_checkpoint,
 };
@@ -26,15 +26,16 @@ use self::ggml::{
 pub use self::ggml::{ggml_type_label, synapse_dequant_path_supported};
 use self::routing::{
     checkpoint_gate_scores, normalize_l2, normalize_to_internal_embedding_dim, resample_embedding,
-    softmax, synthetic_gate_scores, top_k_indices,
+    safetensors_gate_scores, softmax, synthetic_gate_scores, top_k_indices,
 };
+use self::safetensors::MappedSafetensorsCheckpoint;
 use crate::error::{HybridError, Result};
 pub use crate::types::RoutingMode;
 use crate::types::{EMBEDDING_DIM, ModelFamily};
 
 /// Diagnostic snapshot of the GGUF tensor that the adapter wants to use as
 /// the GPU synapse weight source for this router. Returned by
-/// [`OlmoeRouter::preferred_gpu_synapse_tensor_descriptor`]; only consumed
+/// [`Router::preferred_gpu_synapse_tensor_descriptor`]; only consumed
 /// by `examples/synapse_diagnostic.rs` today, but exposed publicly so
 /// future runner / manifest stamping can reuse it without re-mapping the
 /// checkpoint. Carries no live tensor data.
@@ -85,7 +86,12 @@ impl RouterMetadata {
     }
 }
 
-pub struct OlmoeRouter {
+enum CheckpointBackend {
+    Gguf(MappedGgufCheckpoint),
+    Safetensors(MappedSafetensorsCheckpoint),
+}
+
+pub struct Router {
     metadata: RouterMetadata,
     adapter: Option<ModelAdapter>,
     model_path: String,
@@ -97,7 +103,7 @@ pub struct OlmoeRouter {
     hidden_membranes: Vec<f32>,
     threshold: f32,
     decay: f32,
-    checkpoint: Option<MappedGgufCheckpoint>,
+    checkpoint: Option<CheckpointBackend>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -116,13 +122,13 @@ pub struct RouterMetadata {
 }
 
 #[derive(Debug, Clone)]
-pub struct OlmoeOutput {
+pub struct RouterOutput {
     pub expert_weights: Vec<f32>,
     pub selected_experts: Vec<usize>,
     pub hidden: Vec<f32>,
 }
 
-impl OlmoeRouter {
+impl Router {
     pub fn load(model_path: &str, num_experts: usize, top_k: usize) -> Result<Self> {
         Self::load_with_family_and_mode(
             model_path,
@@ -172,7 +178,7 @@ impl OlmoeRouter {
             });
         }
 
-        let (metadata, checkpoint) = Self::probe_and_map(model_path, family_override)?;
+        let (metadata, checkpoint, adapter) = Self::probe_and_map(model_path, family_override)?;
         let effective_num_experts = if num_experts == 0 {
             metadata.num_experts
         } else {
@@ -190,12 +196,6 @@ impl OlmoeRouter {
         } else {
             top_k.max(1).min(effective_num_experts)
         };
-        let adapter = resolve_adapter(
-            checkpoint.metadata(),
-            &checkpoint,
-            family_override,
-            model_path,
-        )?;
 
         Ok(Self {
             model_path: model_path.to_owned(),
@@ -214,11 +214,11 @@ impl OlmoeRouter {
     }
 
     pub fn probe_model(path: &str, family_override: Option<ModelFamily>) -> Result<RouterMetadata> {
-        let (metadata, _checkpoint) = Self::probe_and_map(path, family_override)?;
+        let (metadata, _checkpoint, _adapter) = Self::probe_and_map(path, family_override)?;
         Ok(metadata)
     }
 
-    pub fn forward(&mut self, embedding: &[f32]) -> Result<OlmoeOutput> {
+    pub fn forward(&mut self, embedding: &[f32]) -> Result<RouterOutput> {
         if embedding.len() != EMBEDDING_DIM {
             return Err(HybridError::InputLengthMismatch {
                 expected: EMBEDDING_DIM,
@@ -248,12 +248,17 @@ impl OlmoeRouter {
                 path: self.model_path.clone(),
                 reason: "checkpoint not loaded".into(),
             })?;
-        let embedding = extract_named_token_embedding_from_checkpoint(
-            checkpoint,
-            &adapter.token_embedding_tensor,
-            &self.model_path,
-            token_id,
-        )?;
+        let embedding = match checkpoint {
+            CheckpointBackend::Gguf(cp) => extract_named_token_embedding_from_checkpoint(
+                cp,
+                &adapter.token_embedding_tensor,
+                &self.model_path,
+                token_id,
+            )?,
+            CheckpointBackend::Safetensors(cp) => {
+                cp.extract_token_embedding(&adapter.token_embedding_tensor, &self.model_path, token_id)?
+            }
+        };
         Ok(normalize_to_internal_embedding_dim(&embedding))
     }
 
@@ -266,7 +271,12 @@ impl OlmoeRouter {
                 path: self.model_path.clone(),
                 reason: "checkpoint not loaded".into(),
             })?;
-        checkpoint.registered_f16_tensor(tensor_name, &self.model_path)
+        match checkpoint {
+            CheckpointBackend::Gguf(cp) => cp.registered_f16_tensor(tensor_name, &self.model_path),
+            CheckpointBackend::Safetensors(_) => Err(HybridError::UnsupportedFormat(
+                "Safetensors checkpoint does not support GPU synapse registration".into(),
+            )),
+        }
     }
 
     /// Returns the tensor name to use for Q8_0 dequantized synapse loading,
@@ -293,7 +303,12 @@ impl OlmoeRouter {
                 path: self.model_path.clone(),
                 reason: "checkpoint not loaded".into(),
             })?;
-        checkpoint.dequantize_q8_0_tensor(tensor_name, &self.model_path)
+        match checkpoint {
+            CheckpointBackend::Gguf(cp) => cp.dequantize_q8_0_tensor(tensor_name, &self.model_path),
+            CheckpointBackend::Safetensors(_) => Err(HybridError::UnsupportedFormat(
+                "Safetensors checkpoint does not support Q8_0 dequantization".into(),
+            )),
+        }
     }
 
     /// Returns the tensor name to use for Q5_K dequantized synapse loading,
@@ -320,7 +335,12 @@ impl OlmoeRouter {
                 path: self.model_path.clone(),
                 reason: "checkpoint not loaded".into(),
             })?;
-        checkpoint.dequantize_q5_k_tensor(tensor_name, &self.model_path)
+        match checkpoint {
+            CheckpointBackend::Gguf(cp) => cp.dequantize_q5_k_tensor(tensor_name, &self.model_path),
+            CheckpointBackend::Safetensors(_) => Err(HybridError::UnsupportedFormat(
+                "Safetensors checkpoint does not support Q5_K dequantization".into(),
+            )),
+        }
     }
 
     #[allow(dead_code)]
@@ -343,7 +363,12 @@ impl OlmoeRouter {
                 path: self.model_path.clone(),
                 reason: "checkpoint not loaded".into(),
             })?;
-        checkpoint.dequantize_q6_k_tensor(tensor_name, &self.model_path)
+        match checkpoint {
+            CheckpointBackend::Gguf(cp) => cp.dequantize_q6_k_tensor(tensor_name, &self.model_path),
+            CheckpointBackend::Safetensors(_) => Err(HybridError::UnsupportedFormat(
+                "Safetensors checkpoint does not support Q6_K dequantization".into(),
+            )),
+        }
     }
 
     /// `(src_rows, src_cols)` matching the row-major layout produced by
@@ -361,28 +386,55 @@ impl OlmoeRouter {
                 path: self.model_path.clone(),
                 reason: "checkpoint not loaded".into(),
             })?;
-        let info = checkpoint.tensor_info(tensor_name, &self.model_path)?;
-        if info.dims.is_empty() {
+        let dims = match checkpoint {
+            CheckpointBackend::Gguf(cp) => {
+                let info = cp.tensor_info(tensor_name, &self.model_path)?;
+                info.dims.clone()
+            }
+            CheckpointBackend::Safetensors(cp) => {
+                let info = cp.tensor_info(tensor_name).ok_or_else(|| HybridError::MissingTensor {
+                    name: tensor_name.to_owned(),
+                    path: self.model_path.clone(),
+                })?;
+                info.1.to_vec()
+            }
+        };
+        if dims.is_empty() {
             return Err(HybridError::UnsupportedFormat(format!(
                 "tensor '{tensor_name}' has no dimensions"
             )));
         }
-        let src_cols = info.dims[0];
-        let src_rows = info.dims.get(1).copied().unwrap_or(1);
+        let src_cols = dims[0];
+        let src_rows = dims.get(1).copied().unwrap_or(1);
         Ok((src_rows, src_cols))
     }
 
     fn probe_and_map(
         path: &str,
         family_override: Option<ModelFamily>,
-    ) -> Result<(RouterMetadata, MappedGgufCheckpoint)> {
+    ) -> Result<(RouterMetadata, CheckpointBackend, ModelAdapter)> {
+        let is_safetensors = std::path::Path::new(path).is_dir()
+            || !path.ends_with(".gguf");
+
+        if is_safetensors {
+            let checkpoint = MappedSafetensorsCheckpoint::from_directory(path)?;
+            let adapter = resolve_safetensors_adapter(
+                &checkpoint.metadata,
+                &checkpoint,
+                family_override,
+                path,
+            )?;
+            let metadata = RouterMetadata::from_adapter(&adapter);
+            return Ok((metadata, CheckpointBackend::Safetensors(checkpoint), adapter));
+        }
+
         let (_raw_metadata, checkpoint) = probe_and_map_checkpoint(path)?;
         let adapter = resolve_adapter(checkpoint.metadata(), &checkpoint, family_override, path)?;
         let metadata = RouterMetadata::from_adapter(&adapter);
-        Ok((metadata, checkpoint))
+        Ok((metadata, CheckpointBackend::Gguf(checkpoint), adapter))
     }
 
-    fn simulate_moe_routing(&self, embedding: &[f32]) -> Result<OlmoeOutput> {
+    fn simulate_moe_routing(&self, embedding: &[f32]) -> Result<RouterOutput> {
         let gate_scores = self.compute_gate_scores(embedding)?;
         let expert_weights = softmax(&gate_scores);
         let selected_experts = top_k_indices(&expert_weights, self.top_k);
@@ -392,14 +444,14 @@ impl OlmoeRouter {
             .sum();
         let hidden: Vec<f32> = embedding.iter().map(|&v| v * selected_mass).collect();
 
-        Ok(OlmoeOutput {
+        Ok(RouterOutput {
             expert_weights,
             selected_experts,
             hidden,
         })
     }
 
-    fn spiking_moe_routing(&mut self, embedding: &[f32]) -> Result<OlmoeOutput> {
+    fn spiking_moe_routing(&mut self, embedding: &[f32]) -> Result<RouterOutput> {
         let gate_scores = self.compute_gate_scores(embedding)?;
         let n = self.num_experts;
         let mut membrane_scores = Vec::with_capacity(n);
@@ -446,7 +498,7 @@ impl OlmoeRouter {
             *value = spike * 0.3;
         }
 
-        Ok(OlmoeOutput {
+        Ok(RouterOutput {
             expert_weights,
             selected_experts,
             hidden,
@@ -457,21 +509,30 @@ impl OlmoeRouter {
         if let (Some(checkpoint), Some(adapter)) = (&self.checkpoint, &self.adapter) {
             let mut routed_embedding = resample_embedding(embedding, adapter.hidden_size);
             normalize_l2(&mut routed_embedding);
-            return checkpoint_gate_scores(
-                checkpoint,
-                &self.model_path,
-                &adapter.routing_tensor,
-                self.num_experts,
-                &routed_embedding,
-            );
+            return match checkpoint {
+                CheckpointBackend::Gguf(cp) => checkpoint_gate_scores(
+                    cp,
+                    &self.model_path,
+                    &adapter.routing_tensor,
+                    self.num_experts,
+                    &routed_embedding,
+                ),
+                CheckpointBackend::Safetensors(cp) => safetensors_gate_scores(
+                    cp,
+                    &self.model_path,
+                    &adapter.routing_tensor,
+                    self.num_experts,
+                    &routed_embedding,
+                ),
+            };
         }
 
         Ok(synthetic_gate_scores(self.num_experts, embedding))
     }
 
-    fn stub_output(&self) -> OlmoeOutput {
+    fn stub_output(&self) -> RouterOutput {
         let n = self.num_experts.max(1);
-        OlmoeOutput {
+        RouterOutput {
             expert_weights: vec![1.0 / n as f32; n],
             selected_experts: (0..self.top_k.min(n)).collect(),
             hidden: vec![0.0; EMBEDDING_DIM],
@@ -547,14 +608,19 @@ impl OlmoeRouter {
     pub fn preferred_gpu_synapse_tensor_descriptor(&self) -> Option<GpuSynapseTensorDescriptor> {
         let name = self.metadata.preferred_gpu_synapse_tensor_name.as_deref()?;
         let checkpoint = self.checkpoint.as_ref()?;
-        let info = checkpoint.tensor_info(name, &self.model_path).ok()?;
-        Some(GpuSynapseTensorDescriptor {
-            name: name.to_owned(),
-            ggml_type_id: info.ggml_type,
-            ggml_type_label: ggml_type_label(info.ggml_type),
-            dims: info.dims.clone(),
-            has_dequant_path: synapse_dequant_path_supported(info.ggml_type),
-        })
+        match checkpoint {
+            CheckpointBackend::Gguf(cp) => {
+                let info = cp.tensor_info(name, &self.model_path).ok()?;
+                Some(GpuSynapseTensorDescriptor {
+                    name: name.to_owned(),
+                    ggml_type_id: info.ggml_type,
+                    ggml_type_label: ggml_type_label(info.ggml_type),
+                    dims: info.dims.clone(),
+                    has_dequant_path: synapse_dequant_path_supported(info.ggml_type),
+                })
+            }
+            CheckpointBackend::Safetensors(_) => None,
+        }
     }
 
     pub fn num_experts(&self) -> usize {

--- a/src/moe/mod.rs
+++ b/src/moe/mod.rs
@@ -255,9 +255,11 @@ impl Router {
                 &self.model_path,
                 token_id,
             )?,
-            CheckpointBackend::Safetensors(cp) => {
-                cp.extract_token_embedding(&adapter.token_embedding_tensor, &self.model_path, token_id)?
-            }
+            CheckpointBackend::Safetensors(cp) => cp.extract_token_embedding(
+                &adapter.token_embedding_tensor,
+                &self.model_path,
+                token_id,
+            )?,
         };
         Ok(normalize_to_internal_embedding_dim(&embedding))
     }
@@ -392,10 +394,12 @@ impl Router {
                 info.dims.clone()
             }
             CheckpointBackend::Safetensors(cp) => {
-                let info = cp.tensor_info(tensor_name).ok_or_else(|| HybridError::MissingTensor {
-                    name: tensor_name.to_owned(),
-                    path: self.model_path.clone(),
-                })?;
+                let info =
+                    cp.tensor_info(tensor_name)
+                        .ok_or_else(|| HybridError::MissingTensor {
+                            name: tensor_name.to_owned(),
+                            path: self.model_path.clone(),
+                        })?;
                 info.1.to_vec()
             }
         };
@@ -413,8 +417,7 @@ impl Router {
         path: &str,
         family_override: Option<ModelFamily>,
     ) -> Result<(RouterMetadata, CheckpointBackend, ModelAdapter)> {
-        let is_safetensors = std::path::Path::new(path).is_dir()
-            || !path.ends_with(".gguf");
+        let is_safetensors = std::path::Path::new(path).is_dir() || !path.ends_with(".gguf");
 
         if is_safetensors {
             let checkpoint = MappedSafetensorsCheckpoint::from_directory(path)?;
@@ -425,7 +428,11 @@ impl Router {
                 path,
             )?;
             let metadata = RouterMetadata::from_adapter(&adapter);
-            return Ok((metadata, CheckpointBackend::Safetensors(checkpoint), adapter));
+            return Ok((
+                metadata,
+                CheckpointBackend::Safetensors(checkpoint),
+                adapter,
+            ));
         }
 
         let (_raw_metadata, checkpoint) = probe_and_map_checkpoint(path)?;

--- a/src/moe/routing.rs
+++ b/src/moe/routing.rs
@@ -1,6 +1,7 @@
-//! Routing math and embedding resampling for the GGUF router bridge.
+//! Routing math and embedding resampling for the GGUF and Safetensors router bridge.
 
 use super::checkpoint::{GgufTensorInfo, MappedGgufCheckpoint};
+use super::safetensors::MappedSafetensorsCheckpoint;
 use crate::error::{HybridError, Result};
 use crate::types::EMBEDDING_DIM;
 use std::cmp::Ordering;
@@ -19,6 +20,52 @@ pub(super) fn checkpoint_gate_scores(
         let mut score = 0.0f32;
         for (dim, &value) in embedding.iter().enumerate() {
             let index = routing_weight_index(info, expert_id, dim, num_experts, embedding.len())?;
+            score += weights[index] * value;
+        }
+        gate_scores.push(score);
+    }
+    Ok(gate_scores)
+}
+
+pub(super) fn safetensors_gate_scores(
+    checkpoint: &MappedSafetensorsCheckpoint,
+    model_path: &str,
+    routing_tensor_name: &str,
+    num_experts: usize,
+    embedding: &[f32],
+) -> Result<Vec<f32>> {
+    let weights = checkpoint.extract_tensor_f32(routing_tensor_name, model_path)?;
+    let info = checkpoint
+        .tensor_info(routing_tensor_name)
+        .ok_or_else(|| HybridError::MissingTensor {
+            name: routing_tensor_name.to_owned(),
+            path: model_path.to_owned(),
+        })?;
+    let shape = info.1;
+    if shape.len() != 2 {
+        return Err(HybridError::UnsupportedFormat(format!(
+            "routing tensor '{routing_tensor_name}' must be rank-2, got {:?}",
+            shape
+        )));
+    }
+    let d0 = shape[0];
+    let d1 = shape[1];
+
+    let mut gate_scores = Vec::with_capacity(num_experts);
+    for expert_id in 0..num_experts {
+        let mut score = 0.0f32;
+        for (dim, &value) in embedding.iter().enumerate() {
+            let index = if d0 == embedding.len() && d1 >= num_experts {
+                dim * d1 + expert_id
+            } else if d0 >= num_experts && d1 == embedding.len() {
+                expert_id * d1 + dim
+            } else {
+                return Err(HybridError::UnsupportedFormat(format!(
+                    "unsupported safetensors routing tensor orientation {:?} for hidden_size={}",
+                    shape,
+                    embedding.len()
+                )));
+            };
             score += weights[index] * value;
         }
         gate_scores.push(score);

--- a/src/moe/routing.rs
+++ b/src/moe/routing.rs
@@ -56,9 +56,9 @@ pub(super) fn safetensors_gate_scores(
     for expert_id in 0..num_experts {
         let mut score = 0.0f32;
         for (dim, &value) in embedding.iter().enumerate() {
-            let index = if d0 == embedding.len() && d1 >= num_experts {
+            let index = if d0 == embedding.len() && d1 == num_experts {
                 dim * d1 + expert_id
-            } else if d0 >= num_experts && d1 == embedding.len() {
+            } else if d0 == num_experts && d1 == embedding.len() {
                 expert_id * d1 + dim
             } else {
                 return Err(HybridError::UnsupportedFormat(format!(

--- a/src/moe/routing.rs
+++ b/src/moe/routing.rs
@@ -35,12 +35,13 @@ pub(super) fn safetensors_gate_scores(
     embedding: &[f32],
 ) -> Result<Vec<f32>> {
     let weights = checkpoint.extract_tensor_f32(routing_tensor_name, model_path)?;
-    let info = checkpoint
-        .tensor_info(routing_tensor_name)
-        .ok_or_else(|| HybridError::MissingTensor {
-            name: routing_tensor_name.to_owned(),
-            path: model_path.to_owned(),
-        })?;
+    let info =
+        checkpoint
+            .tensor_info(routing_tensor_name)
+            .ok_or_else(|| HybridError::MissingTensor {
+                name: routing_tensor_name.to_owned(),
+                path: model_path.to_owned(),
+            })?;
     let shape = info.1;
     if shape.len() != 2 {
         return Err(HybridError::UnsupportedFormat(format!(

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1004,9 +1004,96 @@ struct HfConfig {
     vocab_size: usize,
 }
 
+fn build_indexed_shard_map(
+    root: &Path,
+    index_path: &Path,
+) -> Result<(Vec<PathBuf>, std::collections::BTreeMap<String, TensorLocation>)> {
+    let raw_index = read_index(index_path)?;
+    let mut shard_paths: Vec<PathBuf> = Vec::new();
+    let mut tensor_map: std::collections::BTreeMap<String, TensorLocation> =
+        std::collections::BTreeMap::new();
+    let mut shard_index_by_path: std::collections::BTreeMap<PathBuf, usize> =
+        std::collections::BTreeMap::new();
+    for (tensor_name, relative) in &raw_index.weight_map {
+        let shard_path = index_shard_path(root, index_path, relative)?;
+        let shard_idx = *shard_index_by_path
+            .entry(shard_path.clone())
+            .or_insert_with(|| {
+                let idx = shard_paths.len();
+                shard_paths.push(shard_path);
+                idx
+            });
+        tensor_map.insert(
+            tensor_name.clone(),
+            TensorLocation {
+                shard_idx,
+                dtype: String::new(),
+                shape: Vec::new(),
+                data_offsets: [0, 0],
+            },
+        );
+    }
+    Ok((shard_paths, tensor_map))
+}
+
+fn build_unsharded_shard_map(
+    shards: &[PathBuf],
+) -> Result<(Vec<PathBuf>, std::collections::BTreeMap<String, TensorLocation>)> {
+    let mut tensor_map: std::collections::BTreeMap<String, TensorLocation> =
+        std::collections::BTreeMap::new();
+    for (shard_idx, shard_path) in shards.iter().enumerate() {
+        let file = File::open(shard_path).map_err(|e| model_load(shard_path, e.to_string()))?;
+        let mmap =
+            unsafe { Mmap::map(&file) }.map_err(|e| model_load(shard_path, e.to_string()))?;
+        let file_len = mmap.len() as u64;
+        let mut len_bytes = [0u8; 8];
+        let mut reader = &mmap[..];
+        reader
+            .read_exact(&mut len_bytes)
+            .map_err(|e| model_load(shard_path, format!("read header length: {e}")))?;
+        let header_len = u64::from_le_bytes(len_bytes);
+        if header_len > MAX_HEADER_BYTES as u64 {
+            return Err(model_load(
+                shard_path,
+                format!("header length {header_len} exceeds limit {MAX_HEADER_BYTES}"),
+            ));
+        }
+        if 8u64
+            .checked_add(header_len)
+            .is_none_or(|end| end > file_len)
+        {
+            return Err(model_load(shard_path, "header extends beyond file".into()));
+        }
+        let header_bytes = &mmap[8..8 + header_len as usize];
+        let header = parse_json_rejecting_duplicate_keys(header_bytes, shard_path, "header")?;
+        let object = header.as_object().ok_or_else(|| {
+            model_load(
+                shard_path,
+                "Safetensors header must be a JSON object".into(),
+            )
+        })?;
+        for (name, _value) in object {
+            if name == "__metadata__" {
+                continue;
+            }
+            tensor_map.insert(
+                name.clone(),
+                TensorLocation {
+                    shard_idx,
+                    dtype: String::new(),
+                    shape: Vec::new(),
+                    data_offsets: [0, 0],
+                },
+            );
+        }
+    }
+    Ok((shards.to_vec(), tensor_map))
+}
+
 impl MappedSafetensorsCheckpoint {
-    /// Map a Safetensors directory containing `config.json` and
-    /// `model.safetensors.index.json`.
+    /// Map a Safetensors directory containing `config.json` and either
+    /// `model.safetensors.index.json` (sharded) or `model.safetensors`
+    /// (single-file).
     pub fn from_directory(path: &str) -> Result<Self> {
         let root = Path::new(path);
         if !root.is_dir() {
@@ -1017,42 +1104,24 @@ impl MappedSafetensorsCheckpoint {
         }
 
         let config = Self::read_config(root)?;
-        let index_path = find_index_file(root)?.ok_or_else(|| HybridError::ModelLoad {
-            path: path.to_owned(),
-            reason: "no model.safetensors.index.json found".into(),
-        })?;
-        let raw_index = read_index(&index_path)?;
 
-        let mut shards: Vec<MappedShard> = Vec::new();
-        let mut shard_paths: Vec<PathBuf> = Vec::new();
-        let mut tensor_map: std::collections::BTreeMap<String, TensorLocation> =
-            std::collections::BTreeMap::new();
-
-        // Collect unique shard paths from the weight map
-        let mut shard_index_by_path: std::collections::BTreeMap<PathBuf, usize> =
-            std::collections::BTreeMap::new();
-        for (tensor_name, relative) in &raw_index.weight_map {
-            let shard_path = index_shard_path(root, &index_path, relative)?;
-            let shard_idx = *shard_index_by_path
-                .entry(shard_path.clone())
-                .or_insert_with(|| {
-                    let idx = shard_paths.len();
-                    shard_paths.push(shard_path);
-                    idx
+        // Try index-first (sharded) layout; fall back to single-file
+        let (shard_paths, mut tensor_map) = if let Some(index_path) = find_index_file(root)? {
+            build_indexed_shard_map(root, &index_path)?
+        } else {
+            let shards = list_safetensors_files(root)?;
+            if shards.is_empty() {
+                return Err(HybridError::ModelLoad {
+                    path: path.to_owned(),
+                    reason: "no .safetensors files found".into(),
                 });
-            tensor_map.insert(
-                tensor_name.clone(),
-                TensorLocation {
-                    shard_idx,
-                    dtype: String::new(),
-                    shape: Vec::new(),
-                    data_offsets: [0, 0],
-                },
-            );
-        }
+            }
+            build_unsharded_shard_map(&shards)?
+        };
 
         // Map each shard and parse its header to resolve tensor dtypes/offsets
-        for shard_path in &shard_paths {
+        let mut shards: Vec<MappedShard> = Vec::new();
+        for (shard_idx, shard_path) in shard_paths.iter().enumerate() {
             let file = File::open(shard_path).map_err(|e| model_load(shard_path, e.to_string()))?;
             let mmap =
                 unsafe { Mmap::map(&file) }.map_err(|e| model_load(shard_path, e.to_string()))?;
@@ -1096,7 +1165,7 @@ impl MappedSafetensorsCheckpoint {
                 let Some(loc) = tensor_map.get_mut(name) else {
                     continue;
                 };
-                if loc.shard_idx != shards.len() {
+                if loc.shard_idx != shard_idx {
                     continue;
                 }
                 let tensor = value.as_object().ok_or_else(|| {
@@ -1177,6 +1246,18 @@ impl MappedSafetensorsCheckpoint {
                 mmap,
                 header_len,
             });
+        }
+
+        // Validate that all tensors listed in weight_map were found in their declared shard
+        for (name, loc) in &tensor_map {
+            if loc.dtype.is_empty() {
+                return Err(model_load(
+                    &shard_paths[loc.shard_idx],
+                    format!(
+                        "tensor '{name}' listed in weight_map but missing from shard header"
+                    ),
+                ));
+            }
         }
 
         let metadata = SafetensorsMetadata {

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1211,7 +1211,7 @@ impl MappedSafetensorsCheckpoint {
 
         match loc.dtype.as_str() {
             "F32" => {
-                if bytes.len() % 4 != 0 {
+                if !bytes.len().is_multiple_of(4) {
                     return Err(HybridError::UnsupportedFormat(format!(
                         "tensor '{name}' F32 data is not 4-byte aligned"
                     )));
@@ -1222,7 +1222,7 @@ impl MappedSafetensorsCheckpoint {
                     .collect())
             }
             "F16" => {
-                if bytes.len() % 2 != 0 {
+                if !bytes.len().is_multiple_of(2) {
                     return Err(HybridError::UnsupportedFormat(format!(
                         "tensor '{name}' F16 data is not 2-byte aligned"
                     )));
@@ -1233,7 +1233,7 @@ impl MappedSafetensorsCheckpoint {
                     .collect())
             }
             "BF16" => {
-                if bytes.len() % 2 != 0 {
+                if !bytes.len().is_multiple_of(2) {
                     return Err(HybridError::UnsupportedFormat(format!(
                         "tensor '{name}' BF16 data is not 2-byte aligned"
                     )));

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1,9 +1,11 @@
-//! Safetensors checkpoint inspection and deterministic manifest generation.
+//! Safetensors checkpoint inspection, deterministic manifest generation, and
+//! tensor loading for the router bridge.
 //!
-//! This module reads only Safetensors headers and optional Hugging Face shard
-//! index metadata. It does not read tensor payload bytes into memory and does
-//! not perform activation tracing or router math.
+//! The `inspect_*` functions read only Safetensors headers and optional
+//! Hugging Face shard index metadata.  The `MappedSafetensorsCheckpoint`
+//! type memory-maps shards and extracts tensor payload bytes on demand.
 
+use super::checkpoint::f16_to_f32;
 use crate::error::{HybridError, Result};
 use serde::de::{self, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
@@ -16,6 +18,8 @@ use std::os::unix::fs::MetadataExt;
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
 use std::path::{Component, Path, PathBuf};
+
+use memmap2::Mmap;
 
 const SAFETENSORS_EXTENSION: &str = "safetensors";
 const MAX_HEADER_BYTES: usize = 64 * 1024 * 1024;
@@ -948,6 +952,349 @@ fn model_load(path: &Path, reason: String) -> HybridError {
         path: path.display().to_string(),
         reason,
     }
+}
+
+// ── Tensor loading backend ──────────────────────────────────────────────
+
+/// Metadata extracted from a Hugging Face `config.json` for adapter
+/// resolution.
+#[derive(Debug, Clone)]
+pub struct SafetensorsMetadata {
+    pub architecture: String,
+    pub hidden_size: usize,
+    pub num_layers: usize,
+    pub num_experts: usize,
+    pub expert_used_count: usize,
+    pub vocab_size: usize,
+}
+
+/// Memory-mapped Safetensors checkpoint with indexed tensor access.
+#[derive(Debug)]
+pub struct MappedSafetensorsCheckpoint {
+    shards: Vec<MappedShard>,
+    tensor_map: std::collections::BTreeMap<String, TensorLocation>,
+    pub metadata: SafetensorsMetadata,
+}
+
+#[derive(Debug, Clone)]
+struct TensorLocation {
+    shard_idx: usize,
+    dtype: String,
+    shape: Vec<usize>,
+    data_offsets: [usize; 2],
+}
+
+#[derive(Debug)]
+struct MappedShard {
+    #[allow(dead_code)]
+    path: PathBuf,
+    mmap: Mmap,
+    header_len: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct HfConfig {
+    architectures: Vec<String>,
+    hidden_size: usize,
+    num_hidden_layers: usize,
+    #[serde(default)]
+    num_experts: Option<usize>,
+    #[serde(default)]
+    num_experts_per_tok: Option<usize>,
+    vocab_size: usize,
+}
+
+impl MappedSafetensorsCheckpoint {
+    /// Map a Safetensors directory containing `config.json` and
+    /// `model.safetensors.index.json`.
+    pub fn from_directory(path: &str) -> Result<Self> {
+        let root = Path::new(path);
+        if !root.is_dir() {
+            return Err(HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: "path is not a directory".into(),
+            });
+        }
+
+        let config = Self::read_config(root)?;
+        let index_path = find_index_file(root)?.ok_or_else(|| {
+            HybridError::ModelLoad {
+                path: path.to_owned(),
+                reason: "no model.safetensors.index.json found".into(),
+            }
+        })?;
+        let raw_index = read_index(&index_path)?;
+
+        let mut shards: Vec<MappedShard> = Vec::new();
+        let mut shard_paths: Vec<PathBuf> = Vec::new();
+        let mut tensor_map: std::collections::BTreeMap<String, TensorLocation> =
+            std::collections::BTreeMap::new();
+
+        // Collect unique shard paths from the weight map
+        let mut shard_index_by_path: std::collections::BTreeMap<PathBuf, usize> =
+            std::collections::BTreeMap::new();
+        for (tensor_name, relative) in &raw_index.weight_map {
+            let shard_path = index_shard_path(root, &index_path, relative)?;
+            let shard_idx = *shard_index_by_path.entry(shard_path.clone()).or_insert_with(|| {
+                let idx = shard_paths.len();
+                shard_paths.push(shard_path);
+                idx
+            });
+            tensor_map.insert(
+                tensor_name.clone(),
+                TensorLocation {
+                    shard_idx,
+                    dtype: String::new(),
+                    shape: Vec::new(),
+                    data_offsets: [0, 0],
+                },
+            );
+        }
+
+        // Map each shard and parse its header to resolve tensor dtypes/offsets
+        for shard_path in &shard_paths {
+            let file = File::open(shard_path).map_err(|e| model_load(shard_path, e.to_string()))?;
+            let mmap = unsafe { Mmap::map(&file) }.map_err(|e| model_load(shard_path, e.to_string()))?;
+            let file_len = mmap.len() as u64;
+            let mut len_bytes = [0u8; 8];
+            let mut reader = &mmap[..];
+            reader
+                .read_exact(&mut len_bytes)
+                .map_err(|e| model_load(shard_path, format!("read header length: {e}")))?;
+            let header_len = u64::from_le_bytes(len_bytes);
+            if header_len > MAX_HEADER_BYTES as u64 {
+                return Err(model_load(
+                    shard_path,
+                    format!("header length {header_len} exceeds limit {MAX_HEADER_BYTES}"),
+                ));
+            }
+            if 8u64.checked_add(header_len).is_none_or(|end| end > file_len) {
+                return Err(model_load(shard_path, "header extends beyond file".into()));
+            }
+            let header_bytes = &mmap[8..8 + header_len as usize];
+            let header = parse_json_rejecting_duplicate_keys(header_bytes, shard_path, "header")?;
+            let object = header.as_object().ok_or_else(|| {
+                model_load(shard_path, "Safetensors header must be a JSON object".into())
+            })?;
+
+            let data_len = file_len
+                .checked_sub(8)
+                .and_then(|len| len.checked_sub(header_len))
+                .ok_or_else(|| model_load(shard_path, "data range underflow".into()))?;
+
+            for (name, value) in object {
+                if name == "__metadata__" {
+                    continue;
+                }
+                let Some(loc) = tensor_map.get_mut(name) else {
+                    continue;
+                };
+                if loc.shard_idx != shards.len() {
+                    continue;
+                }
+                let tensor = value.as_object().ok_or_else(|| {
+                    model_load(shard_path, format!("tensor '{name}' metadata must be an object"))
+                })?;
+                let dtype = tensor
+                    .get("dtype")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' missing dtype")))?
+                    .to_string();
+                let shape = tensor
+                    .get("shape")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' missing shape")))?
+                    .iter()
+                    .map(|dim| {
+                        dim.as_u64()
+                            .and_then(|v| usize::try_from(v).ok())
+                            .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' invalid shape")))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let offsets = tensor
+                    .get("data_offsets")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| {
+                        model_load(shard_path, format!("tensor '{name}' missing data_offsets"))
+                    })?;
+                if offsets.len() != 2 {
+                    return Err(model_load(
+                        shard_path,
+                        format!("tensor '{name}' data_offsets must have length 2"),
+                    ));
+                }
+                let start = offsets[0]
+                    .as_u64()
+                    .and_then(|v| usize::try_from(v).ok())
+                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' invalid start offset")))?;
+                let end = offsets[1]
+                    .as_u64()
+                    .and_then(|v| usize::try_from(v).ok())
+                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' invalid end offset")))?;
+                if start > end || end as u64 > data_len {
+                    return Err(model_load(
+                        shard_path,
+                        format!("tensor '{name}' data range invalid"),
+                    ));
+                }
+                let expected = expected_tensor_byte_size(&dtype, &shape, shard_path, name)?;
+                if expected != end - start {
+                    return Err(model_load(
+                        shard_path,
+                        format!(
+                            "tensor '{name}' byte size mismatch: expected {expected}, got {}",
+                            end - start
+                        ),
+                    ));
+                }
+                loc.dtype = dtype;
+                loc.shape = shape;
+                loc.data_offsets = [start, end];
+            }
+
+            shards.push(MappedShard {
+                path: shard_path.clone(),
+                mmap,
+                header_len,
+            });
+        }
+
+        let metadata = SafetensorsMetadata {
+            architecture: config.architectures.first().cloned().unwrap_or_default(),
+            hidden_size: config.hidden_size,
+            num_layers: config.num_hidden_layers,
+            num_experts: config.num_experts.unwrap_or(1),
+            expert_used_count: config.num_experts_per_tok.unwrap_or(1),
+            vocab_size: config.vocab_size,
+        };
+
+        Ok(Self {
+            shards,
+            tensor_map,
+            metadata,
+        })
+    }
+
+    /// Extract a full tensor as `Vec<f32>`, converting BF16/F16 as needed.
+    pub fn extract_tensor_f32(&self, name: &str, path: &str) -> Result<Vec<f32>> {
+        let loc = self.tensor_map.get(name).ok_or_else(|| HybridError::MissingTensor {
+            name: name.to_owned(),
+            path: path.to_owned(),
+        })?;
+        let shard = &self.shards[loc.shard_idx];
+        let data_start = 8 + shard.header_len as usize + loc.data_offsets[0];
+        let data_end = 8 + shard.header_len as usize + loc.data_offsets[1];
+        let bytes = &shard.mmap[data_start..data_end];
+
+        match loc.dtype.as_str() {
+            "F32" => {
+                if bytes.len() % 4 != 0 {
+                    return Err(HybridError::UnsupportedFormat(format!(
+                        "tensor '{name}' F32 data is not 4-byte aligned"
+                    )));
+                }
+                Ok(bytes
+                    .chunks_exact(4)
+                    .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .collect())
+            }
+            "F16" => {
+                if bytes.len() % 2 != 0 {
+                    return Err(HybridError::UnsupportedFormat(format!(
+                        "tensor '{name}' F16 data is not 2-byte aligned"
+                    )));
+                }
+                Ok(bytes
+                    .chunks_exact(2)
+                    .map(|b| f16_to_f32(u16::from_le_bytes([b[0], b[1]])))
+                    .collect())
+            }
+            "BF16" => {
+                if bytes.len() % 2 != 0 {
+                    return Err(HybridError::UnsupportedFormat(format!(
+                        "tensor '{name}' BF16 data is not 2-byte aligned"
+                    )));
+                }
+                Ok(bytes
+                    .chunks_exact(2)
+                    .map(|b| bf16_to_f32(u16::from_le_bytes([b[0], b[1]])))
+                    .collect())
+            }
+            other => Err(HybridError::UnsupportedFormat(format!(
+                "tensor '{name}' has unsupported Safetensors dtype '{other}'"
+            ))),
+        }
+    }
+
+    /// Extract a single row (token embedding) as `Vec<f32>`.
+    pub fn extract_token_embedding(
+        &self,
+        name: &str,
+        path: &str,
+        token_id: usize,
+    ) -> Result<Vec<f32>> {
+        let loc = self.tensor_map.get(name).ok_or_else(|| HybridError::MissingTensor {
+            name: name.to_owned(),
+            path: path.to_owned(),
+        })?;
+        if loc.shape.len() != 2 {
+            return Err(HybridError::UnsupportedFormat(format!(
+                "token embedding tensor '{name}' must be rank-2, got {:?}",
+                loc.shape
+            )));
+        }
+        let d0 = loc.shape[0];
+        let d1 = loc.shape[1];
+        if token_id >= d0 {
+            return Err(HybridError::InputLengthMismatch {
+                expected: d0,
+                got: token_id,
+            });
+        }
+        let row_elements = d1;
+        let element_size = dtype_size_bytes(&loc.dtype).unwrap_or(2);
+        let row_bytes = row_elements * element_size;
+        let shard = &self.shards[loc.shard_idx];
+        let data_start = 8 + shard.header_len as usize + loc.data_offsets[0];
+        let row_start = data_start + token_id * row_bytes;
+        let row_end = row_start + row_bytes;
+        let bytes = &shard.mmap[row_start..row_end];
+
+        match loc.dtype.as_str() {
+            "F32" => Ok(bytes
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect()),
+            "F16" => Ok(bytes
+                .chunks_exact(2)
+                .map(|b| f16_to_f32(u16::from_le_bytes([b[0], b[1]])))
+                .collect()),
+            "BF16" => Ok(bytes
+                .chunks_exact(2)
+                .map(|b| bf16_to_f32(u16::from_le_bytes([b[0], b[1]])))
+                .collect()),
+            other => Err(HybridError::UnsupportedFormat(format!(
+                "token embedding tensor '{name}' has unsupported dtype '{other}'"
+            ))),
+        }
+    }
+
+    pub fn tensor_info(&self, name: &str) -> Option<(&str, &[usize])> {
+        self.tensor_map
+            .get(name)
+            .map(|loc| (loc.dtype.as_str(), loc.shape.as_slice()))
+    }
+
+    fn read_config(root: &Path) -> Result<HfConfig> {
+        let config_path = root.join("config.json");
+        let bytes = fs::read(&config_path).map_err(|e| model_load(&config_path, e.to_string()))?;
+        serde_json::from_slice(&bytes).map_err(|e| model_load(&config_path, format!("parse config.json: {e}")))
+    }
+}
+
+/// Convert a BF16 bit pattern to `f32`.
+pub fn bf16_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
 }
 
 #[cfg(test)]

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1007,7 +1007,10 @@ struct HfConfig {
 fn build_indexed_shard_map(
     root: &Path,
     index_path: &Path,
-) -> Result<(Vec<PathBuf>, std::collections::BTreeMap<String, TensorLocation>)> {
+) -> Result<(
+    Vec<PathBuf>,
+    std::collections::BTreeMap<String, TensorLocation>,
+)> {
     let raw_index = read_index(index_path)?;
     let mut shard_paths: Vec<PathBuf> = Vec::new();
     let mut tensor_map: std::collections::BTreeMap<String, TensorLocation> =
@@ -1038,7 +1041,10 @@ fn build_indexed_shard_map(
 
 fn build_unsharded_shard_map(
     shards: &[PathBuf],
-) -> Result<(Vec<PathBuf>, std::collections::BTreeMap<String, TensorLocation>)> {
+) -> Result<(
+    Vec<PathBuf>,
+    std::collections::BTreeMap<String, TensorLocation>,
+)> {
     let mut tensor_map: std::collections::BTreeMap<String, TensorLocation> =
         std::collections::BTreeMap::new();
     for (shard_idx, shard_path) in shards.iter().enumerate() {
@@ -1253,9 +1259,7 @@ impl MappedSafetensorsCheckpoint {
             if loc.dtype.is_empty() {
                 return Err(model_load(
                     &shard_paths[loc.shard_idx],
-                    format!(
-                        "tensor '{name}' listed in weight_map but missing from shard header"
-                    ),
+                    format!("tensor '{name}' listed in weight_map but missing from shard header"),
                 ));
             }
         }

--- a/src/moe/safetensors.rs
+++ b/src/moe/safetensors.rs
@@ -1017,11 +1017,9 @@ impl MappedSafetensorsCheckpoint {
         }
 
         let config = Self::read_config(root)?;
-        let index_path = find_index_file(root)?.ok_or_else(|| {
-            HybridError::ModelLoad {
-                path: path.to_owned(),
-                reason: "no model.safetensors.index.json found".into(),
-            }
+        let index_path = find_index_file(root)?.ok_or_else(|| HybridError::ModelLoad {
+            path: path.to_owned(),
+            reason: "no model.safetensors.index.json found".into(),
         })?;
         let raw_index = read_index(&index_path)?;
 
@@ -1035,11 +1033,13 @@ impl MappedSafetensorsCheckpoint {
             std::collections::BTreeMap::new();
         for (tensor_name, relative) in &raw_index.weight_map {
             let shard_path = index_shard_path(root, &index_path, relative)?;
-            let shard_idx = *shard_index_by_path.entry(shard_path.clone()).or_insert_with(|| {
-                let idx = shard_paths.len();
-                shard_paths.push(shard_path);
-                idx
-            });
+            let shard_idx = *shard_index_by_path
+                .entry(shard_path.clone())
+                .or_insert_with(|| {
+                    let idx = shard_paths.len();
+                    shard_paths.push(shard_path);
+                    idx
+                });
             tensor_map.insert(
                 tensor_name.clone(),
                 TensorLocation {
@@ -1054,7 +1054,8 @@ impl MappedSafetensorsCheckpoint {
         // Map each shard and parse its header to resolve tensor dtypes/offsets
         for shard_path in &shard_paths {
             let file = File::open(shard_path).map_err(|e| model_load(shard_path, e.to_string()))?;
-            let mmap = unsafe { Mmap::map(&file) }.map_err(|e| model_load(shard_path, e.to_string()))?;
+            let mmap =
+                unsafe { Mmap::map(&file) }.map_err(|e| model_load(shard_path, e.to_string()))?;
             let file_len = mmap.len() as u64;
             let mut len_bytes = [0u8; 8];
             let mut reader = &mmap[..];
@@ -1068,13 +1069,19 @@ impl MappedSafetensorsCheckpoint {
                     format!("header length {header_len} exceeds limit {MAX_HEADER_BYTES}"),
                 ));
             }
-            if 8u64.checked_add(header_len).is_none_or(|end| end > file_len) {
+            if 8u64
+                .checked_add(header_len)
+                .is_none_or(|end| end > file_len)
+            {
                 return Err(model_load(shard_path, "header extends beyond file".into()));
             }
             let header_bytes = &mmap[8..8 + header_len as usize];
             let header = parse_json_rejecting_duplicate_keys(header_bytes, shard_path, "header")?;
             let object = header.as_object().ok_or_else(|| {
-                model_load(shard_path, "Safetensors header must be a JSON object".into())
+                model_load(
+                    shard_path,
+                    "Safetensors header must be a JSON object".into(),
+                )
             })?;
 
             let data_len = file_len
@@ -1093,22 +1100,31 @@ impl MappedSafetensorsCheckpoint {
                     continue;
                 }
                 let tensor = value.as_object().ok_or_else(|| {
-                    model_load(shard_path, format!("tensor '{name}' metadata must be an object"))
+                    model_load(
+                        shard_path,
+                        format!("tensor '{name}' metadata must be an object"),
+                    )
                 })?;
                 let dtype = tensor
                     .get("dtype")
                     .and_then(Value::as_str)
-                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' missing dtype")))?
+                    .ok_or_else(|| {
+                        model_load(shard_path, format!("tensor '{name}' missing dtype"))
+                    })?
                     .to_string();
                 let shape = tensor
                     .get("shape")
                     .and_then(Value::as_array)
-                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' missing shape")))?
+                    .ok_or_else(|| {
+                        model_load(shard_path, format!("tensor '{name}' missing shape"))
+                    })?
                     .iter()
                     .map(|dim| {
                         dim.as_u64()
                             .and_then(|v| usize::try_from(v).ok())
-                            .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' invalid shape")))
+                            .ok_or_else(|| {
+                                model_load(shard_path, format!("tensor '{name}' invalid shape"))
+                            })
                     })
                     .collect::<Result<Vec<_>>>()?;
                 let offsets = tensor
@@ -1126,11 +1142,15 @@ impl MappedSafetensorsCheckpoint {
                 let start = offsets[0]
                     .as_u64()
                     .and_then(|v| usize::try_from(v).ok())
-                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' invalid start offset")))?;
+                    .ok_or_else(|| {
+                        model_load(shard_path, format!("tensor '{name}' invalid start offset"))
+                    })?;
                 let end = offsets[1]
                     .as_u64()
                     .and_then(|v| usize::try_from(v).ok())
-                    .ok_or_else(|| model_load(shard_path, format!("tensor '{name}' invalid end offset")))?;
+                    .ok_or_else(|| {
+                        model_load(shard_path, format!("tensor '{name}' invalid end offset"))
+                    })?;
                 if start > end || end as u64 > data_len {
                     return Err(model_load(
                         shard_path,
@@ -1177,10 +1197,13 @@ impl MappedSafetensorsCheckpoint {
 
     /// Extract a full tensor as `Vec<f32>`, converting BF16/F16 as needed.
     pub fn extract_tensor_f32(&self, name: &str, path: &str) -> Result<Vec<f32>> {
-        let loc = self.tensor_map.get(name).ok_or_else(|| HybridError::MissingTensor {
-            name: name.to_owned(),
-            path: path.to_owned(),
-        })?;
+        let loc = self
+            .tensor_map
+            .get(name)
+            .ok_or_else(|| HybridError::MissingTensor {
+                name: name.to_owned(),
+                path: path.to_owned(),
+            })?;
         let shard = &self.shards[loc.shard_idx];
         let data_start = 8 + shard.header_len as usize + loc.data_offsets[0];
         let data_end = 8 + shard.header_len as usize + loc.data_offsets[1];
@@ -1233,10 +1256,13 @@ impl MappedSafetensorsCheckpoint {
         path: &str,
         token_id: usize,
     ) -> Result<Vec<f32>> {
-        let loc = self.tensor_map.get(name).ok_or_else(|| HybridError::MissingTensor {
-            name: name.to_owned(),
-            path: path.to_owned(),
-        })?;
+        let loc = self
+            .tensor_map
+            .get(name)
+            .ok_or_else(|| HybridError::MissingTensor {
+                name: name.to_owned(),
+                path: path.to_owned(),
+            })?;
         if loc.shape.len() != 2 {
             return Err(HybridError::UnsupportedFormat(format!(
                 "token embedding tensor '{name}' must be rank-2, got {:?}",
@@ -1288,7 +1314,8 @@ impl MappedSafetensorsCheckpoint {
     fn read_config(root: &Path) -> Result<HfConfig> {
         let config_path = root.join("config.json");
         let bytes = fs::read(&config_path).map_err(|e| model_load(&config_path, e.to_string()))?;
-        serde_json::from_slice(&bytes).map_err(|e| model_load(&config_path, format!("parse config.json: {e}")))
+        serde_json::from_slice(&bytes)
+            .map_err(|e| model_load(&config_path, format!("parse config.json: {e}")))
     }
 }
 

--- a/src/moe/tests.rs
+++ b/src/moe/tests.rs
@@ -335,8 +335,8 @@ fn build_q5_k_synapse_checkpoint(gate_payload: Vec<u8>) -> Vec<u8> {
     )
 }
 
-fn stub() -> OlmoeRouter {
-    OlmoeRouter::load_with_mode("", 8, 1, RoutingMode::StubUniform)
+fn stub() -> Router {
+    Router::load_with_mode("", 8, 1, RoutingMode::StubUniform)
         .expect("stub load should succeed")
 }
 
@@ -366,7 +366,7 @@ fn test_dense_sim_uses_real_gate_weights() {
     let path = write_temp_file(&build_real_size_checkpoint(gate_bytes), "dense-real");
 
     let mut model =
-        OlmoeRouter::load_with_mode(path.to_str().unwrap(), 8, 2, RoutingMode::DenseSim).unwrap();
+        Router::load_with_mode(path.to_str().unwrap(), 8, 2, RoutingMode::DenseSim).unwrap();
     let mut embedding = vec![0.0f32; EMBEDDING_DIM];
     embedding[0] = 1.0;
     let out = model.forward(&embedding).unwrap();
@@ -385,7 +385,7 @@ fn test_quantized_synapse_probe_uses_synthetic_fallback() {
         "iq3-s-synapse",
     );
 
-    let metadata = OlmoeRouter::probe_model(path.to_str().unwrap(), None).unwrap();
+    let metadata = Router::probe_model(path.to_str().unwrap(), None).unwrap();
     assert_eq!(
         metadata.preferred_gpu_synapse_tensor_name.as_deref(),
         Some("blk.0.attn_q.weight")
@@ -426,7 +426,7 @@ fn test_quantized_attn_q_does_not_advertise_real_gpu_synapse_tensor() {
     );
 
     let path = write_temp_file(&checkpoint, "quantized-attn-q");
-    let metadata = OlmoeRouter::probe_model(path.to_str().unwrap(), None).unwrap();
+    let metadata = Router::probe_model(path.to_str().unwrap(), None).unwrap();
 
     assert_eq!(
         metadata.preferred_gpu_synapse_tensor_name.as_deref(),
@@ -446,7 +446,7 @@ fn test_preferred_synapse_descriptor_iq3s_has_no_dequant_path() {
         "iq3-s-descriptor",
     );
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
@@ -468,7 +468,7 @@ fn test_preferred_synapse_descriptor_f16_has_dequant_path() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_real_size_checkpoint(gate_payload), "f16-descriptor");
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
@@ -496,7 +496,7 @@ fn test_preferred_synapse_descriptor_q8_0_has_dequant_path() {
         "q8-0-descriptor",
     );
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
@@ -522,7 +522,7 @@ fn test_q8_0_synapse_probe_uses_dequantized_source() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q8_0_synapse_checkpoint(gate_payload), "q8-0-probe");
 
-    let metadata = OlmoeRouter::probe_model(path.to_str().unwrap(), None).unwrap();
+    let metadata = Router::probe_model(path.to_str().unwrap(), None).unwrap();
     assert_eq!(
         metadata.preferred_gpu_synapse_tensor_name.as_deref(),
         Some("blk.0.attn_q.weight")
@@ -538,7 +538,7 @@ fn test_synapse_tensor_row_major_shape_reports_q8_0_dims() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q8_0_synapse_checkpoint(gate_payload), "q8-0-shape");
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
 
     let shape = model
@@ -578,7 +578,7 @@ fn test_synapse_tensor_row_major_shape_uses_one_row_for_rank_one_tensor() {
     );
     let path = write_temp_file(&checkpoint, "rank-1-shape");
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
 
     let shape = model
@@ -618,7 +618,7 @@ fn test_synapse_tensor_row_major_shape_rejects_zero_dim_tensor() {
     );
     let path = write_temp_file(&checkpoint, "zero-dim-shape");
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
 
     let err = model
@@ -637,7 +637,7 @@ fn test_preferred_synapse_descriptor_q5_k_has_dequant_path() {
         "q5-k-descriptor",
     );
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
@@ -663,7 +663,7 @@ fn test_q5_k_synapse_probe_uses_dequantized_source() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q5_k_synapse_checkpoint(gate_payload), "q5-k-probe");
 
-    let metadata = OlmoeRouter::probe_model(path.to_str().unwrap(), None).unwrap();
+    let metadata = Router::probe_model(path.to_str().unwrap(), None).unwrap();
     assert_eq!(
         metadata.preferred_gpu_synapse_tensor_name.as_deref(),
         Some("blk.0.attn_q.weight")
@@ -679,7 +679,7 @@ fn test_q6_k_synapse_probe_uses_dequantized_source() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q6_k_synapse_checkpoint(gate_payload), "q6-k-probe");
 
-    let metadata = OlmoeRouter::probe_model(path.to_str().unwrap(), None).unwrap();
+    let metadata = Router::probe_model(path.to_str().unwrap(), None).unwrap();
     assert_eq!(
         metadata.preferred_gpu_synapse_tensor_name.as_deref(),
         Some("blk.0.attn_q.weight")
@@ -695,7 +695,7 @@ fn test_q5_k_dequantize_full_tensor_succeeds() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q5_k_synapse_checkpoint(gate_payload), "q5-k-dequant");
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
 
     let weights = model
@@ -747,7 +747,7 @@ fn test_q6_k_dequantize_full_tensor_succeeds() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q6_k_synapse_checkpoint(gate_payload), "q6-k-dequant");
 
-    let model = OlmoeRouter::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
+    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
         .unwrap();
 
     let weights = model
@@ -817,7 +817,7 @@ fn test_ggml_type_label_covers_lineup_quants() {
 
 #[test]
 fn test_spiking_sim_state_can_reset() {
-    let mut model = OlmoeRouter::load_with_mode("", 8, 2, RoutingMode::SpikingSim).unwrap();
+    let mut model = Router::load_with_mode("", 8, 2, RoutingMode::SpikingSim).unwrap();
     let _ = model.forward(&vec![1.0; EMBEDDING_DIM]).unwrap();
     assert!(model.has_state_activity());
     model.reset_state();
@@ -826,11 +826,11 @@ fn test_spiking_sim_state_can_reset() {
 
 #[test]
 fn test_real_checkpoint_probe_via_env() {
-    let Some(path) = std::env::var("GGUF_CHECKPOINT_PATH").ok() else {
+    let Some(path) = std::env::var("CHECKPOINT_PATH").ok() else {
         return;
     };
 
-    let metadata = OlmoeRouter::probe_model(&path, None).unwrap();
+    let metadata = Router::probe_model(&path, None).unwrap();
     assert!(!metadata.architecture.is_empty());
     assert!(metadata.hidden_size > 0);
     assert!(metadata.num_experts > 0);
@@ -917,4 +917,43 @@ fn test_synapse_dequant_path_supported_comprehensive() {
     assert!(!synapse_dequant_path_supported(GGML_TYPE_IQ3_S));
     assert!(!synapse_dequant_path_supported(2)); // Q4_0
     assert!(!synapse_dequant_path_supported(15)); // Q8_K
+}
+
+#[test]
+fn test_safetensors_olmoe_load_and_route() {
+    let path = std::path::PathBuf::from(
+        std::env::var("HOME").unwrap_or_else(|_| "/root".into()),
+    )
+    .join(".models/safetensors/allenai/OLMoE-1B-7B-0125-Instruct");
+    if !path.is_dir() {
+        return;
+    }
+    let path_str = path.to_str().unwrap();
+
+    let metadata = Router::probe_model(path_str, None).unwrap();
+    assert_eq!(metadata.family, ModelFamily::Olmoe);
+    assert_eq!(metadata.hidden_size, 2048);
+    assert_eq!(metadata.num_experts, 64);
+    assert_eq!(metadata.expert_used_count, 8);
+    assert_eq!(metadata.architecture, "OlmoeForCausalLM");
+    assert_eq!(metadata.quantization, "safetensors");
+
+    let mut model =
+        Router::load_with_mode(path_str, 0, 0, RoutingMode::DenseSim).unwrap();
+    assert!(model.is_loaded());
+    assert_eq!(model.family(), ModelFamily::Olmoe);
+    assert_eq!(model.hidden_size(), 2048);
+    assert_eq!(model.checkpoint_num_experts(), 64);
+    assert_eq!(model.checkpoint_expert_used_count(), 8);
+    assert_eq!(model.routing_tensor_name(), "model.layers.0.mlp.gate.weight");
+
+    // Forward pass with a dummy embedding
+    let embedding = vec![0.0f32; EMBEDDING_DIM];
+    let out = model.forward(&embedding).unwrap();
+    assert_eq!(out.expert_weights.len(), 64);
+    assert_eq!(out.selected_experts.len(), 8);
+
+    // Token embedding extraction
+    let token_emb = model.extract_token_embedding(0).unwrap();
+    assert_eq!(token_emb.len(), EMBEDDING_DIM);
 }

--- a/src/moe/tests.rs
+++ b/src/moe/tests.rs
@@ -336,8 +336,7 @@ fn build_q5_k_synapse_checkpoint(gate_payload: Vec<u8>) -> Vec<u8> {
 }
 
 fn stub() -> Router {
-    Router::load_with_mode("", 8, 1, RoutingMode::StubUniform)
-        .expect("stub load should succeed")
+    Router::load_with_mode("", 8, 1, RoutingMode::StubUniform).expect("stub load should succeed")
 }
 
 #[test]
@@ -446,8 +445,8 @@ fn test_preferred_synapse_descriptor_iq3s_has_no_dequant_path() {
         "iq3-s-descriptor",
     );
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
         .expect("preferred descriptor must be exposed for quantized attn_q");
@@ -468,8 +467,8 @@ fn test_preferred_synapse_descriptor_f16_has_dequant_path() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_real_size_checkpoint(gate_payload), "f16-descriptor");
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
         .expect("preferred descriptor must be exposed for F16 attn_q");
@@ -496,8 +495,8 @@ fn test_preferred_synapse_descriptor_q8_0_has_dequant_path() {
         "q8-0-descriptor",
     );
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
         .expect("preferred descriptor must be exposed for Q8_0 attn_q");
@@ -538,8 +537,8 @@ fn test_synapse_tensor_row_major_shape_reports_q8_0_dims() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q8_0_synapse_checkpoint(gate_payload), "q8-0-shape");
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
 
     let shape = model
         .synapse_tensor_row_major_shape("blk.0.attn_q.weight")
@@ -578,8 +577,8 @@ fn test_synapse_tensor_row_major_shape_uses_one_row_for_rank_one_tensor() {
     );
     let path = write_temp_file(&checkpoint, "rank-1-shape");
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
 
     let shape = model
         .synapse_tensor_row_major_shape("rank1.tensor")
@@ -618,8 +617,8 @@ fn test_synapse_tensor_row_major_shape_rejects_zero_dim_tensor() {
     );
     let path = write_temp_file(&checkpoint, "zero-dim-shape");
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
 
     let err = model
         .synapse_tensor_row_major_shape("zero-dim.tensor")
@@ -637,8 +636,8 @@ fn test_preferred_synapse_descriptor_q5_k_has_dequant_path() {
         "q5-k-descriptor",
     );
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
     let descriptor = model
         .preferred_gpu_synapse_tensor_descriptor()
         .expect("preferred descriptor must be exposed for Q5_K attn_q");
@@ -695,8 +694,8 @@ fn test_q5_k_dequantize_full_tensor_succeeds() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q5_k_synapse_checkpoint(gate_payload), "q5-k-dequant");
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
 
     let weights = model
         .dequantized_q5_k_synapse_weights("blk.0.attn_q.weight")
@@ -747,8 +746,8 @@ fn test_q6_k_dequantize_full_tensor_succeeds() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(&build_q6_k_synapse_checkpoint(gate_payload), "q6-k-dequant");
 
-    let model = Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform)
-        .unwrap();
+    let model =
+        Router::load_with_mode(path.to_str().unwrap(), 0, 0, RoutingMode::StubUniform).unwrap();
 
     let weights = model
         .dequantized_q6_k_synapse_weights("blk.0.attn_q.weight")
@@ -921,10 +920,8 @@ fn test_synapse_dequant_path_supported_comprehensive() {
 
 #[test]
 fn test_safetensors_olmoe_load_and_route() {
-    let path = std::path::PathBuf::from(
-        std::env::var("HOME").unwrap_or_else(|_| "/root".into()),
-    )
-    .join(".models/safetensors/allenai/OLMoE-1B-7B-0125-Instruct");
+    let path = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/root".into()))
+        .join(".models/safetensors/allenai/OLMoE-1B-7B-0125-Instruct");
     if !path.is_dir() {
         return;
     }
@@ -938,14 +935,16 @@ fn test_safetensors_olmoe_load_and_route() {
     assert_eq!(metadata.architecture, "OlmoeForCausalLM");
     assert_eq!(metadata.quantization, "safetensors");
 
-    let mut model =
-        Router::load_with_mode(path_str, 0, 0, RoutingMode::DenseSim).unwrap();
+    let mut model = Router::load_with_mode(path_str, 0, 0, RoutingMode::DenseSim).unwrap();
     assert!(model.is_loaded());
     assert_eq!(model.family(), ModelFamily::Olmoe);
     assert_eq!(model.hidden_size(), 2048);
     assert_eq!(model.checkpoint_num_experts(), 64);
     assert_eq!(model.checkpoint_expert_used_count(), 8);
-    assert_eq!(model.routing_tensor_name(), "model.layers.0.mlp.gate.weight");
+    assert_eq!(
+        model.routing_tensor_name(),
+        "model.layers.0.mlp.gate.weight"
+    );
 
     // Forward pass with a dummy embedding
     let embedding = vec![0.0f32; EMBEDDING_DIM];

--- a/src/projector.rs
+++ b/src/projector.rs
@@ -1,9 +1,9 @@
 //! Spike-to-expert projector — the heart of the neuromorphic-ANN fusion.
 //!
-//! The [`Projector`] sits between the Spikenaut SNN and OlmoeRouter's expert router.
+//! The [`Projector`] sits between the Spikenaut SNN and Router's expert router.
 //! Its job is to compress the high-dimensional spike activity (neuron indices +
 //! firing rates + membrane potentials) into a single dense embedding vector
-//! that OlmoeRouter can use as a context prefix.
+//! that Router can use as a context prefix.
 //!
 //! # Projection modes
 //!
@@ -13,7 +13,7 @@
 //! | [`TemporalHistogram`] | Spikes binned over time → flatten | timing-sensitive HFT |
 //! | [`MembraneSnapshot`] | Post-step membrane potentials → linear | smooth gradient flow |
 //!
-//! # No OlmoeRouter dependency
+//! # No Router dependency
 //!
 //! The projector is intentionally **pure** — it depends only on the spike
 //! activity represented as spike indices, potentials, and adaptive voltages,
@@ -43,7 +43,7 @@ fn feature_dim_for(snn_neurons: usize) -> usize {
 
 // ── Projector ─────────────────────────────────────────────────────────────────
 
-/// Converts Spikenaut SNN output into a dense embedding for OlmoeRouter.
+/// Converts Spikenaut SNN output into a dense embedding for Router.
 ///
 /// Internally this is a **learned linear layer** `W ∈ ℝ^{EMBEDDING_DIM × FEATURE_DIM}`
 /// plus a bias `b ∈ ℝ^{EMBEDDING_DIM}`, initialised with Xavier-uniform weights.

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-/// Dimensionality of the dense embedding the projector hands to OlmoeRouter.
+/// Dimensionality of the dense embedding the projector hands to Router.
 pub const EMBEDDING_DIM: usize = 2048;
 
 /// Supported GGUF model families for the router bridge.
@@ -54,10 +54,28 @@ impl TelemetrySnapshot {
     }
 }
 
+/// Supported checkpoint formats for model loading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum CheckpointFormat {
+    #[default]
+    Gguf,
+    Safetensors,
+}
+
+impl CheckpointFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Gguf => "gguf",
+            Self::Safetensors => "safetensors",
+        }
+    }
+}
+
 /// Top-level configuration for the hybrid quantization pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
-    pub gguf_checkpoint_path: String,
+    pub checkpoint_path: String,
+    pub checkpoint_format: CheckpointFormat,
     pub model_family: Option<ModelFamily>,
     pub gpu_synapse_tensor_name: String,
     pub num_experts: usize,
@@ -77,7 +95,8 @@ pub struct ModelConfig {
 impl Default for ModelConfig {
     fn default() -> Self {
         Self {
-            gguf_checkpoint_path: String::new(),
+            checkpoint_path: String::new(),
+            checkpoint_format: CheckpointFormat::Gguf,
             model_family: None,
             gpu_synapse_tensor_name: String::new(),
             num_experts: 8,
@@ -90,7 +109,7 @@ impl Default for ModelConfig {
     }
 }
 
-/// Strategy used to convert spike activity into an OlmoeRouter embedding.
+/// Strategy used to convert spike activity into a Router embedding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ProjectionMode {
     RateSum,
@@ -100,7 +119,7 @@ pub enum ProjectionMode {
     SpikingTernary,
 }
 
-/// Execution mode used by the OlmoeRouter router.
+/// Execution mode used by the Router router.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum RoutingMode {
     StubUniform,


### PR DESCRIPTION
## Summary

This PR combines the implementation for three related issues into a single cohesive feature branch:

- **#75** — Set up configuration for local LLM SAAQ experimentation
- **#76** — Create first local SAAQ experiment path for model onboarding  
- **#85** — Standardize SAAQ experiment output schema for Surrogate_Viz.jl ingestion

## Changes

### Model Infrastructure
- **Moved OLMoE model** to `~/.models/safetensors/allenai/OLMoE-1B-7B-0125-Instruct/`
- **Downloaded official HF config files** (`config.json` + `model.safetensors.index.json`)
- **Renamed `OlmoeRouter` → `Router`** across entire codebase

### Safetensors Support
- **Added `CheckpointFormat` enum** (`gguf` | `safetensors`) to `ModelConfig`
- **Implemented safetensors tensor loading** in `Router` with memory-mapped shard access
- **Supports BF16, F16, F32** tensor extraction for routing weights and token embeddings
- **Auto-detects format** from file extension (.gguf vs directory)

### Configuration & Documentation
- **Updated `.env.example`** with:
  - `$MODEL_ROOT` / `$CORINTH_MODEL_ROOT` for model path conventions
  - `SAFETENSORS_LINEUP_CONFIG` for safetensors model lineup
  - `EMBEDDING_BACKEND` for local embedding backend selection
- **Added OLMoE entry** to `configs/safetensors_lineup.template.toml`

### Output Schema Standardization
- **Created `src/experiment/schema.rs`** with canonical structs:
  - `ExperimentManifest` — per-run metadata
  - `ExperimentSummary` — compact downstream summary
  - `ExperimentMetrics` — quantitative metrics (weight_mse, router_top1_agreement, compression_estimate, etc.)
  - `ExperimentBundle` — top-level ingestion structure
- **Stripped all heartbeat references** from manifest and metrics
- **Updated `saaq_latent_calibration.rs`** to emit standardized `ExperimentManifest`/`ExperimentSummary`/`ExperimentMetrics`

## Validation

- ✅ `cargo check --no-default-features` — clean
- ✅ `cargo test --no-default-features` — **106 tests pass**
- ✅ `cargo check --all-targets` — clean (with CUDA)
- ✅ rust-analyzer diagnostics — no real issues (only inactive-code weak warnings)

## Cloud Handoff

Updated docs reference **IBM Cloud** and **Oracle Cloud** as next cloud onboarding targets (replacing Vultr HGX A100 references).

## Non-Goals

- No cloud provisioning in this PR
- No model weights committed
- No hardcoded absolute paths in committed code
- No changes to SAAQ math or router math

---

**Closes:** #75, #76, #85

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add safetensors checkpoint support to `Router` and rename `OlmoeRouter` to `Router`
> - Renames `OlmoeRouter` to `Router` throughout the codebase and renames `gguf_checkpoint_path` / `GGUF_CHECKPOINT_PATH` to `checkpoint_path` / `CHECKPOINT_PATH` in config structs, env vars, and docs.
> - Adds `MappedSafetensorsCheckpoint` in [safetensors.rs](https://github.com/rmems/corinth-canal/pull/91/files#diff-77454ae492726c9da32a1b80efaa0df893a1e42dac1246128d49eac3679c0ff5) that memory-maps sharded or single-file safetensors directories, parses headers, and exposes `extract_tensor_f32` and `extract_token_embedding`.
> - Introduces a `CheckpointBackend` enum so `Router` can back routing at runtime with either a GGUF file or a safetensors directory; GPU synapse paths (Q8_0, Q5_K, Q6_K) return `UnsupportedFormat` for the safetensors backend.
> - Adds `safetensors_gate_scores` in [routing.rs](https://github.com/rmems/corinth-canal/pull/91/files#diff-7c7fb4d9f66d1501fb5324351042a746f967c8b73cff0465510724a02d8dfeec) and `resolve_safetensors_adapter` in [adapter.rs](https://github.com/rmems/corinth-canal/pull/91/files#diff-1a258a9c4e9a266d1fda17f55ef011613f5cb40a19396bf79177f548359d2a57) to validate routing tensor shape and compute gate scores from safetensors weights.
> - Adds a new `experiment` module with `ExperimentManifest`, `ExperimentSummary`, `ExperimentMetrics`, `ExperimentBundle`, and `ExperimentWarning` schema types, re-exported from the crate root; `saaq_latent_calibration` example migrates to these types.
> - Adds `configs/safetensors_lineup.template.toml` and `SAFETENSORS_LINEUP_CONFIG` env support so examples can discover safetensors models alongside GGUF lineups.
> - Risk: `ModelConfig` field rename from `gguf_checkpoint_path` to `checkpoint_path` is a breaking deserialization change for any persisted configs or external callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5774cea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->