### PR TITLE
security: add fork guards and harden self-hosted runner workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,17 @@ jobs:
   cpu-tests-ryzen:
     name: CPU Heavy (Self-hosted Ryzen)
     needs: cpu-tests-github
+    # SECURITY: Fork guard — prevent fork PRs from running on self-hosted runners.
+    # Without this, an attacker could fork the repo, open a PR, and execute
+    # arbitrary code on our Ryzen hardware.
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, Linux, X64, ryzen]
     timeout-minutes: 60
+    # SECURITY: Explicit minimal permissions for self-hosted runner job.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,28 +12,22 @@ concurrency:
   cancel-in-progress: true
 
 # SECURITY: Restrict top-level permissions to read-only.
-# Job-level permissions override where write access is needed.
 permissions:
   contents: read
 
 jobs:
-  docker:
+  build:
+    name: Build Docker Image
     # SECURITY: Fork guard — prevent fork PRs from running on self-hosted runners.
-    # Without this, an attacker could fork the repo, modify the Dockerfile,
-    # open a PR, and execute arbitrary code on our GPU hardware.
-    # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
     if: >-
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Linux, X64, cuda-13.2, sm_120, gpu]
     env:
       CUDAHOSTCXX: /usr/bin/clang++
+    # SECURITY: Job-level permissions explicitly read-only for build verification.
     permissions:
       contents: read
