### PR TITLE
feat: local SAAQ dry-run validator and sprint summarizer (#90 Lane A+D)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ configs/local_lineup.toml
 configs/local_gguf_lineup.toml
 configs/local_safetensors_lineup.toml
 configs/safetensors_lineup.toml
+.beads/

--- a/.kilo/kilo.jsonc
+++ b/.kilo/kilo.jsonc
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://app.kilo.ai/config.json"
+}

--- a/examples/summarize_local_saaq.rs
+++ b/examples/summarize_local_saaq.rs
@@ -3,13 +3,88 @@
 //! Usage:
 //!   cargo run --example summarize_local_saaq -- <runs-dir>
 //!
-//! Reads all `run_manifest.json` / `summary.json` files under `<runs-dir>`
-//! and emits a markdown summary table to stdout.
+//! Recursively reads all `run_manifest.json` / `summary.json` files under
+//! `<runs-dir>` and emits a markdown summary table to stdout.
 
 use corinth_canal::ExperimentManifest;
 use std::env;
 use std::fs;
 use std::path::Path;
+
+fn classify_status(validation: &str, has_manifest: bool) -> String {
+    if validation == "completed" || validation == "ok" {
+        "ok".into()
+    } else if validation == "error"
+        || validation.ends_with("_failed")
+        || validation == "tick_failed"
+    {
+        "error".into()
+    } else if has_manifest {
+        validation.into()
+    } else {
+        "missing".into()
+    }
+}
+
+fn collect_run_summaries(runs_dir: &Path, entries: &mut Vec<RunSummary>) {
+    if let Ok(subdirs) = fs::read_dir(runs_dir) {
+        for entry in subdirs.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let manifest_path = path.join("run_manifest.json");
+
+            if manifest_path.exists() {
+                let summary_path = path.join("summary.json");
+                let manifest = fs::read_to_string(&manifest_path)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<ExperimentManifest>(&s).ok());
+
+                let ticks = manifest.as_ref().map(|m| m.ticks).unwrap_or(0);
+                let model_slug = manifest
+                    .as_ref()
+                    .map(|m| m.model_slug.clone())
+                    .unwrap_or_else(|| "?".into());
+                let model_family = manifest
+                    .as_ref()
+                    .map(|m| m.model_family.clone())
+                    .unwrap_or_else(|| "?".into());
+                let validation = manifest
+                    .as_ref()
+                    .map(|m| m.validation_status.clone())
+                    .unwrap_or_else(|| "missing".into());
+
+                let run_id = path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned();
+
+                let has_manifest = true;
+                let has_summary = summary_path.exists();
+                let has_telemetry = path.join("tick_telemetry.txt").exists()
+                    || path.join("latent_telemetry.csv").exists();
+
+                let status = classify_status(&validation, has_manifest);
+
+                entries.push(RunSummary {
+                    run_id,
+                    model_slug,
+                    model_family,
+                    ticks,
+                    status,
+                    has_manifest,
+                    has_summary,
+                    has_telemetry,
+                });
+            } else {
+                collect_run_summaries(&path, entries);
+            }
+        }
+    }
+}
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -25,71 +100,7 @@ fn main() {
     }
 
     let mut entries: Vec<RunSummary> = Vec::new();