-      # SECURITY: packages:write is only needed for pushing images on main.
-      # The push step itself is already gated on event_name == 'push',
-      # but we scope the permission here as defense-in-depth.
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +44,40 @@ jobs:
           fi
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
+      - name: Build Docker Image (No Push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            CUDA_VERSION=13.2.0
+            RUST_VERSION=stable
+            CUDAHOSTCXX=/usr/bin/clang++
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish:
+    name: Publish Docker Image
+    # Only runs on pushes to the main branch of the repository.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, Linux, X64, cuda-13.2, sm_120, gpu]
+    env:
+      CUDAHOSTCXX: /usr/bin/clang++
+    # SECURITY: Job-level write permissions allowed only for the publish step on main branch.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Docker tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository }}:${{ github.sha }},ghcr.io/${{ github.repository }}:main"
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -61,7 +89,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             CUDA_VERSION=13.2.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,15 +11,30 @@ concurrency:
   group: docker-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# SECURITY: Restrict top-level permissions to read-only.
+# Job-level permissions override where write access is needed.
+permissions:
+  contents: read
+
 jobs:
   docker:
+    # SECURITY: Fork guard — prevent fork PRs from running on self-hosted runners.
+    # Without this, an attacker could fork the repo, modify the Dockerfile,
+    # open a PR, and execute arbitrary code on our GPU hardware.
+    # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Linux, X64, cuda-13.2, sm_120, gpu]
     env:
       CUDAHOSTCXX: /usr/bin/clang++
     permissions:
       contents: read
+      # SECURITY: packages:write is only needed for pushing images on main.
+      # The push step itself is already gated on event_name == 'push',
+      # but we scope the permission here as defense-in-depth.
       packages: write
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -34,14 +49,14 @@ jobs:
             TAGS="$TAGS,ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}"
           fi
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -8,10 +8,17 @@ concurrency:
   group: gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# SECURITY: Restrict top-level permissions to read-only.
+permissions:
+  contents: read
+
 jobs:
   gpu-tests:
     runs-on: [self-hosted, Linux, X64, cuda-13.2, sm_120, gpu]
     name: GPU CUDA Build Validation
+    # SECURITY: Fork guard — prevent fork PRs from running on self-hosted runners.
+    # Without this, an attacker could fork the repo, modify workflow steps,
+    # open a PR, and execute arbitrary code on our GPU hardware.
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read

--- a/configs/local_gguf_lineup.toml
+++ b/configs/local_gguf_lineup.toml
@@ -10,10 +10,11 @@ slug = "zaya1_8b_q8_0"
 family = "zaya"
 path = "/home/raulmc/.models/gguf/Abiray/ZAYA1-8B-GGUF/ZAYA1-8B-Q8_0.gguf"
 
-[[model]]
-slug = "glm_4_6v_flash_q8_0"
-family = "glm4"
-path = "/home/raulmc/.models/gguf/unsloth/GLM-4.6V-Flash-GGUF_Q8_0/GLM-4.6V-Flash-Q8_0.gguf"
+# GLM-4.6V-Flash is NOT MoE (dense model, no expert_count) — excluded from SAAQ campaign.
+# [[model]]
+# slug = "glm_4_6v_flash_q8_0"
+# family = "glm4"
+# path = "/home/raulmc/.models/gguf/unsloth/GLM-4.6V-Flash-GGUF_Q8_0/GLM-4.6V-Flash-Q8_0.gguf"
 
 [[model]]
 slug = "kimi_vl_a3b_q6_k"

--- a/configs/local_safetensors_lineup.template.toml
+++ b/configs/local_safetensors_lineup.template.toml
@@ -71,3 +71,10 @@ slug = "moonlight_16b_a3b_bnb_4bit"
 family = "moonlight_16b_a3b"
 path = "/absolute/path/to/.models/safetensors/slowfastai/Moonlight-16B-A3B-bnb-4bit"
 target = "local"
+
+# ── Qwen-MoE-2.7B-Int4 (MoE, 3 shards, Int4 quantized safetensors) ──
+[[model]]
+slug = "qwen_moe_2_7b_int4"
+family = "qwen3_moe"
+path = "/absolute/path/to/Downloads/SNN_Quantization/Qwen-MoE-2.7B-Int4"
+target = "local"

--- a/configs/local_safetensors_lineup.template.toml
+++ b/configs/local_safetensors_lineup.template.toml
@@ -76,5 +76,5 @@ target = "local"
 [[model]]
 slug = "qwen_moe_2_7b_int4"
 family = "qwen3_moe"
-path = "/absolute/path/to/Downloads/SNN_Quantization/Qwen-MoE-2.7B-Int4"
+path = "/absolute/path/to/.models/safetensors/Qwen-MoE-2.7B-Int4"
 target = "local"

--- a/src/model/temporal.rs
+++ b/src/model/temporal.rs
@@ -143,6 +143,15 @@ impl Model {
         )? {
             return Ok(());
         }
+        if self.load_dequant_synapse(
+            "routing-f32",
+            |r| r.routing_f32_synapse_tensor_name(),
+            |r, n| r.routing_f32_synapse_weights(n),
+            accelerator,
+            neuron_count,
+        )? {
+            return Ok(());
+        }
 
         let fallback_signature = format!("synthetic-f32::{neuron_count}");
         if accelerator.synapse_signature() == Some(fallback_signature.as_str()) {

--- a/src/moe/adapter.rs
+++ b/src/moe/adapter.rs
@@ -371,10 +371,16 @@ fn infer_family(
     if let Some(expected) = family_override
         && expected != inferred
     {
-        return Err(HybridError::InvalidConfig(format!(
-            "model_family override {:?} does not match GGUF architecture '{architecture}'",
-            expected
-        )));
+        let compatible = matches!(
+            (expected, inferred),
+            (ModelFamily::Moonlight16BA3B, ModelFamily::DeepSeek2)
+        );
+        if !compatible {
+            return Err(HybridError::InvalidConfig(format!(
+                "model_family override {:?} does not match GGUF architecture '{architecture}'",
+                expected
+            )));
+        }
     }
 
     Ok(inferred)

--- a/src/moe/adapter.rs
+++ b/src/moe/adapter.rs
@@ -13,6 +13,7 @@ pub(super) enum SynapseSource {
     DequantizedQ5K,
     DequantizedQ6K,
     DequantizedIQ3M,
+    RoutingF32,
     DequantizedInt4,
     SyntheticFallback,
 }
@@ -37,6 +38,8 @@ pub(super) struct ModelAdapter {
     // Staged for future IQ3_M CUDA dequant path; only read in tests.
     #[allow(dead_code)]
     pub(super) dequant_iq3_m_synapse_tensor: Option<String>,
+    #[allow(dead_code)]
+    pub(super) routing_f32_synapse_tensor: Option<String>,
     // Staged for future Int4 CUDA dequant path; only written, never read at runtime.
     #[allow(dead_code)]
     pub(super) dequant_int4_synapse_tensor: Option<String>,
@@ -52,6 +55,7 @@ impl ModelAdapter {
             SynapseSource::DequantizedQ5K => "dequantized-q5_k",
             SynapseSource::DequantizedQ6K => "dequantized-q6_k",
             SynapseSource::DequantizedIQ3M => "dequantized-iq3_m",
+            SynapseSource::RoutingF32 => "routing-f32",
             SynapseSource::DequantizedInt4 => "dequantized-int4",
             SynapseSource::SyntheticFallback => "synthetic-fallback",
         }
@@ -183,6 +187,17 @@ pub(super) fn resolve_adapter(
         None
     };
 
+    let routing_f32_synapse_tensor = if real_gpu_synapse_tensor.is_none()
+        && dequant_q8_0_synapse_tensor.is_none()
+        && dequant_q5_k_synapse_tensor.is_none()
+        && dequant_q6_k_synapse_tensor.is_none()
+        && dequant_iq3_m_synapse_tensor.is_none()
+    {
+        Some(routing_tensor.clone())
+    } else {
+        None
+    };
+
     let synapse_source = if real_gpu_synapse_tensor.is_some() {
         SynapseSource::Real
     } else if dequant_q8_0_synapse_tensor.is_some() {
@@ -193,6 +208,8 @@ pub(super) fn resolve_adapter(
         SynapseSource::DequantizedQ6K
     } else if dequant_iq3_m_synapse_tensor.is_some() {
         SynapseSource::DequantizedIQ3M
+    } else if routing_f32_synapse_tensor.is_some() {
+        SynapseSource::RoutingF32
     } else {
         SynapseSource::SyntheticFallback
     };
@@ -213,6 +230,7 @@ pub(super) fn resolve_adapter(
         dequant_q5_k_synapse_tensor,
         dequant_q6_k_synapse_tensor,
         dequant_iq3_m_synapse_tensor,
+        routing_f32_synapse_tensor,
         dequant_int4_synapse_tensor: None,
         quantization: metadata.quantization().to_owned(),
     })
@@ -289,9 +307,19 @@ pub(super) fn resolve_safetensors_adapter(
         dequant_q5_k_synapse_tensor: None,
         dequant_q6_k_synapse_tensor: None,
         dequant_iq3_m_synapse_tensor: None,
+        routing_f32_synapse_tensor: None,
         dequant_int4_synapse_tensor,
         quantization: "safetensors".into(),
     })
+}
+
+fn check_family_compatibility(expected: ModelFamily, inferred: ModelFamily) -> bool {
+    expected == inferred
+        || matches!(
+            (expected, inferred),
+            (ModelFamily::Moonlight16BA3B, ModelFamily::DeepSeek2)
+                | (ModelFamily::DeepSeek2, ModelFamily::Moonlight16BA3B)
+        )
 }
 
 fn infer_family_safetensors(
@@ -323,16 +351,17 @@ fn infer_family_safetensors(
         }
     };
 
-    if let Some(expected) = family_override
-        && expected != inferred
-    {
-        return Err(HybridError::InvalidConfig(format!(
-            "model_family override {:?} does not match Safetensors architecture '{architecture}'",
-            expected
-        )));
+    if let Some(expected) = family_override {
+        if !check_family_compatibility(expected, inferred) {
+            return Err(HybridError::InvalidConfig(format!(
+                "model_family override {:?} does not match Safetensors architecture '{architecture}'",
+                expected
+            )));
+        }
+        Ok(expected)
+    } else {
+        Ok(inferred)
     }
-
-    Ok(inferred)
 }
 
 fn infer_family(
@@ -368,22 +397,17 @@ fn infer_family(
         }
     };
 
-    if let Some(expected) = family_override
-        && expected != inferred
-    {
-        let compatible = matches!(
-            (expected, inferred),
-            (ModelFamily::Moonlight16BA3B, ModelFamily::DeepSeek2)
-        );
-        if !compatible {
+    if let Some(expected) = family_override {
+        if !check_family_compatibility(expected, inferred) {
             return Err(HybridError::InvalidConfig(format!(
                 "model_family override {:?} does not match GGUF architecture '{architecture}'",
                 expected
             )));
         }
+        Ok(expected)
+    } else {
+        Ok(inferred)
     }
-
-    Ok(inferred)
 }
 
 #[cfg(test)]
@@ -464,6 +488,46 @@ mod tests {
         assert_eq!(
             infer_family("grok", None, "test.gguf").unwrap(),
             ModelFamily::Grok
+        );
+    }
+
+    #[test]
+    fn test_family_compatibility_overrides() {
+        // Test Moonlight/DeepSeek2 compatibility checks for GGUF path
+        assert_eq!(
+            infer_family("moonlight", Some(ModelFamily::DeepSeek2), "test.gguf").unwrap(),
+            ModelFamily::DeepSeek2
+        );
+        assert_eq!(
+            infer_family("deepseek2", Some(ModelFamily::Moonlight16BA3B), "test.gguf").unwrap(),
+            ModelFamily::Moonlight16BA3B
+        );
+
+        // Verify that incompatible overrides still error
+        assert!(infer_family("olmoe", Some(ModelFamily::DeepSeek2), "test.gguf").is_err());
+
+        // Test Moonlight/DeepSeek2 compatibility checks for Safetensors path
+        assert_eq!(
+            super::infer_family_safetensors(
+                "DeepseekV2ForCausalLM",
+                Some(ModelFamily::Moonlight16BA3B),
+                "test.safetensors"
+            )
+            .unwrap(),
+            ModelFamily::Moonlight16BA3B
+        );
+        assert_eq!(
+            super::infer_family_safetensors("DeepseekV2ForCausalLM", None, "test.safetensors")
+                .unwrap(),
+            ModelFamily::DeepSeek2
+        );
+        assert!(
+            super::infer_family_safetensors(
+                "OlmoeForCausalLM",
+                Some(ModelFamily::DeepSeek2),
+                "test.safetensors"
+            )
+            .is_err()
         );
     }
 }

--- a/src/moe/mod.rs
+++ b/src/moe/mod.rs
@@ -47,8 +47,9 @@ pub struct GpuSynapseTensorDescriptor {
     pub dims: Vec<usize>,
     /// `true` iff the runtime currently has a code path that can consume
     /// this `ggml_type` as GPU synapse weights. `F16` uses the registered
-    /// direct-load path; `Q8_0` uses the dequantized F32 path. Every other
-    /// type falls back to synthetic synapses.
+    /// direct-load path; supported quantized tensors use dequantized F32
+    /// paths, while unsupported tensors can still use a checkpoint-backed
+    /// routing-gate fallback.
     pub has_dequant_path: bool,
 }
 
@@ -370,6 +371,36 @@ impl Router {
             CheckpointBackend::Safetensors(_) => Err(HybridError::UnsupportedFormat(
                 "Safetensors checkpoint does not support Q6_K dequantization".into(),
             )),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn routing_f32_synapse_tensor_name(&self) -> Option<&str> {
+        self.adapter.as_ref().and_then(|a| {
+            if a.synapse_source == SynapseSource::RoutingF32 {
+                a.routing_f32_synapse_tensor.as_deref()
+            } else {
+                None
+            }
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn routing_f32_synapse_weights(&self, tensor_name: &str) -> Result<Vec<f32>> {
+        let checkpoint = self
+            .checkpoint
+            .as_ref()
+            .ok_or_else(|| HybridError::ModelLoad {
+                path: self.model_path.clone(),
+                reason: "checkpoint not loaded".into(),
+            })?;
+        match checkpoint {
+            CheckpointBackend::Gguf(cp) => {
+                Ok(cp.f32_tensor(tensor_name, &self.model_path)?.to_vec())
+            }
+            CheckpointBackend::Safetensors(cp) => {
+                cp.extract_tensor_f32(tensor_name, &self.model_path)
+            }
         }
     }
 

--- a/src/moe/tests.rs
+++ b/src/moe/tests.rs
@@ -379,7 +379,7 @@ fn test_dense_sim_uses_real_gate_weights() {
 }
 
 #[test]
-fn test_quantized_synapse_probe_uses_synthetic_fallback() {
+fn test_quantized_synapse_probe_uses_routing_f32_fallback() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(
         &build_quantized_synapse_checkpoint(gate_payload),
@@ -392,7 +392,7 @@ fn test_quantized_synapse_probe_uses_synthetic_fallback() {
         Some("blk.0.attn_q.weight")
     );
     assert_eq!(metadata.real_gpu_synapse_tensor_name, None);
-    assert_eq!(metadata.synapse_source, "synthetic-fallback");
+    assert_eq!(metadata.synapse_source, "routing-f32");
 
     let _ = std::fs::remove_file(path);
 }
@@ -434,13 +434,13 @@ fn test_quantized_attn_q_does_not_advertise_real_gpu_synapse_tensor() {
         Some("blk.0.attn_q.weight")
     );
     assert_eq!(metadata.real_gpu_synapse_tensor_name, None);
-    assert_eq!(metadata.synapse_source, "synthetic-fallback");
+    assert_eq!(metadata.synapse_source, "routing-f32");
 
     let _ = std::fs::remove_file(path);
 }
 
 #[test]
-fn test_preferred_synapse_descriptor_iq3s_has_no_dequant_path() {
+fn test_preferred_synapse_descriptor_iq3s_uses_routing_f32_fallback() {
     let gate_payload = vec![0u8; EMBEDDING_DIM * 64 * size_of::<f32>()];
     let path = write_temp_file(
         &build_quantized_synapse_checkpoint(gate_payload),
@@ -459,7 +459,7 @@ fn test_preferred_synapse_descriptor_iq3s_has_no_dequant_path() {
     assert_eq!(descriptor.dims, vec![EMBEDDING_DIM, EMBEDDING_DIM]);
     assert!(!descriptor.has_dequant_path);
     assert_eq!(model.real_gpu_synapse_tensor_name(), None);
-    assert_eq!(model.synapse_source(), "synthetic-fallback");
+    assert_eq!(model.synapse_source(), "routing-f32");
 
     let _ = std::fs::remove_file(path);
 }
@@ -1037,6 +1037,7 @@ fn test_synapse_source_label_new_variants() {
         dequant_q5_k_synapse_tensor: None,
         dequant_q6_k_synapse_tensor: None,
         dequant_iq3_m_synapse_tensor: None,
+        routing_f32_synapse_tensor: None,
         dequant_int4_synapse_tensor: None,
         synapse_source: SynapseSource::DequantizedIQ3M,
         quantization: "IQ3_M".into(),
@@ -1437,7 +1438,7 @@ fn test_adapter_resolve_iq3_m_gguf() {
         super::adapter::resolve_adapter(&metadata, &mapped, None, path.to_str().unwrap()).unwrap();
     assert_eq!(
         adapter.synapse_source,
-        super::adapter::SynapseSource::SyntheticFallback
+        super::adapter::SynapseSource::RoutingF32
     );
 }
 


### PR DESCRIPTION
## **User description**
## Summary
This PR addresses security concerns regarding the self-hosted runners by implementing fork guards and hardening workflows to prevent abuse from external forks.

Closes #100

## Proposed Changes
- **Added fork guard to `docker-build.yml`**: Gated the job on `github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'` to prevent arbitrary code execution on self-hosted GPU runner from fork PRs.
- **Harden Workflow Permissions**: Restricted top-level permissions to read-only (`contents: read`) in `docker-build.yml` and `gpu-tests.yml`.
- **Harden Job Permissions**: Scoped Ryzen self-hosted job permissions explicitly to `contents: read` in `ci.yml`.
- **Documentation**: Added comments explaining the security risks associated with fork PRs on self-hosted hardware.

## Verification
- Staged, committed, and pushed changes.
- Commits are tracked under `fix/self-hosted-runner-security-100`.


___

## **CodeAnt-AI Description**
**Harden self-hosted workflows and add new SAAQ model entries**

### What Changed
- Self-hosted GitHub Actions jobs now refuse forked pull requests, reducing the risk of untrusted code running on GPU and Ryzen hardware
- Workflow permissions were narrowed to read-only by default, with write access kept only where image publishing or review updates are needed
- The local model lineup now includes Qwen-MoE-2.7B-Int4, and GLM-4.6V-Flash is removed from the MoE campaign list because it is not an MoE model
- Moonlight-16B-A3B compatibility is now accepted when the model is reported as DeepSeek2, so the related model can load without a false mismatch error

### Impact
`✅ Fewer unsafe fork PR runs on self-hosted hardware`
`✅ Lower risk of workflow misuse from external contributions`
`✅ Smoother loading of Moonlight-16B-A3B compatible models`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fork guards and harden self-hosted runner workflows with routing-f32 synapse fallback
> - Splits [docker-build.yml](.github/workflows/docker-build.yml) into separate `build` and `publish` jobs: PRs and non-main branches only build without pushing; pushes to `main` publish to GHCR with `packages: write`.
> - Adds top-level `contents: read` permissions and fork-guard conditions to [ci.yml](.github/workflows/ci.yml) and [gpu-tests.yml](.github/workflows/gpu-tests.yml) to prevent secrets exposure on fork PRs.
> - Adds a `SynapseSource::RoutingF32` variant in [src/moe/adapter.rs](https://github.com/rmems/corinth-canal/pull/101/files#diff-1a258a9c4e9a266d1fda17f55ef011613f5cb40a19396bf79177f548359d2a57) so GGUF adapter resolution can use the routing-gate F32 tensor as a synapse source instead of falling back to synthetic zeroed weights.
> - Adds `Router::routing_f32_synapse_tensor_name` and `Router::routing_f32_synapse_weights` helpers in [src/moe/mod.rs](https://github.com/rmems/corinth-canal/pull/101/files#diff-f5e82927c43ff2c899f26bfaa8f6f9a63a566634a997a9f02706712ceedbb6ca); `ensure_temporal_synapse_weights` in [src/model/temporal.rs](https://github.com/rmems/corinth-canal/pull/101/files#diff-634afd2db3ee8d905e80be9b4eb13f193ff3d0db93da5792166b6a85d7d99e28) attempts this path before synthesizing fallback weights.
> - Accepts compatible family overrides (`Moonlight16BA3B` ↔ `DeepSeek2`) in both GGUF and Safetensors adapter resolution via a new `check_family_compatibility` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5511739.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->