-
-    if let Ok(subdirs) = fs::read_dir(runs_dir) {
-        for entry in subdirs.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let manifest_path = path.join("run_manifest.json");
-            let summary_path = path.join("summary.json");
-
-            let manifest = if manifest_path.exists() {
-                fs::read_to_string(&manifest_path)
-                    .ok()
-                    .and_then(|s| serde_json::from_str::<ExperimentManifest>(&s).ok())
-            } else {
-                None
-            };
-
-            let ticks = manifest.as_ref().map(|m| m.ticks).unwrap_or(0);
-            let model_slug = manifest
-                .as_ref()
-                .map(|m| m.model_slug.clone())
-                .unwrap_or_else(|| "?".into());
-            let model_family = manifest
-                .as_ref()
-                .map(|m| m.model_family.clone())
-                .unwrap_or_else(|| "?".into());
-            let validation = manifest
-                .as_ref()
-                .map(|m| m.validation_status.clone())
-                .unwrap_or_else(|| "missing".into());
-
-            let run_id = path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .into_owned();
-
-            let has_manifest = manifest_path.exists();
-            let has_summary = summary_path.exists();
-            let has_telemetry = path.join("tick_telemetry.txt").exists()
-                || path.join("latent_telemetry.csv").exists();
-
-            let status = if validation == "ok" {
-                "ok"
-            } else if validation == "error" {
-                "error"
-            } else if has_manifest {
-                &validation
-            } else {
-                "missing"
-            };
-
-            entries.push(RunSummary {
-                run_id,
-                model_slug,
-                model_family,
-                ticks,
-                status: status.to_string(),
-                has_manifest,
-                has_summary,
-                has_telemetry,
-            });
-        }
-    }
+    collect_run_summaries(runs_dir, &mut entries);
 
     if entries.is_empty() {
         println!("No run directories found under `{}`.", runs_dir.display());

--- a/examples/summarize_local_saaq.rs
+++ b/examples/summarize_local_saaq.rs
@@ -1,0 +1,146 @@
+//! Summarize SAAQ run artifacts for a sprint-level report.
+//!
+//! Usage:
+//!   cargo run --example summarize_local_saaq -- <runs-dir>
+//!
+//! Reads all `run_manifest.json` / `summary.json` files under `<runs-dir>`
+//! and emits a markdown summary table to stdout.
+
+use corinth_canal::ExperimentManifest;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: summarize_local_saaq <runs-dir>");
+        std::process::exit(1);
+    }
+
+    let runs_dir = Path::new(&args[1]);
+    if !runs_dir.is_dir() {
+        eprintln!("Error: '{}' is not a directory", runs_dir.display());
+        std::process::exit(1);
+    }
+
+    let mut entries: Vec<RunSummary> = Vec::new();
+
+    if let Ok(subdirs) = fs::read_dir(runs_dir) {
+        for entry in subdirs.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let manifest_path = path.join("run_manifest.json");
+            let summary_path = path.join("summary.json");
+
+            let manifest = if manifest_path.exists() {
+                fs::read_to_string(&manifest_path)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<ExperimentManifest>(&s).ok())
+            } else {
+                None
+            };
+
+            let ticks = manifest.as_ref().map(|m| m.ticks).unwrap_or(0);
+            let model_slug = manifest
+                .as_ref()
+                .map(|m| m.model_slug.clone())
+                .unwrap_or_else(|| "?".into());
+            let model_family = manifest
+                .as_ref()
+                .map(|m| m.model_family.clone())
+                .unwrap_or_else(|| "?".into());
+            let validation = manifest
+                .as_ref()
+                .map(|m| m.validation_status.clone())
+                .unwrap_or_else(|| "missing".into());
+
+            let run_id = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
+
+            let has_manifest = manifest_path.exists();
+            let has_summary = summary_path.exists();
+            let has_telemetry = path.join("tick_telemetry.txt").exists()
+                || path.join("latent_telemetry.csv").exists();
+
+            let status = if validation == "ok" {
+                "ok"
+            } else if validation == "error" {
+                "error"
+            } else if has_manifest {
+                &validation
+            } else {
+                "missing"
+            };
+
+            entries.push(RunSummary {
+                run_id,
+                model_slug,
+                model_family,
+                ticks,
+                status: status.to_string(),
+                has_manifest,
+                has_summary,
+                has_telemetry,
+            });
+        }
+    }
+
+    if entries.is_empty() {
+        println!("No run directories found under `{}`.", runs_dir.display());
+        return;
+    }
+
+    println!("# SAAQ Sprint Summary");
+    println!();
+    println!("**Runs directory:** `{}`", runs_dir.display());
+    println!("**Total runs:** {}", entries.len());
+    println!();
+
+    let ok_count = entries.iter().filter(|e| e.status == "ok").count();
+    let err_count = entries.iter().filter(|e| e.status == "error").count();
+    let missing_count = entries.iter().filter(|e| e.status == "missing").count();
+    let other_count = entries.len() - ok_count - err_count - missing_count;
+
+    println!("| Status | Count |");
+    println!("|--------|-------|");
+    println!("| ok | {} |", ok_count);
+    println!("| error | {} |", err_count);
+    println!("| missing | {} |", missing_count);
+    if other_count > 0 {
+        println!("| other | {} |", other_count);
+    }
+    println!();
+
+    println!("| Run ID | Model | Family | Ticks | Status | Manifest | Summary | Telemetry |");
+    println!("|--------|-------|--------|-------|--------|----------|---------|-----------|");
+    for e in &entries {
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} |",
+            e.run_id,
+            e.model_slug,
+            e.model_family,
+            e.ticks,
+            e.status,
+            if e.has_manifest { "yes" } else { "no" },
+            if e.has_summary { "yes" } else { "no" },
+            if e.has_telemetry { "yes" } else { "no" },
+        );
+    }
+}
+
+struct RunSummary {
+    run_id: String,
+    model_slug: String,
+    model_family: String,
+    ticks: usize,
+    status: String,
+    has_manifest: bool,
+    has_summary: bool,
+    has_telemetry: bool,
+}

--- a/examples/validate_local_saaq.rs
+++ b/examples/validate_local_saaq.rs
@@ -5,8 +5,8 @@
 //!
 //! Validates matrix entries for:
 //! - Structural correctness (RunMatrix::validate)
-//! - Path existence (when --check-paths is given)
-//! - Model family/format consistency
+//! - Policy and source format value checks (strict, not just warnings)
+//! - Path existence (when --check-paths is given, with env var resolution)
 //!
 //! Exits 0 on success, 1 on validation failure.
 
@@ -15,6 +15,18 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::process;
+
+fn resolve_env_path(raw: &str) -> (String, bool) {
+    if let Some(env_val) = raw.strip_prefix("$") {
+        if let Some(var_name) = env_val.split('/').next() {
+            if let Ok(val) = std::env::var(var_name) {
+                return (raw.replacen(&format!("${}", var_name), &val, 1), true);
+            }
+            return (raw.to_string(), false);
+        }
+    }
+    (raw.to_string(), true)
+}
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -49,8 +61,7 @@ fn main() {
         process::exit(1);
     }
 
-    let mut warnings = Vec::new();
-    let mut path_errors = 0;
+    let mut errors = Vec::new();
     let mut enabled = 0;
     let mut skipped = 0;
 
@@ -62,78 +73,73 @@ fn main() {
         enabled += 1;
 
         if !["gguf", "safetensors", "custom_artifact"].contains(&run.source_format.as_str()) {
-            warnings.push(format!(
-                "run '{}': unknown source_format '{}' (expected gguf|safetensors|custom_artifact)",
+            errors.push(format!(
+                "run '{}': invalid source_format '{}' (expected gguf|safetensors|custom_artifact)",
                 run.run_id, run.source_format
             ));
         }
 
         if !["protect", "quantize", "drop"].contains(&run.router_policy.as_str()) {
-            warnings.push(format!(
-                "run '{}': unexpected router_policy '{}' (expected protect|quantize|drop)",
+            errors.push(format!(
+                "run '{}': invalid router_policy '{}' (expected protect|quantize|drop)",
                 run.run_id, run.router_policy
             ));
         }
 
         if !["protect", "quantize", "drop"].contains(&run.norm_policy.as_str()) {
-            warnings.push(format!(
-                "run '{}': unexpected norm_policy '{}' (expected protect|quantize|drop)",
+            errors.push(format!(
+                "run '{}': invalid norm_policy '{}' (expected protect|quantize|drop)",
                 run.run_id, run.norm_policy
             ));
         }
 
         if check_paths {
-            let model_path = Path::new(&run.model_id_or_path);
-            if !model_path.exists() && run.source_format != "custom_artifact" {
-                warnings.push(format!(
-                    "run '{}': model path not found: {}",
-                    run.run_id, run.model_id_or_path
-                ));
-                path_errors += 1;
-            }
-
-            if let Some(env_val) = run.model_id_or_path.strip_prefix("$")
-                && let Some(var_name) = env_val.split('/').next()
-                && std::env::var(var_name).is_err()
-            {
-                warnings.push(format!(
-                    "run '{}': env var '{}' not set (from model_id_or_path '{}')",
-                    run.run_id, var_name, run.model_id_or_path
-                ));
-                path_errors += 1;
-            }
-
-            let output_root = Path::new(&run.output_root);
-            if output_root.exists() {
-                let run_dir = output_root.join(&run.run_id);
-                if run_dir.exists() {
-                    warnings.push(format!(
-                        "run '{}': output directory already exists: {}",
-                        run.run_id,
-                        run_dir.display()
+            let (resolved, env_ok) = resolve_env_path(&run.model_id_or_path);
+            if !env_ok {
+                if let Some(env_val) = run.model_id_or_path.strip_prefix("$") {
+                    let var_name = env_val.split('/').next().unwrap_or("?");
+                    errors.push(format!(
+                        "run '{}': env var '{}' not set (from model_id_or_path '{}')",
+                        run.run_id, var_name, run.model_id_or_path
                     ));
+                }
+            } else if run.source_format != "custom_artifact" {
+                let model_path = Path::new(&resolved);
+                if !model_path.exists() {
+                    errors.push(format!(
+                        "run '{}': model path not found: {} (resolved from '{}')",
+                        run.run_id, resolved, run.model_id_or_path
+                    ));
+                }
+            }
+
+            let (resolved_output, output_env_ok) = resolve_env_path(&run.output_root);
+            if output_env_ok {
+                let output_root = Path::new(&resolved_output);
+                if output_root.exists() {
+                    let run_dir = output_root.join(&run.run_id);
+                    if run_dir.exists() {
+                        errors.push(format!(
+                            "run '{}': output directory already exists: {}",
+                            run.run_id,
+                            run_dir.display()
+                        ));
+                    }
                 }
             }
         }
     }
 
-    println!("Validation passed.");
-    println!("  Enabled runs: {}", enabled);
-    println!("  Skipped runs: {}", skipped);
-
-    if !warnings.is_empty() {
-        println!();
-        println!("Warnings ({}):", warnings.len());
-        for w in &warnings {
-            println!("  - {}", w);
+    if errors.is_empty() {
+        println!("Validation passed.");
+    } else {
+        eprintln!("Validation failed with {} error(s):", errors.len());
+        for e in &errors {
+            eprintln!("  - {}", e);
         }
-    }
-
-    if path_errors > 0 {
-        eprintln!(
-            "Path check found {} missing or unresolved path(s).",
-            path_errors
-        );
         process::exit(1);
     }
+
+    println!("  Enabled runs: {}", enabled);
+    println!("  Skipped runs: {}", skipped);
 }

--- a/examples/validate_local_saaq.rs
+++ b/examples/validate_local_saaq.rs
@@ -1,0 +1,140 @@
+//! Dry-run validation for the local SAAQ experiment matrix.
+//!
+//! Usage:
+//!   cargo run --example validate_local_saaq --no-default-features -- <matrix.toml> [--check-paths]
+//!
+//! Validates matrix entries for:
+//! - Structural correctness (RunMatrix::validate)
+//! - Path existence (when --check-paths is given)
+//! - Model family/format consistency
+//!
+//! Exits 0 on success, 1 on validation failure.
+
+use corinth_canal::RunMatrix;
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: validate_local_saaq <matrix.toml> [--check-paths]");
+        process::exit(1);
+    }
+
+    let matrix_path = &args[1];
+    let check_paths = args.iter().any(|a| a == "--check-paths");
+
+    let contents = match fs::read_to_string(matrix_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error reading '{}': {}", matrix_path, e);
+            process::exit(1);
+        }
+    };
+
+    let matrix: RunMatrix = match toml::from_str(&contents) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error parsing '{}': {}", matrix_path, e);
+            process::exit(1);
+        }
+    };
+
+    println!("Loaded {} run(s) from '{}'", matrix.runs.len(), matrix_path);
+
+    if let Err(e) = matrix.validate() {
+        eprintln!("Validation failed: {}", e);
+        process::exit(1);
+    }
+
+    let mut warnings = Vec::new();
+    let mut path_errors = 0;
+    let mut enabled = 0;
+    let mut skipped = 0;
+
+    for run in &matrix.runs {
+        if run.skip_reason.is_some() {
+            skipped += 1;
+            continue;
+        }
+        enabled += 1;
+
+        if !["gguf", "safetensors", "custom_artifact"].contains(&run.source_format.as_str()) {
+            warnings.push(format!(
+                "run '{}': unknown source_format '{}' (expected gguf|safetensors|custom_artifact)",
+                run.run_id, run.source_format
+            ));
+        }
+
+        if !["protect", "quantize", "drop"].contains(&run.router_policy.as_str()) {
+            warnings.push(format!(
+                "run '{}': unexpected router_policy '{}' (expected protect|quantize|drop)",
+                run.run_id, run.router_policy
+            ));
+        }
+
+        if !["protect", "quantize", "drop"].contains(&run.norm_policy.as_str()) {
+            warnings.push(format!(
+                "run '{}': unexpected norm_policy '{}' (expected protect|quantize|drop)",
+                run.run_id, run.norm_policy
+            ));
+        }
+
+        if check_paths {
+            let model_path = Path::new(&run.model_id_or_path);
+            if !model_path.exists() && run.source_format != "custom_artifact" {
+                warnings.push(format!(
+                    "run '{}': model path not found: {}",
+                    run.run_id, run.model_id_or_path
+                ));
+                path_errors += 1;
+            }
+
+            if let Some(env_val) = run.model_id_or_path.strip_prefix("$") {
+                if let Some(var_name) = env_val.split('/').next() {
+                    if std::env::var(var_name).is_err() {
+                        warnings.push(format!(
+                            "run '{}': env var '{}' not set (from model_id_or_path '{}')",
+                            run.run_id, var_name, run.model_id_or_path
+                        ));
+                        path_errors += 1;
+                    }
+                }
+            }
+
+            let output_root = Path::new(&run.output_root);
+            if output_root.exists() {
+                let run_dir = output_root.join(&run.run_id);
+                if run_dir.exists() {
+                    warnings.push(format!(
+                        "run '{}': output directory already exists: {}",
+                        run.run_id,
+                        run_dir.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    println!("Validation passed.");
+    println!("  Enabled runs: {}", enabled);
+    println!("  Skipped runs: {}", skipped);
+
+    if !warnings.is_empty() {
+        println!();
+        println!("Warnings ({}):", warnings.len());
+        for w in &warnings {
+            println!("  - {}", w);
+        }
+    }
+
+    if path_errors > 0 {
+        eprintln!(
+            "Path check found {} missing or unresolved path(s).",
+            path_errors
+        );
+        process::exit(1);
+    }
+}

--- a/examples/validate_local_saaq.rs
+++ b/examples/validate_local_saaq.rs
@@ -17,13 +17,13 @@ use std::path::Path;
 use std::process;
 
 fn resolve_env_path(raw: &str) -> (String, bool) {
-    if let Some(env_val) = raw.strip_prefix("$") {
-        if let Some(var_name) = env_val.split('/').next() {
-            if let Ok(val) = std::env::var(var_name) {
-                return (raw.replacen(&format!("${}", var_name), &val, 1), true);
-            }
-            return (raw.to_string(), false);
+    if let Some(env_val) = raw.strip_prefix("$")
+        && let Some(var_name) = env_val.split('/').next()
+    {
+        if let Ok(val) = std::env::var(var_name) {
+            return (raw.replacen(&format!("${}", var_name), &val, 1), true);
         }
+        return (raw.to_string(), false);
     }
     (raw.to_string(), true)
 }

--- a/examples/validate_local_saaq.rs
+++ b/examples/validate_local_saaq.rs
@@ -92,16 +92,15 @@ fn main() {
                 path_errors += 1;
             }
 
-            if let Some(env_val) = run.model_id_or_path.strip_prefix("$") {
-                if let Some(var_name) = env_val.split('/').next() {
-                    if std::env::var(var_name).is_err() {
-                        warnings.push(format!(
-                            "run '{}': env var '{}' not set (from model_id_or_path '{}')",
-                            run.run_id, var_name, run.model_id_or_path
-                        ));
-                        path_errors += 1;
-                    }
-                }
+            if let Some(env_val) = run.model_id_or_path.strip_prefix("$")
+                && let Some(var_name) = env_val.split('/').next()
+                && std::env::var(var_name).is_err()
+            {
+                warnings.push(format!(
+                    "run '{}': env var '{}' not set (from model_id_or_path '{}')",
+                    run.run_id, var_name, run.model_id_or_path
+                ));
+                path_errors += 1;
             }
 
             let output_root = Path::new(&run.output_root);


### PR DESCRIPTION
## **User description**
## Summary

Implements Lane A (local experiment CLI) and Lane D (reviewable summaries) from #90.

- **`validate_local_saaq`**: Dry-run matrix validator that checks structural correctness, policy values, source formats, and (with `--check-paths`) model path existence, env var resolution, and output directory conflicts. Exits non-zero on failure.
- **`summarize_local_saaq`**: Reads all `run_manifest.json`/`summary.json` artifacts under a runs directory and emits a markdown sprint summary table with status counts, model/family/ticks columns, and artifact presence checks.

## Key decisions

- `validate_local_saaq` uses `RunMatrix::validate()` for structural checks plus additional policy/format warnings
- `--check-paths` is opt-in since models may not be present on CI machines
- `summarize_local_saaq` emits markdown to stdout for easy piping into reports

## Test plan
- [x] `cargo check --example validate_local_saaq --no-default-features` clean
- [x] `cargo check --example summarize_local_saaq --no-default-features` clean
- [x] `cargo test --no-default-features` 127 tests pass
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual: run `validate_local_saaq` against the experiment matrix
- [ ] Manual: run `summarize_local_saaq` against existing run artifacts

Closes #90 (partial — Lane A + Lane D)

Agent: Kilo (Vultr/GLM-5.1)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local SAAQ dry-run validator and sprint summarizer CLI examples
> - Adds [validate_local_saaq.rs](https://github.com/rmems/corinth-canal/pull/96/files#diff-6ea6cfac9ab22cfee1faf6ba5f8b3cb87184dfe1d80333925a3ca13231d3fa4f), a CLI tool that validates a `RunMatrix` TOML file, checking required enum fields (`source_format`, `router_policy`, `norm_policy`) and optionally resolving env-var-prefixed paths and checking filesystem existence.
> - Adds [summarize_local_saaq.rs](https://github.com/rmems/corinth-canal/pull/96/files#diff-c89d343d9661b06de807e36d16bcc572aaa17c987d19d15b5294d6fff5fbeb5a), a CLI tool that recursively scans a runs directory for `run_manifest.json` files and prints a markdown sprint summary with per-run status, artifact flags, and aggregate counts.
> - Adds a `.beads/` ignore pattern to [.gitignore](https://github.com/rmems/corinth-canal/pull/96/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) and a new [kilo.jsonc](https://github.com/rmems/corinth-canal/pull/96/files#diff-6485d6c4d6372e8ea7cd6da70116a7d4e339f6cbb683bb01bb72f7cf1b8dc7a1) config file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43920f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


___

## **CodeAnt-AI Description**
**Add local tools to validate SAAQ matrices and summarize sprint runs**

### What Changed
- Added a dry-run validator for local SAAQ matrices that checks the file can be loaded, the matrix is structurally valid, and selected path checks can catch missing model paths, unset environment variables, and output folder conflicts.
- Added a sprint summary command that scans run folders and prints a markdown report with run status counts plus per-run model, family, tick count, and artifact presence.
- Skipped runs are excluded from path checks, and the summary marks runs with missing artifacts so gaps are easy to spot.

### Impact
`✅ Faster pre-run checks`
`✅ Fewer failed local experiment launches`
`✅ Clearer sprint reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
